### PR TITLE
Remove storage of the image format in Image. 

### DIFF
--- a/src/image.zig
+++ b/src/image.zig
@@ -19,7 +19,6 @@ pub const ImageFormat = enum {
     png,
     ppm,
     qoi,
-    raw,
     tga,
 };
 
@@ -44,7 +43,6 @@ pub const Image = struct {
     width: usize = 0,
     height: usize = 0,
     pixels: ?PixelStorage = null,
-    image_format: ImageFormat = undefined,
 
     const Self = @This();
 
@@ -118,12 +116,11 @@ pub const Image = struct {
     }
 
     /// Create a pixel surface from scratch
-    pub fn create(allocator: Allocator, width: usize, height: usize, pixel_format: PixelFormat, image_format: ImageFormat) !Self {
+    pub fn create(allocator: Allocator, width: usize, height: usize, pixel_format: PixelFormat) !Self {
         var result = Self{
             .allocator = allocator,
             .width = width,
             .height = height,
-            .image_format = image_format,
             .pixels = try PixelStorage.init(allocator, pixel_format, width * height),
         };
 
@@ -254,8 +251,7 @@ pub const Image = struct {
     }
 
     fn internalRead(self: *Self, allocator: Allocator, stream: *ImageStream) !void {
-        var format_interface = try findImageInterfaceFromStream(stream);
-        self.image_format = format_interface.format();
+        const format_interface = try findImageInterfaceFromStream(stream);
 
         try stream.seekTo(0);
 

--- a/tests/formats/netpbm_test.zig
+++ b/tests/formats/netpbm_test.zig
@@ -309,7 +309,7 @@ test "Write bitmap(grayscale1) ASCII PBM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1, .raw);
+    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
     defer source_image.deinit();
 
     if (source_image.pixels) |source| {
@@ -356,7 +356,7 @@ test "Write bitmap(Grayscale1) binary PBM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1, .raw);
+    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
     defer source_image.deinit();
 
     if (source_image.pixels) |source| {
@@ -400,7 +400,7 @@ test "Write grayscale8 ASCII PGM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8, .raw);
+    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
     defer source_image.deinit();
 
     if (source_image.pixels) |source| {
@@ -444,7 +444,7 @@ test "Write grayscale8 binary PGM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8, .raw);
+    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
     defer source_image.deinit();
 
     if (source_image.pixels) |source| {
@@ -485,7 +485,7 @@ test "Writing Rgb24 ASCII PPM format" {
     const width = expected_colors.len;
     const height = 1;
 
-    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24, .raw);
+    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
     defer source_image.deinit();
 
     try testing.expect(source_image.pixels != null);
@@ -541,7 +541,7 @@ test "Writing Rgb24 binary PPM format" {
     const width = expected_colors.len;
     const height = 1;
 
-    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24, .raw);
+    const source_image = try image.Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
     defer source_image.deinit();
 
     try testing.expect(source_image.pixels != null);

--- a/tests/formats/qoi_test.zig
+++ b/tests/formats/qoi_test.zig
@@ -66,7 +66,7 @@ test "Read zero.qoi file" {
 }
 
 test "Write qoi file" {
-    const source_image = try image.Image.create(helpers.zigimg_test_allocator, 512, 512, PixelFormat.rgba32, .qoi);
+    const source_image = try image.Image.create(helpers.zigimg_test_allocator, 512, 512, PixelFormat.rgba32);
     defer source_image.deinit();
 
     var buffer: [1025 * 1024]u8 = undefined;

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -9,7 +9,7 @@ const errors = @import("../src/errors.zig");
 const ImageError = errors.ImageError;
 
 test "Create Image indexed1" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed1, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed1);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -25,7 +25,7 @@ test "Create Image indexed1" {
 }
 
 test "Create Image indexed2" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed2, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed2);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -41,7 +41,7 @@ test "Create Image indexed2" {
 }
 
 test "Create Image indexed4" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed4, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed4);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -57,7 +57,7 @@ test "Create Image indexed4" {
 }
 
 test "Create Image indexed8" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed8, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed8);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -73,7 +73,7 @@ test "Create Image indexed8" {
 }
 
 test "Create Image indexed16" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed16, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed16);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -89,7 +89,7 @@ test "Create Image indexed16" {
 }
 
 test "Create Image Rgb24" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb24, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb24);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -104,7 +104,7 @@ test "Create Image Rgb24" {
 }
 
 test "Create Image Rgba32" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgba32, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgba32);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -119,7 +119,7 @@ test "Create Image Rgba32" {
 }
 
 test "Create Image Rgb565" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb565, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb565);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -134,7 +134,7 @@ test "Create Image Rgb565" {
 }
 
 test "Create Image Rgb555" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb555, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb555);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -149,7 +149,7 @@ test "Create Image Rgb555" {
 }
 
 test "Create Image Bgra32" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.bgra32, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.bgra32);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -164,7 +164,7 @@ test "Create Image Bgra32" {
 }
 
 test "Create Image float32" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.float32, .raw);
+    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.float32);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
@@ -187,7 +187,6 @@ test "Should detect BMP properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .bmp);
     }
 }
 
@@ -197,7 +196,6 @@ test "Should detect Memory BMP properly" {
 
     const test_image = try Image.fromMemory(helpers.zigimg_test_allocator, buffer);
     defer test_image.deinit();
-    try testing.expect(test_image.image_format == .bmp);
 }
 
 test "Should detect PCX properly" {
@@ -211,7 +209,6 @@ test "Should detect PCX properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .pcx);
     }
 }
 
@@ -224,7 +221,6 @@ test "Should detect PBM properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .pbm);
     }
 }
 
@@ -239,7 +235,6 @@ test "Should detect PGM properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .pgm);
     }
 }
 
@@ -252,7 +247,6 @@ test "Should detect PPM properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .ppm);
     }
 }
 
@@ -265,7 +259,6 @@ test "Should detect PNG properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .png);
     }
 }
 
@@ -284,7 +277,6 @@ test "Should detect TGA properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .tga);
     }
 }
 
@@ -294,7 +286,6 @@ test "Should detect QOI properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .qoi);
     }
 }
 
@@ -307,7 +298,6 @@ test "Should detect JPEG properly" {
     for (image_tests) |image_path| {
         const test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
-        try testing.expect(test_image.image_format == .jpg);
     }
 }
 


### PR DESCRIPTION
It is not needed outside of the test suite and break the purpose of Image to be a format-independant pixel container.