### PR TITLE
wip: jpeg: implement support for different sampling factor

### DIFF
--- a/tests/formats/jpeg_test.zig
+++ b/tests/formats/jpeg_test.zig
@@ -1,33 +1,100 @@
 const std = @import("std");
 const helpers = @import("../helpers.zig");
 
+const netpbm = @import("../../src/formats/netpbm.zig");
 const jpeg = @import("../../src/formats/jpeg.zig");
+const image = @import("../../src/image.zig");
 const color = @import("../../src/color.zig");
 const errors = @import("../../src/errors.zig");
 const testing = std.testing;
 
-test "Should error on non JPEG images" {
-    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "bmp/simple_v4.bmp");
-    defer file.close();
+//test "Should error on non JPEG images" {
+//    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "bmp/simple_v4.bmp");
+//    defer file.close();
+//
+//    var stream_source = std.io.StreamSource{ .file = file };
+//
+//    var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
+//    defer jpeg_file.deinit();
+//
+//    var pixelsOpt: ?color.PixelStorage = null;
+//    const invalidFile = jpeg_file.read(stream_source.reader(), stream_source.seekableStream(), &pixelsOpt);
+//    defer {
+//        if (pixelsOpt) |pixels| {
+//            pixels.deinit(helpers.zigimg_test_allocator);
+//        }
+//    }
+//
+//    try helpers.expectError(invalidFile, errors.ImageError.InvalidMagicHeader);
+//}
+//
+//test "Read JFIF header properly and decode simple Huffman stream" {
+//    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "jpeg/huff_simple0.jpg");
+//    defer file.close();
+//
+//    var stream_source = std.io.StreamSource{ .file = file };
+//
+//    var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
+//    defer jpeg_file.deinit();
+//
+//    var pixelsOpt: ?color.PixelStorage = null;
+//    const frame = try jpeg_file.read(stream_source.reader(), stream_source.seekableStream(), &pixelsOpt);
+//
+//    defer {
+//        if (pixelsOpt) |pixels| {
+//            pixels.deinit(helpers.zigimg_test_allocator);
+//        }
+//    }
+//
+//    try helpers.expectEq(frame.frame_header.row_count, 8);
+//    try helpers.expectEq(frame.frame_header.samples_per_row, 16);
+//    try helpers.expectEq(frame.frame_header.sample_precision, 8);
+//    try helpers.expectEq(frame.frame_header.components.len, 3);
+//
+//    try testing.expect(pixelsOpt != null);
+//
+//    if (pixelsOpt) |pixels| {
+//        try testing.expect(pixels == .rgb24);
+//    }
+//}
 
-    var stream_source = std.io.StreamSource{ .file = file };
+//test "Read the tuba properly" {
+//    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "jpeg/tuba.jpg");
+//    defer file.close();
+//
+//    var stream_source = std.io.StreamSource{ .file = file };
+//
+//    var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
+//    defer jpeg_file.deinit();
+//
+//    var pixelsOpt: ?color.PixelStorage = null;
+//    const frame = try jpeg_file.read(stream_source.reader(), stream_source.seekableStream(), &pixelsOpt);
+//
+//    defer {
+//        if (pixelsOpt) |pixels| {
+//            pixels.deinit(helpers.zigimg_test_allocator);
+//        }
+//    }
+//
+//    try helpers.expectEq(frame.frame_header.row_count, 512);
+//    try helpers.expectEq(frame.frame_header.samples_per_row, 512);
+//    try helpers.expectEq(frame.frame_header.sample_precision, 8);
+//    try helpers.expectEq(frame.frame_header.components.len, 3);
+//
+//    try testing.expect(pixelsOpt != null);
+//
+//    if (pixelsOpt) |pixels| {
+//        try testing.expect(pixels == .rgb24);
+//
+//        // Just for fun, let's sample a few pixels. :^)
+//        try helpers.expectEq(pixels.rgb24[(126 * 512 + 163)], color.Rgb24.initRgb(0xAC, 0x78, 0x54));
+//        try helpers.expectEq(pixels.rgb24[(265 * 512 + 284)], color.Rgb24.initRgb(0x37, 0x30, 0x33));
+//        try helpers.expectEq(pixels.rgb24[(431 * 512 + 300)], color.Rgb24.initRgb(0xFE, 0xE7, 0xC9));
+//    }
+//}
 
-    var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
-    defer jpeg_file.deinit();
-
-    var pixelsOpt: ?color.PixelStorage = null;
-    const invalidFile = jpeg_file.read(stream_source.reader(), stream_source.seekableStream(), &pixelsOpt);
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
-
-    try helpers.expectError(invalidFile, errors.ImageError.InvalidMagicHeader);
-}
-
-test "Read JFIF header properly and decode simple Huffman stream" {
-    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "jpeg/huff_simple0.jpg");
+test "Read weird one" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "jpeg/skills-disabled-3.jpg");
     defer file.close();
 
     var stream_source = std.io.StreamSource{ .file = file };
@@ -44,39 +111,9 @@ test "Read JFIF header properly and decode simple Huffman stream" {
         }
     }
 
-    try helpers.expectEq(frame.frame_header.row_count, 8);
-    try helpers.expectEq(frame.frame_header.samples_per_row, 16);
-    try helpers.expectEq(frame.frame_header.sample_precision, 8);
-    try helpers.expectEq(frame.frame_header.components.len, 3);
-
-    try testing.expect(pixelsOpt != null);
-
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .rgb24);
-    }
-}
-
-test "Read the tuba properly" {
-    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "jpeg/tuba.jpg");
-    defer file.close();
-
-    var stream_source = std.io.StreamSource{ .file = file };
-
-    var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
-    defer jpeg_file.deinit();
-
-    var pixelsOpt: ?color.PixelStorage = null;
-    const frame = try jpeg_file.read(stream_source.reader(), stream_source.seekableStream(), &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
-
-    try helpers.expectEq(frame.frame_header.row_count, 512);
-    try helpers.expectEq(frame.frame_header.samples_per_row, 512);
-    try helpers.expectEq(frame.frame_header.sample_precision, 8);
+    //try helpers.expectEq(frame.frame_header.row_count, 512);
+    //try helpers.expectEq(frame.frame_header.samples_per_row, 512);
+    //try helpers.expectEq(frame.frame_header.sample_precision, 8);
     try helpers.expectEq(frame.frame_header.components.len, 3);
 
     try testing.expect(pixelsOpt != null);
@@ -84,9 +121,17 @@ test "Read the tuba properly" {
     if (pixelsOpt) |pixels| {
         try testing.expect(pixels == .rgb24);
 
-        // Just for fun, let's sample a few pixels. :^)
-        try helpers.expectEq(pixels.rgb24[(126 * 512 + 163)], color.Rgb24.initRgb(0xAC, 0x78, 0x54));
-        try helpers.expectEq(pixels.rgb24[(265 * 512 + 284)], color.Rgb24.initRgb(0x37, 0x30, 0x33));
-        try helpers.expectEq(pixels.rgb24[(431 * 512 + 300)], color.Rgb24.initRgb(0xFE, 0xE7, 0xC9));
+        const cwd = std.fs.cwd();
+        var fw = try cwd.createFile("t.ppm", .{});
+        defer fw.close();
+
+        var w_stream = std.io.StreamSource{ .file = fw };
+
+        const save_info = image.ImageSaveInfo{
+            .width = 1496,
+            .height = 860,
+            .encoder_options = .{ .ppm = .{ .binary = true } },
+        };
+        try netpbm.PPM.writeForImage(testing.allocator, w_stream.writer(), w_stream.seekableStream(), pixels, save_info);
     }
 }

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -18,14 +18,14 @@ pub const tga = @import("src/formats/tga.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());
-    _ = @import("tests/color_test.zig");
-    _ = @import("tests/formats/bmp_test.zig");
+    //_ = @import("tests/color_test.zig");
+    //_ = @import("tests/formats/bmp_test.zig");
     _ = @import("tests/formats/jpeg_test.zig");
-    _ = @import("tests/formats/netpbm_test.zig");
-    _ = @import("tests/formats/pcx_test.zig");
-    _ = @import("tests/formats/png_test.zig");
-    _ = @import("tests/formats/qoi_test.zig");
-    _ = @import("tests/formats/tga_test.zig");
-    _ = @import("tests/image_test.zig");
-    _ = @import("tests/octree_quantizer_test.zig");
+    //_ = @import("tests/formats/netpbm_test.zig");
+    //_ = @import("tests/formats/pcx_test.zig");
+    //_ = @import("tests/formats/png_test.zig");
+    //_ = @import("tests/formats/qoi_test.zig");
+    //_ = @import("tests/formats/tga_test.zig");
+    //_ = @import("tests/image_test.zig");
+    //_ = @import("tests/octree_quantizer_test.zig");
 }


### PR DESCRIPTION
Hello,

I'm opening a pull request but it's actually more like a discussion that I want to open. Especially since the code does not work.

While trying to add support for a specific image, I encountered many issues that I felt might require a significant rework of the JPEG decoder in order to get it "right".

However, I am not familiar with JPEG nor this code base and I'm only dabbling in zig, so bear with me please :sweat_smile: .

The picture in question is the following and is copyrighted (thus the lack of a sibling PR on the test suite): https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dev/src/TreeData/3_18/skills-disabled-3.jpg

The issues I encountered so far are the lack of support for the sampling factor being different than 1 and some overflow in the dequantize function.

I do not really know how to approach this problem. Apparently, the dequantize would need to happen on something with higher precision than `i32` or maybe a floating point type?

There is also the problem of the number of MCU which I failed to properly guess. The number of row is 860 the number of sample per row is 1496. If we follow the original algorithm, we end up with 20103 MCU, if instead of 64 we use 256 (64 * sampling_factor_h * sampling_factor_v), we end up with 5026 samples, but there are 5076. So maybe a solution is to look for EOS instead of trying to guess and preallocate the MCUs?

Finally, my understanding is that the sampling_factor is only increased for the Y channel, not the others. Which means we need to read several Y MCU in a row. If we want proper support for the sampling factor, we need to support the for combination of a 1x1 square, 2x1, 1x2 and 2x2. The current approach preallocates a 2x2 square for the Y channel and then will use less based on the actual sampling_factor encountered. Which might be a huge waste of memory. So maybe there is a better way.

But we also need to consider the sampling when converting the data to a pixmap. Taking into account the fact that the Y channel has a layout that can vary while Cb and Cr are always 1x1.

So yeah, many questions left to answer. What are you recommendations? Should I try to make this work and we will see from there or do you have something else in mind?

Again, do not mind the code too much, it's definitely not meant to be merged as is, it's just there to highlight the places where I had issues. And it's not working anyway. But I'll take any comments you might have.