### PR TITLE
Add support for 16-bit binary PGM format

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,24 @@ zig build test
 
 ## Supported image formats
 
-| Image Format  | Read          | Write  |
-| ------------- |:-------------:|:------:|
-| ANIM          | ❌            |❌     |
-| BMP           | ✔️ (Partial)  |❌     |
-| GIF           | ❌            |❌     |
-| ICO           | ❌            |❌     |
-| IILBM         | ❌            |❌     |
-| JPEG          | ❌            |❌     |
-| PAM           | ❌            |❌     |
-| PBM           | ✔️            |❌     |
-| PCX           | ✔️            |❌     |
-| PGM           | ✔️ (Partial)  |❌     |
-| PNG           | ✔️            |❌     |
-| PPM           | ✔️ (Partial)  |❌     |
-| TGA           | ✔️            |❌     |
-| TIFF          | ❌            |❌     |
-| XBM           | ❌            |❌     |
-| XPM           | ❌            |❌     |
+| Image Format  | Read          | Write          |
+| ------------- |:-------------:|:--------------:|
+| ANIM          | ❌            | ❌            |
+| BMP           | ✔️ (Partial)  | ❌            |
+| GIF           | ❌            | ❌            |
+| ICO           | ❌            | ❌            |
+| IILBM         | ❌            | ❌            |
+| JPEG          | ❌            | ❌            |
+| PAM           | ❌            | ❌            |
+| PBM           | ✔️            | ❌            |
+| PCX           | ✔️            | ❌            |
+| PGM           | ✔️ (Partial)  | ✔️ (Partial)  |
+| PNG           | ✔️            | ❌            |
+| PPM           | ✔️ (Partial)  | ❌            |
+| TGA           | ✔️            | ❌            |
+| TIFF          | ❌            | ❌            |
+| XBM           | ❌            | ❌            |
+| XPM           | ❌            | ❌            |
 
 ### BMP - Bitmap
 
@@ -60,8 +60,8 @@ zig build test
 
 ### PGM - Portable Graymap format
 
-* Support 8-bit grayscale images
-* Missing 16-bit grayscale support for now
+* Support 8-bit and 16-bit grayscale images
+* 16-bit ascii grayscale loading not tested
 
 ### PNG - Portable Network Graphics
 

--- a/src/image.zig
+++ b/src/image.zig
@@ -119,13 +119,13 @@ pub const Image = struct {
         return result;
     }
 
-    pub fn create(allocator: *Allocator, width: usize, height: usize, pixel_format: PixelFormat) !Self {
+    pub fn create(allocator: *Allocator, width: usize, height: usize, pixel_format: PixelFormat, image_format: ImageFormat) !Self {
         var result = Self{
             .allocator = allocator,
             .width = width,
             .height = height,
             .pixel_format = pixel_format,
-            .image_format = .Raw,
+            .image_format = image_format,
             .pixels = try ColorStorage.init(allocator, pixel_format, width * height),
         };
 


### PR DESCRIPTION
Saving and loading in binary format seems to work now. I'm pretty sure saving 16-bit ascii used to work (and it still should) but I haven't tried loading 16-it ascii.

