### PR TITLE
Add gyro (a zig package manager) compatibility

### DIFF
--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,6 +1,6 @@
 pkgs:
   zigimg:
-    varsion: a224b3c942d48dbf580a75f2f87de16046cb335f
+    version: a224b3c942d48dbf580a75f2f87de16046cb335f
     license: MIT
     description: Zig library for reading and writing different image formats 
     source_url: https://github.com/zigimg/zigimg

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,0 +1,6 @@
+pkgs:
+  zigimg:
+    license: MIT
+    description: Zig library for reading and writing different image formats 
+    source_url: https://github.com/zigimg/zigimg
+    root: zigimg.zig

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,5 +1,6 @@
 pkgs:
   zigimg:
+    varsion: a224b3c942d48dbf580a75f2f87de16046cb335f
     license: MIT
     description: Zig library for reading and writing different image formats 
     source_url: https://github.com/zigimg/zigimg

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,6 +1,6 @@
 pkgs:
   zigimg:
-    version: a224b3c942d48dbf580a75f2f87de16046cb335f
+    version: 0.1.0
     license: MIT
     description: Zig library for reading and writing different image formats 
     source_url: https://github.com/zigimg/zigimg


### PR DESCRIPTION
This pr adds compatibility with the gyro package manager for zig, by adding a gyro.zzz file