### PR TITLE
Use buffered I/O with files

### DIFF
--- a/src/buffered_istream.zig
+++ b/src/buffered_istream.zig
@@ -48,7 +48,7 @@ pub fn BufferedIStream(comptime buffer_size: usize, comptime ReaderType: type, c
         }
 
         pub fn seekBy(self: *Self, amt: i64) SeekError!void {
-            if(amt != 0) {
+            if (amt != 0) {
                 self.fifo.discard(self.fifo.count);
             }
             try self.underlying_stream.seekBy(amt);
@@ -69,10 +69,7 @@ pub fn BufferedIStream(comptime buffer_size: usize, comptime ReaderType: type, c
 }
 
 pub fn bufferedIStream(reader: anytype, seekable_stream: anytype) BufferedIStream(4096, @TypeOf(reader), @TypeOf(seekable_stream)) {
-    return .{
-        .unbuffered_reader = reader,
-        .underlying_stream = seekable_stream
-    };
+    return .{ .unbuffered_reader = reader, .underlying_stream = seekable_stream };
 }
 
 test "BufferedIStream" {
@@ -101,9 +98,8 @@ test "BufferedIStream" {
     try std.testing.expectEqual(@as(usize, 11), fbs.pos);
     try std.testing.expectEqual(@as(u64, 11), try seekable_stream.getPos());
 
-
     try std.testing.expectError(error.EndOfStream, reader.readNoEof(buffer[0..]));
     try std.testing.expectEqual(@as(usize, 16), fbs.pos);
     try std.testing.expectEqual(@as(u64, 16), try seekable_stream.getPos());
-    try std.testing.expectEqualStrings(str[11..], buffer[0..5]);    
+    try std.testing.expectEqualStrings(str[11..], buffer[0..5]);
 }

--- a/src/buffered_istream.zig
+++ b/src/buffered_istream.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+
+pub fn BufferedIStream(comptime buffer_size: usize, comptime ReaderType: type, comptime SeekableStreamType: type) type {
+    return struct {
+        const Self = @This();
+
+        unbuffered_reader: ReaderType,
+        underlying_stream: SeekableStreamType,
+        fifo: FifoType = FifoType.init(),
+
+        pub const ReadError = ReaderType.Error;
+        pub const Reader = std.io.Reader(*Self, ReadError, read);
+
+        pub const SeekError = SeekableStreamType.SeekError;
+        pub const GetSeekPosError = SeekableStreamType.GetSeekPosError;
+        pub const SeekableStream = std.io.SeekableStream(*Self, SeekError, GetSeekPosError, seekTo, seekBy, getPos, getEndPos);
+
+        const FifoType = std.fifo.LinearFifo(u8, std.fifo.LinearFifoBufferType{ .Static = buffer_size });
+
+        pub fn read(self: *Self, dest: []u8) ReadError!usize {
+            var dest_index: usize = 0;
+            while (dest_index < dest.len) {
+                const written = self.fifo.read(dest[dest_index..]);
+                if (written == 0) {
+                    // fifo empty, fill it
+                    const writable = self.fifo.writableSlice(0);
+                    std.debug.assert(writable.len > 0);
+                    const n = try self.unbuffered_reader.read(writable);
+                    if (n == 0) {
+                        // reading from the unbuffered stream returned nothing
+                        // so we have nothing left to read.
+                        return dest_index;
+                    }
+                    self.fifo.update(n);
+                }
+                dest_index += written;
+            }
+            return dest.len;
+        }
+
+        pub fn reader(self: *Self) Reader {
+            return .{ .context = self };
+        }
+
+        pub fn seekTo(self: *Self, pos: u64) SeekError!void {
+            self.fifo.discard(self.fifo.count);
+            try self.underlying_stream.seekTo(pos);
+        }
+
+        pub fn seekBy(self: *Self, amt: i64) SeekError!void {
+            if(amt != 0) {
+                self.fifo.discard(self.fifo.count);
+            }
+            try self.underlying_stream.seekBy(amt);
+        }
+
+        pub fn getEndPos(self: *Self) GetSeekPosError!u64 {
+            return self.underlying_stream.getEndPos();
+        }
+
+        pub fn getPos(self: *Self) GetSeekPosError!u64 {
+            return self.underlying_stream.getPos();
+        }
+
+        pub fn seekableStream(self: *Self) SeekableStream {
+            return .{ .context = self };
+        }
+    };
+}
+
+pub fn bufferedIStream(reader: anytype, seekable_stream: anytype) BufferedIStream(4096, @TypeOf(reader), @TypeOf(seekable_stream)) {
+    return .{
+        .unbuffered_reader = reader,
+        .underlying_stream = seekable_stream
+    };
+}
+
+test "BufferedIStream" {
+    const str = "a1b2 thisisatest";
+    var fbs = std.io.fixedBufferStream(str);
+    var istream = bufferedIStream(fbs.reader(), fbs.seekableStream());
+    var reader = istream.reader();
+    var seekable_stream = istream.seekableStream();
+
+    var buffer: [16]u8 = undefined;
+    try reader.readNoEof(buffer[0..]);
+    try std.testing.expectEqual(@as(usize, 16), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 16), try seekable_stream.getPos());
+    try std.testing.expectEqualStrings(str, buffer[0..]);
+
+    try seekable_stream.seekTo(2);
+    try std.testing.expectEqual(@as(usize, 2), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 2), try seekable_stream.getPos());
+
+    try std.testing.expectError(error.EndOfStream, reader.readNoEof(buffer[0..]));
+    try std.testing.expectEqual(@as(usize, 16), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 16), try seekable_stream.getPos());
+    try std.testing.expectEqualStrings(str[2..], buffer[0..14]);
+
+    try seekable_stream.seekBy(-5);
+    try std.testing.expectEqual(@as(usize, 11), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 11), try seekable_stream.getPos());
+
+
+    try std.testing.expectError(error.EndOfStream, reader.readNoEof(buffer[0..]));
+    try std.testing.expectEqual(@as(usize, 16), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 16), try seekable_stream.getPos());
+    try std.testing.expectEqualStrings(str[11..], buffer[0..5]);    
+}

--- a/src/buffered_ostream.zig
+++ b/src/buffered_ostream.zig
@@ -64,10 +64,7 @@ pub fn BufferedOStream(comptime buffer_size: usize, comptime WriterType: type, c
 }
 
 pub fn bufferedOStream(writer: anytype, seekable_stream: anytype) BufferedOStream(4096, @TypeOf(writer), @TypeOf(seekable_stream)) {
-    return .{
-        .unbuffered_writer = writer,
-        .underlying_stream = seekable_stream
-    };
+    return .{ .unbuffered_writer = writer, .underlying_stream = seekable_stream };
 }
 
 test "BufferedOStream" {
@@ -81,7 +78,10 @@ test "BufferedOStream" {
     try ostream.flush();
     try std.testing.expectEqual(@as(usize, 8), fbs.pos);
     try std.testing.expectEqual(@as(u64, 8), try seekable_stream.getPos());
-    try std.testing.expectEqualStrings("abcd1234", buffer[0..8],);
+    try std.testing.expectEqualStrings(
+        "abcd1234",
+        buffer[0..8],
+    );
 
     try seekable_stream.seekTo(1);
     try std.testing.expectEqual(@as(usize, 1), fbs.pos);

--- a/src/buffered_ostream.zig
+++ b/src/buffered_ostream.zig
@@ -1,0 +1,105 @@
+const std = @import("std");
+
+pub fn BufferedOStream(comptime buffer_size: usize, comptime WriterType: type, comptime SeekableStreamType: type) type {
+    return struct {
+        const Self = @This();
+
+        unbuffered_writer: WriterType,
+        underlying_stream: SeekableStreamType,
+        fifo: FifoType = FifoType.init(),
+
+        pub const WriteError = WriterType.Error;
+        pub const Writer = std.io.Writer(*Self, WriteError, write);
+
+        pub const SeekError = SeekableStreamType.SeekError || WriteError;
+        pub const GetSeekPosError = SeekableStreamType.GetSeekPosError;
+        pub const SeekableStream = std.io.SeekableStream(*Self, SeekError, GetSeekPosError, seekTo, seekBy, getPos, getEndPos);
+
+        const FifoType = std.fifo.LinearFifo(u8, std.fifo.LinearFifoBufferType{ .Static = buffer_size });
+
+        pub fn flush(self: *Self) !void {
+            while (true) {
+                const slice = self.fifo.readableSlice(0);
+                if (slice.len == 0) break;
+                try self.unbuffered_writer.writeAll(slice);
+                self.fifo.discard(slice.len);
+            }
+        }
+
+        pub fn writer(self: *Self) Writer {
+            return .{ .context = self };
+        }
+
+        pub fn write(self: *Self, bytes: []const u8) WriteError!usize {
+            if (bytes.len >= self.fifo.writableLength()) {
+                try self.flush();
+                return self.unbuffered_writer.write(bytes);
+            }
+            self.fifo.writeAssumeCapacity(bytes);
+            return bytes.len;
+        }
+
+        pub fn seekTo(self: *Self, pos: u64) SeekError!void {
+            try self.flush();
+            try self.underlying_stream.seekTo(pos);
+        }
+
+        pub fn seekBy(self: *Self, amt: i64) SeekError!void {
+            try self.flush();
+            try self.underlying_stream.seekBy(amt);
+        }
+
+        pub fn getEndPos(self: *Self) GetSeekPosError!u64 {
+            return self.underlying_stream.getEndPos();
+        }
+
+        pub fn getPos(self: *Self) GetSeekPosError!u64 {
+            return self.underlying_stream.getPos();
+        }
+
+        pub fn seekableStream(self: *Self) SeekableStream {
+            return .{ .context = self };
+        }
+    };
+}
+
+pub fn bufferedOStream(writer: anytype, seekable_stream: anytype) BufferedOStream(4096, @TypeOf(writer), @TypeOf(seekable_stream)) {
+    return .{
+        .unbuffered_writer = writer,
+        .underlying_stream = seekable_stream
+    };
+}
+
+test "BufferedOStream" {
+    var buffer = [_]u8{0} ** 4096;
+    var fbs = std.io.fixedBufferStream(buffer[0..]);
+    var ostream = bufferedOStream(fbs.writer(), fbs.seekableStream());
+    var writer = ostream.writer();
+    var seekable_stream = ostream.seekableStream();
+
+    try writer.writeAll("abcd1234");
+    try ostream.flush();
+    try std.testing.expectEqual(@as(usize, 8), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 8), try seekable_stream.getPos());
+    try std.testing.expectEqualStrings("abcd1234", buffer[0..8],);
+
+    try seekable_stream.seekTo(1);
+    try std.testing.expectEqual(@as(usize, 1), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 1), try seekable_stream.getPos());
+
+    try writer.writeAll("cde2345");
+    try ostream.flush();
+    try std.testing.expectEqual(@as(usize, 8), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 8), try seekable_stream.getPos());
+    try std.testing.expectEqualStrings("acde2345", buffer[0..8]);
+
+    try seekable_stream.seekBy(1);
+    try std.testing.expectEqual(@as(usize, 9), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 9), try seekable_stream.getPos());
+
+    try writer.writeAll("foo");
+    try ostream.flush();
+    try std.testing.expectEqual(@as(usize, 12), fbs.pos);
+    try std.testing.expectEqual(@as(u64, 12), try seekable_stream.getPos());
+    try std.testing.expectEqualStrings("acde2345\x00foo", buffer[0..12]);
+}

--- a/src/format_interface.zig
+++ b/src/format_interface.zig
@@ -10,7 +10,7 @@ pub const FormatInterface = struct {
     writeForImage: WriteForImageFn,
 
     pub const FormatFn = fn () image.ImageFormat;
-    pub const FormatDetectFn = fn (reader: image.ImageReader, seekStream: image.ImageSeekStream) anyerror!bool;
-    pub const ReadForImageFn = fn (allocator: Allocator, reader: image.ImageReader, seekStream: image.ImageSeekStream, pixels: *?color.ColorStorage) anyerror!image.ImageInfo;
-    pub const WriteForImageFn = fn (allocator: Allocator, write_stream: image.ImageWriterStream, seek_stream: image.ImageSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) anyerror!void;
+    pub const FormatDetectFn = fn (reader: image.ImageReader, seekStream: image.ImageReaderSeekStream) anyerror!bool;
+    pub const ReadForImageFn = fn (allocator: Allocator, reader: image.ImageReader, seekStream: image.ImageReaderSeekStream, pixels: *?color.ColorStorage) anyerror!image.ImageInfo;
+    pub const WriteForImageFn = fn (allocator: Allocator, write_stream: image.ImageWriter, seek_stream: image.ImageWriterSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) anyerror!void;
 };

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -3,7 +3,8 @@ const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;
 const ImageInfo = image.ImageInfo;
-const ImageSeekStream = image.ImageSeekStream;
+const ImageReaderSeekStream = image.ImageReaderSeekStream;
+const ImageWriterSeekStream = image.ImageWriterSeekStream;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const color = @import("../color.zig");
 const errors = @import("../errors.zig");
@@ -159,7 +160,7 @@ pub const Bitmap = struct {
         return ImageFormat.Bmp;
     }
 
-    pub fn formatDetect(reader: ImageReader, seek_stream: ImageSeekStream) !bool {
+    pub fn formatDetect(reader: ImageReader, seek_stream: ImageReaderSeekStream) !bool {
         _ = seek_stream;
         var magic_number_buffer: [2]u8 = undefined;
         _ = try reader.read(magic_number_buffer[0..]);
@@ -170,7 +171,7 @@ pub const Bitmap = struct {
         return false;
     }
 
-    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
+    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
         var bmp = Self{};
 
         try bmp.read(allocator, reader, seek_stream, pixels);
@@ -181,7 +182,7 @@ pub const Bitmap = struct {
         return image_info;
     }
 
-    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriterStream, seek_stream: ImageSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
+    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriter, seek_stream: ImageWriterSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
         _ = allocator;
         _ = write_stream;
         _ = seek_stream;
@@ -225,7 +226,7 @@ pub const Bitmap = struct {
         };
     }
 
-    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels_opt: *?color.ColorStorage) !void {
+    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels_opt: *?color.ColorStorage) !void {
         // Read file header
         self.file_header = try utils.readStructLittle(reader, BitmapFileHeader);
         if (!mem.eql(u8, self.file_header.magic_header[0..], BitmapMagicHeader[0..])) {

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -1,5 +1,4 @@
 const Allocator = std.mem.Allocator;
-const File = std.fs.File;
 const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;

--- a/src/formats/netpbm.zig
+++ b/src/formats/netpbm.zig
@@ -5,7 +5,8 @@ const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;
 const ImageInfo = image.ImageInfo;
-const ImageSeekStream = image.ImageSeekStream;
+const ImageReaderSeekStream = image.ImageReaderSeekStream;
+const ImageWriterSeekStream = image.ImageWriterSeekStream;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const color = @import("../color.zig");
 const errors = @import("../errors.zig");
@@ -259,7 +260,7 @@ fn Netpbm(comptime image_format: ImageFormat, comptime header_numbers: []const u
             return image_format;
         }
 
-        pub fn formatDetect(reader: ImageReader, seek_stream: ImageSeekStream) !bool {
+        pub fn formatDetect(reader: ImageReader, seek_stream: ImageReaderSeekStream) !bool {
             _ = seek_stream;
 
             var magic_number_buffer: [2]u8 = undefined;
@@ -281,7 +282,7 @@ fn Netpbm(comptime image_format: ImageFormat, comptime header_numbers: []const u
             return found;
         }
 
-        pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
+        pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
             var netpbm_file = Self{};
 
             try netpbm_file.read(allocator, reader, seek_stream, pixels);
@@ -293,7 +294,7 @@ fn Netpbm(comptime image_format: ImageFormat, comptime header_numbers: []const u
             return image_info;
         }
 
-        pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriterStream, seek_stream: ImageSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
+        pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriter, seek_stream: ImageWriterSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
             _ = allocator;
             var netpbm_file = Self{};
             netpbm_file.header.binary = switch (save_info.encoder_options) {
@@ -332,7 +333,7 @@ fn Netpbm(comptime image_format: ImageFormat, comptime header_numbers: []const u
             };
         }
 
-        pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels_opt: *?color.ColorStorage) !void {
+        pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels_opt: *?color.ColorStorage) !void {
             _ = seek_stream;
             self.header = try parseHeader(reader);
 
@@ -367,7 +368,7 @@ fn Netpbm(comptime image_format: ImageFormat, comptime header_numbers: []const u
             }
         }
 
-        pub fn write(self: *Self, write_stream: image.ImageWriterStream, seek_stream: image.ImageSeekStream, pixels: color.ColorStorage) !void {
+        pub fn write(self: *Self, write_stream: image.ImageWriter, seek_stream: image.ImageWriterSeekStream, pixels: color.ColorStorage) !void {
             _ = seek_stream;
             const image_type = if (self.header.binary) header_numbers[1] else header_numbers[0];
             try write_stream.print("P{c}\n", .{image_type});

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -5,7 +5,8 @@ const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;
 const ImageInfo = image.ImageInfo;
-const ImageSeekStream = image.ImageSeekStream;
+const ImageReaderSeekStream = image.ImageReaderSeekStream;
+const ImageWriterSeekStream = image.ImageWriterSeekStream;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const color = @import("../color.zig");
 const errors = @import("../errors.zig");
@@ -115,7 +116,7 @@ pub const PCX = struct {
         return ImageFormat.Pcx;
     }
 
-    pub fn formatDetect(reader: ImageReader, seek_stream: ImageSeekStream) !bool {
+    pub fn formatDetect(reader: ImageReader, seek_stream: ImageReaderSeekStream) !bool {
         _ = seek_stream;
         var magic_number_bufffer: [2]u8 = undefined;
         _ = try reader.read(magic_number_bufffer[0..]);
@@ -131,7 +132,7 @@ pub const PCX = struct {
         return true;
     }
 
-    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
+    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
         var pcx = PCX{};
 
         try pcx.read(allocator, reader, seek_stream, pixels);
@@ -143,7 +144,7 @@ pub const PCX = struct {
         return image_info;
     }
 
-    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriterStream, seek_stream: ImageSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
+    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriter, seek_stream: ImageWriterSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
         _ = allocator;
         _ = write_stream;
         _ = seek_stream;
@@ -169,7 +170,7 @@ pub const PCX = struct {
         }
     }
 
-    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels_opt: *?color.ColorStorage) !void {
+    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels_opt: *?color.ColorStorage) !void {
         self.header = try utils.readStructLittle(reader, PCXHeader);
         _ = try reader.read(PCXHeader.padding[0..]);
 

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -6,7 +6,8 @@ const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;
 const ImageInfo = image.ImageInfo;
-const ImageSeekStream = image.ImageSeekStream;
+const ImageReaderSeekStream = image.ImageReaderSeekStream;
+const ImageWriterSeekStream = image.ImageWriterSeekStream;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const color = @import("../color.zig");
 const errors = @import("../errors.zig");
@@ -485,7 +486,7 @@ pub const PNG = struct {
         return ImageFormat.Png;
     }
 
-    pub fn formatDetect(reader: ImageReader, seek_stream: ImageSeekStream) !bool {
+    pub fn formatDetect(reader: ImageReader, seek_stream: ImageReaderSeekStream) !bool {
         _ = seek_stream;
         var magic_number_buffer: [8]u8 = undefined;
         _ = try reader.read(magic_number_buffer[0..]);
@@ -570,7 +571,7 @@ pub const PNG = struct {
         return null;
     }
 
-    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels_opt: *?color.ColorStorage) !ImageInfo {
+    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels_opt: *?color.ColorStorage) !ImageInfo {
         var png = PNG.init(allocator);
         defer png.deinit();
 
@@ -583,7 +584,7 @@ pub const PNG = struct {
         return image_info;
     }
 
-    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriterStream, seek_stream: ImageSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
+    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriter, seek_stream: ImageWriterSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
         _ = allocator;
         _ = write_stream;
         _ = seek_stream;
@@ -591,7 +592,7 @@ pub const PNG = struct {
         _ = save_info;
     }
 
-    pub fn read(self: *Self, reader: ImageReader, seek_stream: ImageSeekStream, pixels_opt: *?color.ColorStorage) !void {
+    pub fn read(self: *Self, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels_opt: *?color.ColorStorage) !void {
         _ = seek_stream;
         var magic_number_buffer: [8]u8 = undefined;
         _ = try reader.read(magic_number_buffer[0..]);

--- a/src/formats/qoi.zig
+++ b/src/formats/qoi.zig
@@ -5,7 +5,8 @@ const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;
 const ImageInfo = image.ImageInfo;
-const ImageSeekStream = image.ImageSeekStream;
+const ImageReaderSeekStream = image.ImageReaderSeekStream;
+const ImageWriterSeekStream = image.ImageWriterSeekStream;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const color = @import("../color.zig");
 const errors = @import("../errors.zig");
@@ -123,7 +124,7 @@ pub const QOI = struct {
         return ImageFormat.Qoi;
     }
 
-    pub fn formatDetect(reader: ImageReader, seek_stream: ImageSeekStream) !bool {
+    pub fn formatDetect(reader: ImageReader, seek_stream: ImageReaderSeekStream) !bool {
         _ = seek_stream;
 
         var magic_buffer: [std.mem.len(Header.correct_magic)]u8 = undefined;
@@ -133,7 +134,7 @@ pub const QOI = struct {
         return std.mem.eql(u8, magic_buffer[0..], Header.correct_magic[0..]);
     }
 
-    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
+    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
         var qoi = Self{};
 
         try qoi.read(allocator, reader, seek_stream, pixels);
@@ -144,7 +145,7 @@ pub const QOI = struct {
         return image_info;
     }
 
-    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriterStream, seek_stream: ImageSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
+    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriter, seek_stream: ImageWriterSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
         _ = allocator;
 
         var qoi = Self{};
@@ -182,7 +183,7 @@ pub const QOI = struct {
         };
     }
 
-    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels_opt: *?color.ColorStorage) !void {
+    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels_opt: *?color.ColorStorage) !void {
         _ = seek_stream;
 
         var magic_buffer: [std.mem.len(Header.correct_magic)]u8 = undefined;
@@ -278,7 +279,7 @@ pub const QOI = struct {
         }
     }
 
-    pub fn write(self: Self, write_stream: image.ImageWriterStream, seek_stream: ImageSeekStream, pixels: color.ColorStorage) !void {
+    pub fn write(self: Self, write_stream: image.ImageWriter, seek_stream: ImageWriterSeekStream, pixels: color.ColorStorage) !void {
         _ = seek_stream;
 
         try write_stream.writeAll(&self.header.encode());
@@ -307,7 +308,7 @@ pub const QOI = struct {
         });
     }
 
-    fn writeData(write_stream: image.ImageWriterStream, pixels_data: anytype) !void {
+    fn writeData(write_stream: image.ImageWriter, pixels_data: anytype) !void {
         var color_lut = std.mem.zeroes([64]QoiColor);
 
         var previous_pixel = QoiColor{ .r = 0, .g = 0, .b = 0, .a = 0xFF };

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -3,7 +3,8 @@ const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageFormat = image.ImageFormat;
 const ImageReader = image.ImageReader;
 const ImageInfo = image.ImageInfo;
-const ImageSeekStream = image.ImageSeekStream;
+const ImageReaderSeekStream = image.ImageReaderSeekStream;
+const ImageWriterSeekStream = image.ImageWriterSeekStream;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const color = @import("../color.zig");
 const errors = @import("../errors.zig");
@@ -244,7 +245,7 @@ pub const TGA = struct {
         return ImageFormat.Tga;
     }
 
-    pub fn formatDetect(reader: ImageReader, seek_stream: ImageSeekStream) !bool {
+    pub fn formatDetect(reader: ImageReader, seek_stream: ImageReaderSeekStream) !bool {
         const end_pos = try seek_stream.getEndPos();
 
         if (@sizeOf(TGAFooter) < end_pos) {
@@ -269,7 +270,7 @@ pub const TGA = struct {
         return false;
     }
 
-    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
+    pub fn readForImage(allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels: *?color.ColorStorage) !ImageInfo {
         var tga = Self{};
 
         try tga.read(allocator, reader, seek_stream, pixels);
@@ -280,7 +281,7 @@ pub const TGA = struct {
         return image_info;
     }
 
-    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriterStream, seek_stream: ImageSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
+    pub fn writeForImage(allocator: Allocator, write_stream: image.ImageWriter, seek_stream: ImageWriterSeekStream, pixels: color.ColorStorage, save_info: image.ImageSaveInfo) !void {
         _ = allocator;
         _ = write_stream;
         _ = seek_stream;
@@ -315,7 +316,7 @@ pub const TGA = struct {
         return errors.ImageError.UnsupportedPixelFormat;
     }
 
-    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageSeekStream, pixels_opt: *?color.ColorStorage) !void {
+    pub fn read(self: *Self, allocator: Allocator, reader: ImageReader, seek_stream: ImageReaderSeekStream, pixels_opt: *?color.ColorStorage) !void {
         // Read footage
         const end_pos = try seek_stream.getEndPos();
 

--- a/src/image.zig
+++ b/src/image.zig
@@ -9,7 +9,9 @@ const errors = @import("errors.zig");
 const io = std.io;
 const std = @import("std");
 const bufferedIStream = @import("buffered_istream.zig").bufferedIStream;
+const BufferedIStream = @import("buffered_istream.zig").BufferedIStream;
 const bufferedOStream = @import("buffered_ostream.zig").bufferedOStream;
+const BufferedOStream = @import("buffered_ostream.zig").BufferedOStream;
 
 pub const ImageFormat = enum {
     Bmp,
@@ -23,9 +25,11 @@ pub const ImageFormat = enum {
     Tga,
 };
 
-pub const ImageReader = io.StreamSource.Reader;
-pub const ImageSeekStream = io.StreamSource.SeekableStream;
-pub const ImageWriterStream = io.StreamSource.Writer;
+const IStream = BufferedIStream(4096, io.StreamSource.Reader, io.StreamSource.SeekableStream);
+const OStream = BufferedOStream(4096, io.StreamSource.Writer, io.StreamSource.SeekableStream);
+pub const ImageReader = IStream.Reader;
+pub const ImageSeekStream = IStream.SeekableStream;
+pub const ImageWriterStream = OStream.Writer;
 
 pub const ImageEncoderOptions = AllImageFormats.ImageEncoderOptions;
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -31,11 +31,11 @@ pub const toMagicNumberLittle = switch (native_endian) {
     builtin.Endian.Big => toMagicNumberForeign,
 };
 
-pub fn readStructNative(reader: io.StreamSource.Reader, comptime T: type) !T {
+pub fn readStructNative(reader: anytype, comptime T: type) !T {
     return try reader.readStruct(T);
 }
 
-pub fn readStructForeign(reader: io.StreamSource.Reader, comptime T: type) !T {
+pub fn readStructForeign(reader: anytype, comptime T: type) !T {
     comptime std.debug.assert(@typeInfo(T).Struct.layout != builtin.TypeInfo.ContainerLayout.Auto);
 
     var result: T = undefined;


### PR DESCRIPTION
This PR adds two new types (BufferedIStream and BufferedOStream) and uses them to add buffering to file I/O to minimize the number of necessary syscalls.

This PR is intended to resolve issue #55 