### PR TITLE
Makes zigimg work properly on freestanding targets

### DIFF
--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -247,7 +247,7 @@ pub const PCX = struct {
                                 x += 1;
                             }
                         },
-                        else => std.debug.panic("{s} pixel format not supported yet!", .{@tagName(pixels)}),
+                        else => return error.UnsupportedPixelFormat,
                     }
                 }
 

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -1,5 +1,4 @@
 const Allocator = std.mem.Allocator;
-const File = std.fs.File;
 const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;
@@ -116,7 +115,7 @@ const TargaRLEDecoder = struct {
 
     const Self = @This();
 
-    pub const ReadError = std.fs.File.ReadError;
+    pub const ReadError = error{ InputOutput, BrokenPipe } || std.io.StreamSource.ReadError;
 
     const State = enum {
         ReadHeader,
@@ -213,7 +212,7 @@ pub const TargaStream = union(enum) {
     image: ImageReader,
     rle: TargaRLEDecoder,
 
-    pub const ReadError = std.fs.File.ReadError;
+    pub const ReadError = ImageReader.Error || TargaRLEDecoder.ReadError;
     pub const Reader = std.io.Reader(*TargaStream, ReadError, read);
 
     pub fn read(self: *TargaStream, dest: []u8) ReadError!usize {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -55,7 +55,7 @@ pub fn readStructForeign(reader: io.StreamSource.Reader, comptime T: type) !T {
                 });
             },
             else => {
-                std.debug.panic("Add support for type {} in readStructForeign", .{@typeName(entry.field_type)});
+                @compileError(std.fmt.comptimePrint("Add support for type {} in readStructForeign", .{@typeName(entry.field_type)}));
             },
         }
     }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -3,6 +3,8 @@ const std = @import("std");
 const io = std.io;
 const meta = std.meta;
 
+const native_endian = std.Target.current.cpu.arch.endian();
+
 pub fn toMagicNumberNative(magic: []const u8) u32 {
     var result: u32 = 0;
     for (magic) |character, index| {
@@ -19,12 +21,12 @@ pub fn toMagicNumberForeign(magic: []const u8) u32 {
     return result;
 }
 
-pub const toMagicNumberBig = switch (builtin.endian) {
+pub const toMagicNumberBig = switch (native_endian) {
     builtin.Endian.Little => toMagicNumberForeign,
     builtin.Endian.Big => toMagicNumberNative,
 };
 
-pub const toMagicNumberLittle = switch (builtin.endian) {
+pub const toMagicNumberLittle = switch (native_endian) {
     builtin.Endian.Little => toMagicNumberNative,
     builtin.Endian.Big => toMagicNumberForeign,
 };
@@ -47,7 +49,7 @@ pub fn readStructForeign(reader: io.StreamSource.Reader, comptime T: type) !T {
                 @field(result, entry.name) = try readStructForeign(reader, entry.field_type);
             },
             .Enum => {
-                @field(result, entry.name) = try reader.readEnum(entry.field_type, switch (builtin.endian) {
+                @field(result, entry.name) = try reader.readEnum(entry.field_type, switch (native_endian) {
                     builtin.Endian.Little => builtin.Endian.Big,
                     builtin.Endian.Big => builtin.Endian.Little,
                 });
@@ -61,12 +63,12 @@ pub fn readStructForeign(reader: io.StreamSource.Reader, comptime T: type) !T {
     return result;
 }
 
-pub const readStructLittle = switch (builtin.endian) {
+pub const readStructLittle = switch (native_endian) {
     builtin.Endian.Little => readStructNative,
     builtin.Endian.Big => readStructForeign,
 };
 
-pub const readStructBig = switch (builtin.endian) {
+pub const readStructBig = switch (native_endian) {
     builtin.Endian.Little => readStructForeign,
     builtin.Endian.Big => readStructNative,
 };


### PR DESCRIPTION
This PR updates zigimg to latest master and tries to fix some usages of `std.fs.File` that will make it work with StreamSource assuming it won't reference std.fs.File on freestanding targets (this will be a companion PR for ziglang)