### PR TITLE
Refactor Image to support animation

### DIFF
--- a/src/Image.zig
+++ b/src/Image.zig
@@ -56,8 +56,11 @@ pub const Animation = struct {
     loop_count: i32 = AnimationLoopInfinite,
 
     pub fn deinit(self: *Animation, allocator: std.mem.Allocator) void {
-        for (self.frames.items) |frame| {
-            frame.pixels.deinit(allocator);
+        // Animation share its first frame with the pixels in Image, we don't want to free it twice
+        if (self.frames.items.len >= 2) {
+            for (self.frames.items[1..]) |frame| {
+                frame.pixels.deinit(allocator);
+            }
         }
 
         self.frames.deinit(allocator);
@@ -69,7 +72,7 @@ allocator: Allocator = undefined,
 width: usize = 0,
 height: usize = 0,
 pixels: PixelStorage = .{ .invalid = void{} },
-animation: ?Animation = null,
+animation: Animation = .{},
 
 const Self = @This();
 
@@ -108,9 +111,7 @@ pub fn init(allocator: Allocator) Self {
 /// Deinit the image
 pub fn deinit(self: *Self) void {
     self.pixels.deinit(self.allocator);
-    if (self.animation) |*animation| {
-        animation.deinit(self.allocator);
-    }
+    self.animation.deinit(self.allocator);
 }
 
 /// Load an image from a file path
@@ -147,23 +148,11 @@ pub fn create(allocator: Allocator, width: usize, height: usize, pixel_format: P
 
 /// Return the pixel format of the image
 pub fn pixelFormat(self: Self) PixelFormat {
-    if (self.animation) |animation| {
-        if (animation.frames.items.len > 0) {
-            return std.meta.activeTag(animation.frames.items[0].pixels);
-        }
-    }
-
     return std.meta.activeTag(self.pixels);
 }
 
 /// Return the pixel data as a const byte slice. In case of an animation, it return the pixel data of the first frame.
 pub fn rawBytes(self: Self) []const u8 {
-    if (self.animation) |animation| {
-        if (animation.frames.items.len > 0) {
-            return animation.frames.items[0].pixels.asBytes();
-        }
-    }
-
     return self.pixels.asBytes();
 }
 
@@ -179,7 +168,7 @@ pub fn imageByteSize(self: Self) usize {
 
 /// Is this image is an animation?
 pub fn isAnimation(self: Self) bool {
-    return self.animation != null;
+    return self.animation.frames.len > 0;
 }
 
 /// Write the image to an image format to the specified path
@@ -209,12 +198,6 @@ pub fn writeToMemory(self: Self, write_buffer: []u8, encoder_options: EncoderOpt
 
 /// Iterate the pixel in pixel-format agnostic way. In the case of an animation, it returns an iterator for the first frame. The iterator is read-only.
 pub fn iterator(self: Self) color.PixelStorageIterator {
-    if (self.animation) |animation| {
-        if (animation.frames.items.len > 0) {
-            return color.PixelStorageIterator.init(&animation.frames.items[0].pixels);
-        }
-    }
-
     return color.PixelStorageIterator.init(&self.pixels);
 }
 

--- a/src/format_interface.zig
+++ b/src/format_interface.zig
@@ -14,5 +14,5 @@ pub const FormatInterface = struct {
     pub const FormatFn = fn () Image.Format;
     pub const FormatDetectFn = fn (stream: *Image.Stream) ImageReadError!bool;
     pub const ReadImageFn = fn (allocator: Allocator, stream: *Image.Stream) ImageReadError!Image;
-    pub const WriteImageFn = fn (allocator: Allocator, write_stream: *Image.Stream, pixels: color.PixelStorage, save_info: Image.SaveInfo) ImageWriteError!void;
+    pub const WriteImageFn = fn (allocator: Allocator, write_stream: *Image.Stream, image: Image, encoder_options: Image.EncoderOptions) ImageWriteError!void;
 };

--- a/src/formats/all.zig
+++ b/src/formats/all.zig
@@ -8,14 +8,14 @@ pub const PPM = @import("netpbm.zig").PPM;
 pub const QOI = @import("qoi.zig").QOI;
 pub const TGA = @import("tga.zig").TGA;
 
-pub const ImageEncoderOptions = union(enum) {
-    none: void,
+pub const ImageEncoderOptions = union(@import("../Image.zig").Format) {
+    bmp: void,
+    jpg: void,
     pbm: PBM.EncoderOptions,
+    pcx: void,
     pgm: PGM.EncoderOptions,
+    png: void,
     ppm: PPM.EncoderOptions,
     qoi: QOI.EncoderOptions,
-
-    const Self = @This();
-
-    pub const None = Self{ .none = .{} };
+    tga: void,
 };

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -267,7 +267,7 @@ pub const Bitmap = struct {
                 const pixel_format = try findPixelFormat(v5Header.bit_count, v5Header.compression_method);
 
                 pixels = try color.PixelStorage.init(allocator, pixel_format, @intCast(usize, pixel_width * pixel_height));
-                errdefer pixels.deinit();
+                errdefer pixels.deinit(allocator);
 
                 try readPixels(reader, pixel_width, pixel_height, pixel_format, &pixels);
             },

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -170,20 +170,32 @@ pub const Bitmap = struct {
     pub fn readImage(allocator: Allocator, stream: *Image.Stream) ImageReadError!Image {
         var result = Image.init(allocator);
         errdefer result.deinit();
+
+        var pixels_opt: ?color.PixelStorage = null;
+
         var bmp = Self{};
 
-        try bmp.read(allocator, stream, &result.pixels);
+        try bmp.read(allocator, stream, &pixels_opt);
 
         result.width = @intCast(usize, bmp.width());
         result.height = @intCast(usize, bmp.height());
+
+        if (pixels_opt) |pixels| {
+            result.data = .{
+                .image = pixels,
+            };
+        } else {
+            return ImageReadError.InvalidData;
+        }
+
         return result;
     }
 
-    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, pixels: color.PixelStorage, save_info: Image.SaveInfo) Image.Stream.WriteError!void {
+    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, image: Image, encoder_options: Image.EncoderOptions) Image.Stream.WriteError!void {
         _ = allocator;
         _ = write_stream;
-        _ = pixels;
-        _ = save_info;
+        _ = image;
+        _ = encoder_options;
     }
 
     pub fn width(self: Self) i32 {

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -176,9 +176,7 @@ pub const Bitmap = struct {
 
         result.width = @intCast(usize, bmp.width());
         result.height = @intCast(usize, bmp.height());
-        result.data = .{
-            .image = pixels,
-        };
+        result.pixels = pixels;
 
         return result;
     }

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -257,6 +257,8 @@ pub const Bitmap = struct {
                 const pixel_format = try findPixelFormat(v4Header.bit_count, v4Header.compression_method);
 
                 pixels = try color.PixelStorage.init(allocator, pixel_format, @intCast(usize, pixel_width * pixel_height));
+                errdefer pixels.deinit(allocator);
+
                 try readPixels(reader, pixel_width, pixel_height, pixel_format, &pixels);
             },
             .v5 => |v5Header| {
@@ -265,6 +267,8 @@ pub const Bitmap = struct {
                 const pixel_format = try findPixelFormat(v5Header.bit_count, v5Header.compression_method);
 
                 pixels = try color.PixelStorage.init(allocator, pixel_format, @intCast(usize, pixel_width * pixel_height));
+                errdefer pixels.deinit();
+
                 try readPixels(reader, pixel_width, pixel_height, pixel_format, &pixels);
             },
             else => return ImageError.Unsupported,

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -1018,7 +1018,6 @@ pub const JPEG = struct {
     }
 
     // Format interface
-
     pub fn formatInterface() FormatInterface {
         return FormatInterface{
             .format = format,
@@ -1052,17 +1051,28 @@ pub const JPEG = struct {
         var jpeg = JPEG.init(allocator);
         defer jpeg.deinit();
 
-        const frame = try jpeg.read(stream, &result.pixels);
+        var pixels_opt: ?color.PixelStorage = null;
+
+        const frame = try jpeg.read(stream, &pixels_opt);
+
         result.width = frame.frame_header.samples_per_row;
         result.height = frame.frame_header.row_count;
+
+        if (pixels_opt) |pixels| {
+            result.data = .{
+                .image = pixels,
+            };
+        } else {
+            return ImageReadError.InvalidData;
+        }
+
         return result;
     }
 
-    fn writeImage(allocator: Allocator, write_stream: *Image.Stream, pixels: color.PixelStorage, save_info: Image.SaveInfo) ImageWriteError!void {
+    fn writeImage(allocator: Allocator, write_stream: *Image.Stream, image: Image, encoder_options: Image.EncoderOptions) ImageWriteError!void {
         _ = allocator;
         _ = write_stream;
-        _ = pixels;
-        _ = save_info;
-        @panic("TODO: Implement JPEG writing! (maybe not...)");
+        _ = image;
+        _ = encoder_options;
     }
 };

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -1059,9 +1059,7 @@ pub const JPEG = struct {
         result.height = frame.frame_header.row_count;
 
         if (pixels_opt) |pixels| {
-            result.data = .{
-                .image = pixels,
-            };
+            result.pixels = pixels;
         } else {
             return ImageReadError.InvalidData;
         }

--- a/src/formats/netpbm.zig
+++ b/src/formats/netpbm.zig
@@ -346,6 +346,7 @@ fn Netpbm(comptime image_format: Image.Format, comptime header_numbers: []const 
             const pixel_format = try self.pixelFormat();
 
             var pixels = try color.PixelStorage.init(allocator, pixel_format, self.header.width * self.header.height);
+            errdefer pixels.deinit(allocator);
 
             switch (self.header.format) {
                 .bitmap => {

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -137,9 +137,7 @@ pub const PCX = struct {
 
         result.width = pcx.width;
         result.height = pcx.height;
-        result.data = .{
-            .image = pixels,
-        };
+        result.pixels = pixels;
 
         return result;
     }

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -133,19 +133,29 @@ pub const PCX = struct {
         errdefer result.deinit();
         var pcx = PCX{};
 
-        try pcx.read(allocator, stream, &result.pixels);
+        var pixels_opt: ?color.PixelStorage = null;
+
+        try pcx.read(allocator, stream, &pixels_opt);
 
         result.width = pcx.width;
         result.height = pcx.height;
 
+        if (pixels_opt) |pixels| {
+            result.data = .{
+                .image = pixels,
+            };
+        } else {
+            return ImageReadError.InvalidData;
+        }
+
         return result;
     }
 
-    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, pixels: color.PixelStorage, save_info: Image.SaveInfo) ImageWriteError!void {
+    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, image: Image, encoder_options: Image.EncoderOptions) ImageWriteError!void {
         _ = allocator;
         _ = write_stream;
-        _ = pixels;
-        _ = save_info;
+        _ = image;
+        _ = encoder_options;
     }
 
     pub fn pixelFormat(self: Self) ImageReadError!PixelFormat {

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -62,10 +62,10 @@ pub const PNG = struct {
         return load(stream, allocator, default_options.get());
     }
 
-    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, pixels: color.PixelStorage, save_info: Image.SaveInfo) ImageWriteError!void {
+    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, image: Image, encoder_options: Image.EncoderOptions) ImageWriteError!void {
         _ = allocator;
         _ = write_stream;
-        _ = pixels;
-        _ = save_info;
+        _ = image;
+        _ = encoder_options;
     }
 };

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -174,7 +174,9 @@ pub fn load(stream: *Image.Stream, allocator: Allocator, options: ReaderOptions)
 
     result.width = header.width;
     result.height = header.height;
-    result.pixels = try loadWithHeader(stream, &header, allocator, options);
+    result.data = .{
+        .image = try loadWithHeader(stream, &header, allocator, options),
+    };
 
     return result;
 }

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -174,9 +174,7 @@ pub fn load(stream: *Image.Stream, allocator: Allocator, options: ReaderOptions)
 
     result.width = header.width;
     result.height = header.height;
-    result.data = .{
-        .image = try loadWithHeader(stream, &header, allocator, options),
-    };
+    result.pixels = try loadWithHeader(stream, &header, allocator, options);
 
     return result;
 }

--- a/src/formats/qoi.zig
+++ b/src/formats/qoi.zig
@@ -103,7 +103,7 @@ pub const QOI = struct {
     header: Header = undefined,
 
     pub const EncoderOptions = struct {
-        colorspace: Colorspace,
+        colorspace: Colorspace = .srgb,
     };
 
     const Self = @This();

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -275,9 +275,7 @@ pub const TGA = struct {
 
         result.width = tga.width();
         result.height = tga.height();
-        result.data = .{
-            .image = pixels,
-        };
+        result.pixels = pixels;
 
         return result;
     }

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -271,18 +271,28 @@ pub const TGA = struct {
         errdefer result.deinit();
         var tga = Self{};
 
-        try tga.read(allocator, stream, &result.pixels);
+        var pixels_opt: ?color.PixelStorage = null;
+        try tga.read(allocator, stream, &pixels_opt);
 
         result.width = tga.width();
         result.height = tga.height();
+
+        if (pixels_opt) |pixels| {
+            result.data = .{
+                .image = pixels,
+            };
+        } else {
+            return ImageReadError.InvalidData;
+        }
+
         return result;
     }
 
-    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, pixels: color.PixelStorage, save_info: Image.SaveInfo) ImageWriteError!void {
+    pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, image: Image, encoder_options: Image.EncoderOptions) ImageWriteError!void {
         _ = allocator;
         _ = write_stream;
-        _ = pixels;
-        _ = save_info;
+        _ = image;
+        _ = encoder_options;
     }
 
     pub fn width(self: Self) usize {

--- a/src/pixel_format.zig
+++ b/src/pixel_format.zig
@@ -4,6 +4,7 @@
 /// 3. value & 0xF000 gives a special variant number, 1 for Bgr, 2 for Float and 3 for special Rgb 565
 /// Note that palette index formats have number of channels set to 0.
 pub const PixelFormat = enum(u32) {
+    invalid = 0,
     indexed1 = 1,
     indexed2 = 2,
     indexed4 = 4,
@@ -51,6 +52,7 @@ pub const PixelFormat = enum(u32) {
     pub fn pixelStride(self: Self) u8 {
         // Using bit manipulations of values is not really faster than this switch
         return switch (self) {
+            .invalid => 0,
             .indexed1, .indexed2, .indexed4, .indexed8, .grayscale1, .grayscale2, .grayscale4, .grayscale8 => 1,
             .indexed16, .grayscale16, .grayscale8Alpha, .rgb565, .rgb555 => 2,
             .rgb24, .bgr24 => 3,
@@ -63,6 +65,7 @@ pub const PixelFormat = enum(u32) {
 
     pub fn channelCount(self: Self) u8 {
         return switch (self) {
+            .invalid => 0,
             .grayscale8Alpha, .grayscale16Alpha => 2,
             .rgb565, .rgb555, .rgb24, .bgr24, .rgb48 => 3,
             .rgba32, .bgra32, .rgba64, .float32 => 4,

--- a/tests/formats/netpbm_test.zig
+++ b/tests/formats/netpbm_test.zig
@@ -15,28 +15,17 @@ test "Load ASCII PBM image" {
 
     var pbmFile = netpbm.PBM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pbmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pbmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pbmFile.header.width, 8);
     try helpers.expectEq(pbmFile.header.height, 16);
     try helpers.expectEq(try pbmFile.pixelFormat(), PixelFormat.grayscale1);
 
-    try testing.expect(pixelsOpt != null);
-
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .grayscale1);
-
-        try helpers.expectEq(pixels.grayscale1[0].value, 0);
-        try helpers.expectEq(pixels.grayscale1[1].value, 1);
-        try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 1);
-    }
+    try testing.expect(pixels == .grayscale1);
+    try helpers.expectEq(pixels.grayscale1[0].value, 0);
+    try helpers.expectEq(pixels.grayscale1[1].value, 1);
+    try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 1);
 }
 
 test "Load binary PBM image" {
@@ -47,28 +36,17 @@ test "Load binary PBM image" {
 
     var pbmFile = netpbm.PBM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pbmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pbmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pbmFile.header.width, 8);
     try helpers.expectEq(pbmFile.header.height, 16);
     try helpers.expectEq(try pbmFile.pixelFormat(), PixelFormat.grayscale1);
 
-    try testing.expect(pixelsOpt != null);
-
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .grayscale1);
-
-        try helpers.expectEq(pixels.grayscale1[0].value, 0);
-        try helpers.expectEq(pixels.grayscale1[1].value, 1);
-        try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 1);
-    }
+    try testing.expect(pixels == .grayscale1);
+    try helpers.expectEq(pixels.grayscale1[0].value, 0);
+    try helpers.expectEq(pixels.grayscale1[1].value, 1);
+    try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 1);
 }
 
 test "Load ASCII PGM 8-bit grayscale image" {
@@ -79,28 +57,17 @@ test "Load ASCII PGM 8-bit grayscale image" {
 
     var pgmFile = netpbm.PGM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pgmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pgmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pgmFile.header.width, 16);
     try helpers.expectEq(pgmFile.header.height, 24);
     try helpers.expectEq(try pgmFile.pixelFormat(), PixelFormat.grayscale8);
 
-    try testing.expect(pixelsOpt != null);
-
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .grayscale8);
-
-        try helpers.expectEq(pixels.grayscale8[0].value, 2);
-        try helpers.expectEq(pixels.grayscale8[1].value, 5);
-        try helpers.expectEq(pixels.grayscale8[383].value, 196);
-    }
+    try testing.expect(pixels == .grayscale8);
+    try helpers.expectEq(pixels.grayscale8[0].value, 2);
+    try helpers.expectEq(pixels.grayscale8[1].value, 5);
+    try helpers.expectEq(pixels.grayscale8[383].value, 196);
 }
 
 test "Load Binary PGM 8-bit grayscale image" {
@@ -111,28 +78,17 @@ test "Load Binary PGM 8-bit grayscale image" {
 
     var pgmFile = netpbm.PGM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pgmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pgmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pgmFile.header.width, 16);
     try helpers.expectEq(pgmFile.header.height, 24);
     try helpers.expectEq(try pgmFile.pixelFormat(), PixelFormat.grayscale8);
 
-    try testing.expect(pixelsOpt != null);
-
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .grayscale8);
-
-        try helpers.expectEq(pixels.grayscale8[0].value, 2);
-        try helpers.expectEq(pixels.grayscale8[1].value, 5);
-        try helpers.expectEq(pixels.grayscale8[383].value, 196);
-    }
+    try testing.expect(pixels == .grayscale8);
+    try helpers.expectEq(pixels.grayscale8[0].value, 2);
+    try helpers.expectEq(pixels.grayscale8[1].value, 5);
+    try helpers.expectEq(pixels.grayscale8[383].value, 196);
 }
 
 test "Load ASCII PGM 16-bit grayscale image" {
@@ -143,28 +99,17 @@ test "Load ASCII PGM 16-bit grayscale image" {
 
     var pgmFile = netpbm.PGM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pgmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pgmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pgmFile.header.width, 8);
     try helpers.expectEq(pgmFile.header.height, 16);
     try helpers.expectEq(try pgmFile.pixelFormat(), PixelFormat.grayscale16);
 
-    try testing.expect(pixelsOpt != null);
-
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .grayscale16);
-
-        try helpers.expectEq(pixels.grayscale16[0].value, 3553);
-        try helpers.expectEq(pixels.grayscale16[1].value, 4319);
-        try helpers.expectEq(pixels.grayscale16[127].value, 61139);
-    }
+    try testing.expect(pixels == .grayscale16);
+    try helpers.expectEq(pixels.grayscale16[0].value, 3553);
+    try helpers.expectEq(pixels.grayscale16[1].value, 4319);
+    try helpers.expectEq(pixels.grayscale16[127].value, 61139);
 }
 
 test "Load Binary PGM 16-bit grayscale image" {
@@ -175,28 +120,17 @@ test "Load Binary PGM 16-bit grayscale image" {
 
     var pgmFile = netpbm.PGM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pgmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pgmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pgmFile.header.width, 8);
     try helpers.expectEq(pgmFile.header.height, 16);
     try helpers.expectEq(try pgmFile.pixelFormat(), PixelFormat.grayscale16);
 
-    try testing.expect(pixelsOpt != null);
-
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .grayscale16);
-
-        try helpers.expectEq(pixels.grayscale16[0].value, 3553);
-        try helpers.expectEq(pixels.grayscale16[1].value, 4319);
-        try helpers.expectEq(pixels.grayscale16[127].value, 61139);
-    }
+    try testing.expect(pixels == .grayscale16);
+    try helpers.expectEq(pixels.grayscale16[0].value, 3553);
+    try helpers.expectEq(pixels.grayscale16[1].value, 4319);
+    try helpers.expectEq(pixels.grayscale16[127].value, 61139);
 }
 
 test "Load ASCII PPM image" {
@@ -207,44 +141,34 @@ test "Load ASCII PPM image" {
 
     var ppmFile = netpbm.PPM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try ppmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try ppmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(ppmFile.header.width, 27);
     try helpers.expectEq(ppmFile.header.height, 27);
     try helpers.expectEq(try ppmFile.pixelFormat(), PixelFormat.rgb24);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels == .rgb24);
 
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .rgb24);
+    try helpers.expectEq(pixels.rgb24[0].r, 0x34);
+    try helpers.expectEq(pixels.rgb24[0].g, 0x53);
+    try helpers.expectEq(pixels.rgb24[0].b, 0x9f);
 
-        try helpers.expectEq(pixels.rgb24[0].r, 0x34);
-        try helpers.expectEq(pixels.rgb24[0].g, 0x53);
-        try helpers.expectEq(pixels.rgb24[0].b, 0x9f);
+    try helpers.expectEq(pixels.rgb24[1].r, 0x32);
+    try helpers.expectEq(pixels.rgb24[1].g, 0x5b);
+    try helpers.expectEq(pixels.rgb24[1].b, 0x96);
 
-        try helpers.expectEq(pixels.rgb24[1].r, 0x32);
-        try helpers.expectEq(pixels.rgb24[1].g, 0x5b);
-        try helpers.expectEq(pixels.rgb24[1].b, 0x96);
+    try helpers.expectEq(pixels.rgb24[26].r, 0xa8);
+    try helpers.expectEq(pixels.rgb24[26].g, 0x5a);
+    try helpers.expectEq(pixels.rgb24[26].b, 0x78);
 
-        try helpers.expectEq(pixels.rgb24[26].r, 0xa8);
-        try helpers.expectEq(pixels.rgb24[26].g, 0x5a);
-        try helpers.expectEq(pixels.rgb24[26].b, 0x78);
+    try helpers.expectEq(pixels.rgb24[27].r, 0x2e);
+    try helpers.expectEq(pixels.rgb24[27].g, 0x54);
+    try helpers.expectEq(pixels.rgb24[27].b, 0x99);
 
-        try helpers.expectEq(pixels.rgb24[27].r, 0x2e);
-        try helpers.expectEq(pixels.rgb24[27].g, 0x54);
-        try helpers.expectEq(pixels.rgb24[27].b, 0x99);
-
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].r, 0x88);
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].g, 0xb7);
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].b, 0x55);
-    }
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].r, 0x88);
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].g, 0xb7);
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].b, 0x55);
 }
 
 test "Load binary PPM image" {
@@ -255,44 +179,34 @@ test "Load binary PPM image" {
 
     var ppmFile = netpbm.PPM{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try ppmFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try ppmFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(ppmFile.header.width, 27);
     try helpers.expectEq(ppmFile.header.height, 27);
     try helpers.expectEq(try ppmFile.pixelFormat(), PixelFormat.rgb24);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels == .rgb24);
 
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .rgb24);
+    try helpers.expectEq(pixels.rgb24[0].r, 0x34);
+    try helpers.expectEq(pixels.rgb24[0].g, 0x53);
+    try helpers.expectEq(pixels.rgb24[0].b, 0x9f);
 
-        try helpers.expectEq(pixels.rgb24[0].r, 0x34);
-        try helpers.expectEq(pixels.rgb24[0].g, 0x53);
-        try helpers.expectEq(pixels.rgb24[0].b, 0x9f);
+    try helpers.expectEq(pixels.rgb24[1].r, 0x32);
+    try helpers.expectEq(pixels.rgb24[1].g, 0x5b);
+    try helpers.expectEq(pixels.rgb24[1].b, 0x96);
 
-        try helpers.expectEq(pixels.rgb24[1].r, 0x32);
-        try helpers.expectEq(pixels.rgb24[1].g, 0x5b);
-        try helpers.expectEq(pixels.rgb24[1].b, 0x96);
+    try helpers.expectEq(pixels.rgb24[26].r, 0xa8);
+    try helpers.expectEq(pixels.rgb24[26].g, 0x5a);
+    try helpers.expectEq(pixels.rgb24[26].b, 0x78);
 
-        try helpers.expectEq(pixels.rgb24[26].r, 0xa8);
-        try helpers.expectEq(pixels.rgb24[26].g, 0x5a);
-        try helpers.expectEq(pixels.rgb24[26].b, 0x78);
+    try helpers.expectEq(pixels.rgb24[27].r, 0x2e);
+    try helpers.expectEq(pixels.rgb24[27].g, 0x54);
+    try helpers.expectEq(pixels.rgb24[27].b, 0x99);
 
-        try helpers.expectEq(pixels.rgb24[27].r, 0x2e);
-        try helpers.expectEq(pixels.rgb24[27].g, 0x54);
-        try helpers.expectEq(pixels.rgb24[27].b, 0x99);
-
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].r, 0x88);
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].g, 0xb7);
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].b, 0x55);
-    }
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].r, 0x88);
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].g, 0xb7);
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].b, 0x55);
 }
 
 test "Write bitmap(grayscale1) ASCII PBM file" {

--- a/tests/formats/netpbm_test.zig
+++ b/tests/formats/netpbm_test.zig
@@ -224,7 +224,7 @@ test "Write bitmap(grayscale1) ASCII PBM file" {
     var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
     defer source_image.deinit();
 
-    const source = source_image.data.image;
+    const source = source_image.pixels;
     for (grayscales) |value, index| {
         source.grayscale1[index].value = value;
     }
@@ -243,9 +243,7 @@ test "Write bitmap(grayscale1) ASCII PBM file" {
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.data == .image);
-
-    const read_pixels = read_image.data.image;
+    const read_pixels = read_image.pixels;
 
     try testing.expect(read_pixels == .grayscale1);
 
@@ -270,7 +268,7 @@ test "Write bitmap(Grayscale1) binary PBM file" {
     var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
     defer source_image.deinit();
 
-    const source = source_image.data.image;
+    const source = source_image.pixels;
 
     for (grayscales) |value, index| {
         source.grayscale1[index].value = value;
@@ -290,9 +288,7 @@ test "Write bitmap(Grayscale1) binary PBM file" {
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.data == .image);
-
-    const read_pixels = read_image.data.image;
+    const read_pixels = read_image.pixels;
 
     try testing.expect(read_pixels == .grayscale1);
 
@@ -314,7 +310,7 @@ test "Write grayscale8 ASCII PGM file" {
     var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
     defer source_image.deinit();
 
-    const source = source_image.data.image;
+    const source = source_image.pixels;
     for (grayscales) |value, index| {
         source.grayscale8[index].value = value;
     }
@@ -333,9 +329,8 @@ test "Write grayscale8 ASCII PGM file" {
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.data == .image);
+    const read_pixels = read_image.pixels;
 
-    const read_pixels = read_image.data.image;
     try testing.expect(read_pixels == .grayscale8);
 
     for (grayscales) |grayscale_value, index| {
@@ -356,7 +351,7 @@ test "Write grayscale8 binary PGM file" {
     var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
     defer source_image.deinit();
 
-    const source = source_image.data.image;
+    const source = source_image.pixels;
     for (grayscales) |value, index| {
         source.grayscale8[index].value = value;
     }
@@ -375,9 +370,7 @@ test "Write grayscale8 binary PGM file" {
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.data == .image);
-
-    const read_pixels = read_image.data.image;
+    const read_pixels = read_image.pixels;
     try testing.expect(read_pixels == .grayscale8);
 
     for (grayscales) |grayscale_value, index| {
@@ -395,9 +388,8 @@ test "Writing Rgb24 ASCII PPM format" {
     var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
     defer source_image.deinit();
 
-    try testing.expect(source_image.data == .image);
+    const pixels = source_image.pixels;
 
-    const pixels = source_image.data.image;
     try testing.expect(pixels == .rgb24);
     try testing.expect(pixels.rgb24.len == width * height);
 
@@ -429,9 +421,7 @@ test "Writing Rgb24 ASCII PPM format" {
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.data == .image);
-
-    const read_image_pixels = read_image.data.image;
+    const read_image_pixels = read_image.pixels;
 
     try testing.expect(read_image_pixels == .rgb24);
 
@@ -450,9 +440,7 @@ test "Writing Rgb24 binary PPM format" {
     var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
     defer source_image.deinit();
 
-    try testing.expect(source_image.data == .image);
-
-    const pixels = source_image.data.image;
+    const pixels = source_image.pixels;
 
     try testing.expect(pixels == .rgb24);
     try testing.expect(pixels.rgb24.len == width * height);
@@ -485,9 +473,7 @@ test "Writing Rgb24 binary PPM format" {
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.data == .image);
-
-    const read_image_pixels = read_image.data.image;
+    const read_image_pixels = read_image.pixels;
 
     try testing.expect(read_image_pixels == .rgb24);
 

--- a/tests/formats/netpbm_test.zig
+++ b/tests/formats/netpbm_test.zig
@@ -229,7 +229,7 @@ test "Write bitmap(grayscale1) ASCII PBM file" {
         source.grayscale1[index].value = value;
     }
 
-    try source_image.writeToFilePath(image_file_name, Image.Format.pbm, Image.EncoderOptions{
+    try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .pbm = .{ .binary = false },
     });
 
@@ -276,7 +276,7 @@ test "Write bitmap(Grayscale1) binary PBM file" {
         source.grayscale1[index].value = value;
     }
 
-    try source_image.writeToFilePath(image_file_name, Image.Format.pbm, Image.EncoderOptions{
+    try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .pbm = .{ .binary = true },
     });
 
@@ -319,7 +319,7 @@ test "Write grayscale8 ASCII PGM file" {
         source.grayscale8[index].value = value;
     }
 
-    try source_image.writeToFilePath(image_file_name, Image.Format.pgm, Image.EncoderOptions{
+    try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .pgm = .{ .binary = false },
     });
 
@@ -361,7 +361,7 @@ test "Write grayscale8 binary PGM file" {
         source.grayscale8[index].value = value;
     }
 
-    try source_image.writeToFilePath(image_file_name, Image.Format.pgm, Image.EncoderOptions{
+    try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .pgm = .{ .binary = true },
     });
 
@@ -415,7 +415,7 @@ test "Writing Rgb24 ASCII PPM format" {
     pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
     pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
 
-    try source_image.writeToFilePath(image_file_name, Image.Format.ppm, Image.EncoderOptions{
+    try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .ppm = .{ .binary = false },
     });
 
@@ -471,7 +471,7 @@ test "Writing Rgb24 binary PPM format" {
     pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
     pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
 
-    try source_image.writeToFilePath(image_file_name, Image.Format.ppm, Image.EncoderOptions{
+    try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .ppm = .{ .binary = true },
     });
 

--- a/tests/formats/netpbm_test.zig
+++ b/tests/formats/netpbm_test.zig
@@ -307,13 +307,12 @@ test "Write bitmap(grayscale1) ASCII PBM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
+    var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
     defer source_image.deinit();
 
-    if (source_image.pixels) |source| {
-        for (grayscales) |value, index| {
-            source.grayscale1[index].value = value;
-        }
+    const source = source_image.data.image;
+    for (grayscales) |value, index| {
+        source.grayscale1[index].value = value;
     }
 
     try source_image.writeToFilePath(image_file_name, Image.Format.pbm, Image.EncoderOptions{
@@ -324,20 +323,20 @@ test "Write bitmap(grayscale1) ASCII PBM file" {
         std.fs.cwd().deleteFile(image_file_name) catch unreachable;
     }
 
-    const read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
+    var read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
     defer read_image.deinit();
 
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.pixels != null);
+    try testing.expect(read_image.data == .image);
 
-    if (read_image.pixels) |read_pixels| {
-        try testing.expect(read_pixels == .grayscale1);
+    const read_pixels = read_image.data.image;
 
-        for (grayscales) |grayscale_value, index| {
-            try helpers.expectEq(read_pixels.grayscale1[index].value, grayscale_value);
-        }
+    try testing.expect(read_pixels == .grayscale1);
+
+    for (grayscales) |grayscale_value, index| {
+        try helpers.expectEq(read_pixels.grayscale1[index].value, grayscale_value);
     }
 }
 
@@ -354,13 +353,13 @@ test "Write bitmap(Grayscale1) binary PBM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
+    var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale1);
     defer source_image.deinit();
 
-    if (source_image.pixels) |source| {
-        for (grayscales) |value, index| {
-            source.grayscale1[index].value = value;
-        }
+    const source = source_image.data.image;
+
+    for (grayscales) |value, index| {
+        source.grayscale1[index].value = value;
     }
 
     try source_image.writeToFilePath(image_file_name, Image.Format.pbm, Image.EncoderOptions{
@@ -371,20 +370,20 @@ test "Write bitmap(Grayscale1) binary PBM file" {
         std.fs.cwd().deleteFile(image_file_name) catch unreachable;
     }
 
-    const read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
+    var read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
     defer read_image.deinit();
 
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.pixels != null);
+    try testing.expect(read_image.data == .image);
 
-    if (read_image.pixels) |read_pixels| {
-        try testing.expect(read_pixels == .grayscale1);
+    const read_pixels = read_image.data.image;
 
-        for (grayscales) |grayscale_value, index| {
-            try helpers.expectEq(read_pixels.grayscale1[index].value, grayscale_value);
-        }
+    try testing.expect(read_pixels == .grayscale1);
+
+    for (grayscales) |grayscale_value, index| {
+        try helpers.expectEq(read_pixels.grayscale1[index].value, grayscale_value);
     }
 }
 
@@ -398,13 +397,12 @@ test "Write grayscale8 ASCII PGM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
+    var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
     defer source_image.deinit();
 
-    if (source_image.pixels) |source| {
-        for (grayscales) |value, index| {
-            source.grayscale8[index].value = value;
-        }
+    const source = source_image.data.image;
+    for (grayscales) |value, index| {
+        source.grayscale8[index].value = value;
     }
 
     try source_image.writeToFilePath(image_file_name, Image.Format.pgm, Image.EncoderOptions{
@@ -415,20 +413,19 @@ test "Write grayscale8 ASCII PGM file" {
         std.fs.cwd().deleteFile(image_file_name) catch unreachable;
     }
 
-    const read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
+    var read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
     defer read_image.deinit();
 
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.pixels != null);
+    try testing.expect(read_image.data == .image);
 
-    if (read_image.pixels) |read_pixels| {
-        try testing.expect(read_pixels == .grayscale8);
+    const read_pixels = read_image.data.image;
+    try testing.expect(read_pixels == .grayscale8);
 
-        for (grayscales) |grayscale_value, index| {
-            try helpers.expectEq(read_pixels.grayscale8[index].value, grayscale_value);
-        }
+    for (grayscales) |grayscale_value, index| {
+        try helpers.expectEq(read_pixels.grayscale8[index].value, grayscale_value);
     }
 }
 
@@ -442,13 +439,12 @@ test "Write grayscale8 binary PGM file" {
     const width = grayscales.len;
     const height = 1;
 
-    const source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
+    var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.grayscale8);
     defer source_image.deinit();
 
-    if (source_image.pixels) |source| {
-        for (grayscales) |value, index| {
-            source.grayscale8[index].value = value;
-        }
+    const source = source_image.data.image;
+    for (grayscales) |value, index| {
+        source.grayscale8[index].value = value;
     }
 
     try source_image.writeToFilePath(image_file_name, Image.Format.pgm, Image.EncoderOptions{
@@ -459,20 +455,19 @@ test "Write grayscale8 binary PGM file" {
         std.fs.cwd().deleteFile(image_file_name) catch unreachable;
     }
 
-    const read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
+    var read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
     defer read_image.deinit();
 
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.pixels != null);
+    try testing.expect(read_image.data == .image);
 
-    if (read_image.pixels) |read_pixels| {
-        try testing.expect(read_pixels == .grayscale8);
+    const read_pixels = read_image.data.image;
+    try testing.expect(read_pixels == .grayscale8);
 
-        for (grayscales) |grayscale_value, index| {
-            try helpers.expectEq(read_pixels.grayscale8[index].value, grayscale_value);
-        }
+    for (grayscales) |grayscale_value, index| {
+        try helpers.expectEq(read_pixels.grayscale8[index].value, grayscale_value);
     }
 }
 
@@ -483,29 +478,28 @@ test "Writing Rgb24 ASCII PPM format" {
     const width = expected_colors.len;
     const height = 1;
 
-    const source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
+    var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
     defer source_image.deinit();
 
-    try testing.expect(source_image.pixels != null);
+    try testing.expect(source_image.data == .image);
 
-    if (source_image.pixels) |pixels| {
-        try testing.expect(pixels == .rgb24);
-        try testing.expect(pixels.rgb24.len == width * height);
+    const pixels = source_image.data.image;
+    try testing.expect(pixels == .rgb24);
+    try testing.expect(pixels.rgb24.len == width * height);
 
-        // R, G, B
-        pixels.rgb24[0] = color.Rgb24.initRgb(255, 0, 0);
-        pixels.rgb24[1] = color.Rgb24.initRgb(0, 255, 0);
-        pixels.rgb24[2] = color.Rgb24.initRgb(0, 0, 255);
+    // R, G, B
+    pixels.rgb24[0] = color.Rgb24.initRgb(255, 0, 0);
+    pixels.rgb24[1] = color.Rgb24.initRgb(0, 255, 0);
+    pixels.rgb24[2] = color.Rgb24.initRgb(0, 0, 255);
 
-        // Black, white
-        pixels.rgb24[3] = color.Rgb24.initRgb(0, 0, 0);
-        pixels.rgb24[4] = color.Rgb24.initRgb(255, 255, 255);
+    // Black, white
+    pixels.rgb24[3] = color.Rgb24.initRgb(0, 0, 0);
+    pixels.rgb24[4] = color.Rgb24.initRgb(255, 255, 255);
 
-        // Cyan, Magenta, Yellow
-        pixels.rgb24[5] = color.Rgb24.initRgb(0, 255, 255);
-        pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
-        pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
-    }
+    // Cyan, Magenta, Yellow
+    pixels.rgb24[5] = color.Rgb24.initRgb(0, 255, 255);
+    pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
+    pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
 
     try source_image.writeToFilePath(image_file_name, Image.Format.ppm, Image.EncoderOptions{
         .ppm = .{ .binary = false },
@@ -515,20 +509,20 @@ test "Writing Rgb24 ASCII PPM format" {
         std.fs.cwd().deleteFile(image_file_name) catch unreachable;
     }
 
-    const read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
+    var read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
     defer read_image.deinit();
 
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.pixels != null);
+    try testing.expect(read_image.data == .image);
 
-    if (read_image.pixels) |read_image_pixels| {
-        try testing.expect(read_image_pixels == .rgb24);
+    const read_image_pixels = read_image.data.image;
 
-        for (expected_colors) |hex_color, index| {
-            try helpers.expectEq(read_image_pixels.rgb24[index].toU32Rgb(), hex_color);
-        }
+    try testing.expect(read_image_pixels == .rgb24);
+
+    for (expected_colors) |hex_color, index| {
+        try helpers.expectEq(read_image_pixels.rgb24[index].toU32Rgb(), hex_color);
     }
 }
 
@@ -539,29 +533,29 @@ test "Writing Rgb24 binary PPM format" {
     const width = expected_colors.len;
     const height = 1;
 
-    const source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
+    var source_image = try Image.create(helpers.zigimg_test_allocator, width, height, PixelFormat.rgb24);
     defer source_image.deinit();
 
-    try testing.expect(source_image.pixels != null);
+    try testing.expect(source_image.data == .image);
 
-    if (source_image.pixels) |pixels| {
-        try testing.expect(pixels == .rgb24);
-        try testing.expect(pixels.rgb24.len == width * height);
+    const pixels = source_image.data.image;
 
-        // R, G, B
-        pixels.rgb24[0] = color.Rgb24.initRgb(255, 0, 0);
-        pixels.rgb24[1] = color.Rgb24.initRgb(0, 255, 0);
-        pixels.rgb24[2] = color.Rgb24.initRgb(0, 0, 255);
+    try testing.expect(pixels == .rgb24);
+    try testing.expect(pixels.rgb24.len == width * height);
 
-        // Black, white
-        pixels.rgb24[3] = color.Rgb24.initRgb(0, 0, 0);
-        pixels.rgb24[4] = color.Rgb24.initRgb(255, 255, 255);
+    // R, G, B
+    pixels.rgb24[0] = color.Rgb24.initRgb(255, 0, 0);
+    pixels.rgb24[1] = color.Rgb24.initRgb(0, 255, 0);
+    pixels.rgb24[2] = color.Rgb24.initRgb(0, 0, 255);
 
-        // Cyan, Magenta, Yellow
-        pixels.rgb24[5] = color.Rgb24.initRgb(0, 255, 255);
-        pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
-        pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
-    }
+    // Black, white
+    pixels.rgb24[3] = color.Rgb24.initRgb(0, 0, 0);
+    pixels.rgb24[4] = color.Rgb24.initRgb(255, 255, 255);
+
+    // Cyan, Magenta, Yellow
+    pixels.rgb24[5] = color.Rgb24.initRgb(0, 255, 255);
+    pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
+    pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
 
     try source_image.writeToFilePath(image_file_name, Image.Format.ppm, Image.EncoderOptions{
         .ppm = .{ .binary = true },
@@ -571,19 +565,19 @@ test "Writing Rgb24 binary PPM format" {
         std.fs.cwd().deleteFile(image_file_name) catch unreachable;
     }
 
-    const read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
+    var read_image = try Image.fromFilePath(helpers.zigimg_test_allocator, image_file_name);
     defer read_image.deinit();
 
     try helpers.expectEq(read_image.width, width);
     try helpers.expectEq(read_image.height, height);
 
-    try testing.expect(read_image.pixels != null);
+    try testing.expect(read_image.data == .image);
 
-    if (read_image.pixels) |read_image_pixels| {
-        try testing.expect(read_image_pixels == .rgb24);
+    const read_image_pixels = read_image.data.image;
 
-        for (expected_colors) |hex_color, index| {
-            try helpers.expectEq(read_image_pixels.rgb24[index].toU32Rgb(), hex_color);
-        }
+    try testing.expect(read_image_pixels == .rgb24);
+
+    for (expected_colors) |hex_color, index| {
+        try helpers.expectEq(read_image_pixels.rgb24[index].toU32Rgb(), hex_color);
     }
 }

--- a/tests/formats/pcx_test.zig
+++ b/tests/formats/pcx_test.zig
@@ -15,43 +15,33 @@ test "PCX indexed1 (linear)" {
 
     var pcxFile = pcx.PCX{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pcxFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pcxFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pcxFile.width, 27);
     try helpers.expectEq(pcxFile.height, 27);
     try helpers.expectEq(try pcxFile.pixelFormat(), PixelFormat.indexed1);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels == .indexed1);
 
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .indexed1);
+    try helpers.expectEq(pixels.indexed1.indices[0], 0);
+    try helpers.expectEq(pixels.indexed1.indices[15], 1);
+    try helpers.expectEq(pixels.indexed1.indices[18], 1);
+    try helpers.expectEq(pixels.indexed1.indices[19], 1);
+    try helpers.expectEq(pixels.indexed1.indices[20], 1);
+    try helpers.expectEq(pixels.indexed1.indices[22 * 27 + 11], 1);
 
-        try helpers.expectEq(pixels.indexed1.indices[0], 0);
-        try helpers.expectEq(pixels.indexed1.indices[15], 1);
-        try helpers.expectEq(pixels.indexed1.indices[18], 1);
-        try helpers.expectEq(pixels.indexed1.indices[19], 1);
-        try helpers.expectEq(pixels.indexed1.indices[20], 1);
-        try helpers.expectEq(pixels.indexed1.indices[22 * 27 + 11], 1);
+    const palette0 = pixels.indexed1.palette[0];
 
-        const palette0 = pixels.indexed1.palette[0];
+    try helpers.expectEq(palette0.r, 102);
+    try helpers.expectEq(palette0.g, 90);
+    try helpers.expectEq(palette0.b, 155);
 
-        try helpers.expectEq(palette0.r, 102);
-        try helpers.expectEq(palette0.g, 90);
-        try helpers.expectEq(palette0.b, 155);
+    const palette1 = pixels.indexed1.palette[1];
 
-        const palette1 = pixels.indexed1.palette[1];
-
-        try helpers.expectEq(palette1.r, 115);
-        try helpers.expectEq(palette1.g, 137);
-        try helpers.expectEq(palette1.b, 106);
-    }
+    try helpers.expectEq(palette1.r, 115);
+    try helpers.expectEq(palette1.g, 137);
+    try helpers.expectEq(palette1.b, 106);
 }
 
 test "PCX indexed4 (linear)" {
@@ -62,44 +52,34 @@ test "PCX indexed4 (linear)" {
 
     var pcxFile = pcx.PCX{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pcxFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pcxFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pcxFile.width, 27);
     try helpers.expectEq(pcxFile.height, 27);
     try helpers.expectEq(try pcxFile.pixelFormat(), PixelFormat.indexed4);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels == .indexed4);
 
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .indexed4);
+    try helpers.expectEq(pixels.indexed4.indices[0], 1);
+    try helpers.expectEq(pixels.indexed4.indices[1], 9);
+    try helpers.expectEq(pixels.indexed4.indices[2], 0);
+    try helpers.expectEq(pixels.indexed4.indices[3], 0);
+    try helpers.expectEq(pixels.indexed4.indices[4], 4);
+    try helpers.expectEq(pixels.indexed4.indices[14 * 27 + 9], 6);
+    try helpers.expectEq(pixels.indexed4.indices[25 * 27 + 25], 7);
 
-        try helpers.expectEq(pixels.indexed4.indices[0], 1);
-        try helpers.expectEq(pixels.indexed4.indices[1], 9);
-        try helpers.expectEq(pixels.indexed4.indices[2], 0);
-        try helpers.expectEq(pixels.indexed4.indices[3], 0);
-        try helpers.expectEq(pixels.indexed4.indices[4], 4);
-        try helpers.expectEq(pixels.indexed4.indices[14 * 27 + 9], 6);
-        try helpers.expectEq(pixels.indexed4.indices[25 * 27 + 25], 7);
+    const palette0 = pixels.indexed4.palette[0];
 
-        const palette0 = pixels.indexed4.palette[0];
+    try helpers.expectEq(palette0.r, 0x5e);
+    try helpers.expectEq(palette0.g, 0x37);
+    try helpers.expectEq(palette0.b, 0x97);
 
-        try helpers.expectEq(palette0.r, 0x5e);
-        try helpers.expectEq(palette0.g, 0x37);
-        try helpers.expectEq(palette0.b, 0x97);
+    const palette15 = pixels.indexed4.palette[15];
 
-        const palette15 = pixels.indexed4.palette[15];
-
-        try helpers.expectEq(palette15.r, 0x60);
-        try helpers.expectEq(palette15.g, 0xb5);
-        try helpers.expectEq(palette15.b, 0x68);
-    }
+    try helpers.expectEq(palette15.r, 0x60);
+    try helpers.expectEq(palette15.g, 0xb5);
+    try helpers.expectEq(palette15.b, 0x68);
 }
 
 test "PCX indexed8 (linear)" {
@@ -110,46 +90,36 @@ test "PCX indexed8 (linear)" {
 
     var pcxFile = pcx.PCX{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pcxFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pcxFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pcxFile.width, 27);
     try helpers.expectEq(pcxFile.height, 27);
     try helpers.expectEq(try pcxFile.pixelFormat(), PixelFormat.indexed8);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels == .indexed8);
 
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .indexed8);
+    try helpers.expectEq(pixels.indexed8.indices[0], 37);
+    try helpers.expectEq(pixels.indexed8.indices[3 * 27 + 15], 60);
+    try helpers.expectEq(pixels.indexed8.indices[26 * 27 + 26], 254);
 
-        try helpers.expectEq(pixels.indexed8.indices[0], 37);
-        try helpers.expectEq(pixels.indexed8.indices[3 * 27 + 15], 60);
-        try helpers.expectEq(pixels.indexed8.indices[26 * 27 + 26], 254);
+    const palette0 = pixels.indexed8.palette[0];
 
-        const palette0 = pixels.indexed8.palette[0];
+    try helpers.expectEq(palette0.r, 0x46);
+    try helpers.expectEq(palette0.g, 0x1c);
+    try helpers.expectEq(palette0.b, 0x71);
 
-        try helpers.expectEq(palette0.r, 0x46);
-        try helpers.expectEq(palette0.g, 0x1c);
-        try helpers.expectEq(palette0.b, 0x71);
+    const palette15 = pixels.indexed8.palette[15];
 
-        const palette15 = pixels.indexed8.palette[15];
+    try helpers.expectEq(palette15.r, 0x41);
+    try helpers.expectEq(palette15.g, 0x49);
+    try helpers.expectEq(palette15.b, 0x30);
 
-        try helpers.expectEq(palette15.r, 0x41);
-        try helpers.expectEq(palette15.g, 0x49);
-        try helpers.expectEq(palette15.b, 0x30);
+    const palette219 = pixels.indexed8.palette[219];
 
-        const palette219 = pixels.indexed8.palette[219];
-
-        try helpers.expectEq(palette219.r, 0x61);
-        try helpers.expectEq(palette219.g, 0x8e);
-        try helpers.expectEq(palette219.b, 0xc3);
-    }
+    try helpers.expectEq(palette219.r, 0x61);
+    try helpers.expectEq(palette219.g, 0x8e);
+    try helpers.expectEq(palette219.b, 0xc3);
 }
 
 test "PCX indexed24 (planar)" {
@@ -160,14 +130,8 @@ test "PCX indexed24 (planar)" {
 
     var pcxFile = pcx.PCX{};
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    try pcxFile.read(helpers.zigimg_test_allocator, &stream_source, &pixelsOpt);
-
-    defer {
-        if (pixelsOpt) |pixels| {
-            pixels.deinit(helpers.zigimg_test_allocator);
-        }
-    }
+    const pixels = try pcxFile.read(helpers.zigimg_test_allocator, &stream_source);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
 
     try helpers.expectEq(pcxFile.header.planes, 3);
     try helpers.expectEq(pcxFile.header.bpp, 8);
@@ -176,29 +140,25 @@ test "PCX indexed24 (planar)" {
     try helpers.expectEq(pcxFile.height, 27);
     try helpers.expectEq(try pcxFile.pixelFormat(), PixelFormat.rgb24);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels == .rgb24);
 
-    if (pixelsOpt) |pixels| {
-        try testing.expect(pixels == .rgb24);
+    try helpers.expectEq(pixels.rgb24[0].r, 0x34);
+    try helpers.expectEq(pixels.rgb24[0].g, 0x53);
+    try helpers.expectEq(pixels.rgb24[0].b, 0x9f);
 
-        try helpers.expectEq(pixels.rgb24[0].r, 0x34);
-        try helpers.expectEq(pixels.rgb24[0].g, 0x53);
-        try helpers.expectEq(pixels.rgb24[0].b, 0x9f);
+    try helpers.expectEq(pixels.rgb24[1].r, 0x32);
+    try helpers.expectEq(pixels.rgb24[1].g, 0x5b);
+    try helpers.expectEq(pixels.rgb24[1].b, 0x96);
 
-        try helpers.expectEq(pixels.rgb24[1].r, 0x32);
-        try helpers.expectEq(pixels.rgb24[1].g, 0x5b);
-        try helpers.expectEq(pixels.rgb24[1].b, 0x96);
+    try helpers.expectEq(pixels.rgb24[26].r, 0xa8);
+    try helpers.expectEq(pixels.rgb24[26].g, 0x5a);
+    try helpers.expectEq(pixels.rgb24[26].b, 0x78);
 
-        try helpers.expectEq(pixels.rgb24[26].r, 0xa8);
-        try helpers.expectEq(pixels.rgb24[26].g, 0x5a);
-        try helpers.expectEq(pixels.rgb24[26].b, 0x78);
+    try helpers.expectEq(pixels.rgb24[27].r, 0x2e);
+    try helpers.expectEq(pixels.rgb24[27].g, 0x54);
+    try helpers.expectEq(pixels.rgb24[27].b, 0x99);
 
-        try helpers.expectEq(pixels.rgb24[27].r, 0x2e);
-        try helpers.expectEq(pixels.rgb24[27].g, 0x54);
-        try helpers.expectEq(pixels.rgb24[27].b, 0x99);
-
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].r, 0x88);
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].g, 0xb7);
-        try helpers.expectEq(pixels.rgb24[26 * 27 + 26].b, 0x55);
-    }
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].r, 0x88);
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].g, 0xb7);
+    try helpers.expectEq(pixels.rgb24[26 * 27 + 26].b, 0x55);
 }

--- a/tests/formats/qoi_test.zig
+++ b/tests/formats/qoi_test.zig
@@ -64,12 +64,12 @@ test "Read zero.qoi file" {
 }
 
 test "Write qoi file" {
-    const source_image = try Image.create(helpers.zigimg_test_allocator, 512, 512, PixelFormat.rgba32);
+    var source_image = try Image.create(helpers.zigimg_test_allocator, 512, 512, PixelFormat.rgba32);
     defer source_image.deinit();
 
     var buffer: [1025 * 1024]u8 = undefined;
     var zero_raw_pixels = try helpers.testReadFile(zero_raw_file, buffer[0..]);
-    std.mem.copy(u8, std.mem.sliceAsBytes(source_image.pixels.?.rgba32), std.mem.bytesAsSlice(u8, zero_raw_pixels));
+    std.mem.copy(u8, std.mem.sliceAsBytes(source_image.data.image.rgba32), std.mem.bytesAsSlice(u8, zero_raw_pixels));
 
     var image_buffer: [100 * 1024]u8 = undefined;
     var zero_qoi = try helpers.testReadFile(zero_qoi_file, buffer[0..]);

--- a/tests/formats/qoi_test.zig
+++ b/tests/formats/qoi_test.zig
@@ -58,7 +58,7 @@ test "Write qoi file" {
     var image_buffer: [100 * 1024]u8 = undefined;
     var zero_qoi = try helpers.testReadFile(zero_qoi_file, buffer[0..]);
 
-    const result_image = try source_image.writeToMemory(image_buffer[0..], .qoi, Image.EncoderOptions.None);
+    const result_image = try source_image.writeToMemory(image_buffer[0..], Image.EncoderOptions{ .qoi = .{} });
 
     try testing.expectEqualSlices(u8, zero_qoi[0..], result_image);
 }

--- a/tests/formats/qoi_test.zig
+++ b/tests/formats/qoi_test.zig
@@ -53,7 +53,7 @@ test "Write qoi file" {
 
     var buffer: [1025 * 1024]u8 = undefined;
     var zero_raw_pixels = try helpers.testReadFile(zero_raw_file, buffer[0..]);
-    std.mem.copy(u8, std.mem.sliceAsBytes(source_image.data.image.rgba32), std.mem.bytesAsSlice(u8, zero_raw_pixels));
+    std.mem.copy(u8, std.mem.sliceAsBytes(source_image.pixels.rgba32), std.mem.bytesAsSlice(u8, zero_raw_pixels));
 
     var image_buffer: [100 * 1024]u8 = undefined;
     var zero_qoi = try helpers.testReadFile(zero_qoi_file, buffer[0..]);

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -8,173 +8,173 @@ const helpers = @import("helpers.zig");
 const ImageError = Image.Error;
 
 test "Create Image indexed1" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed1);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed1);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed1);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .indexed1);
-        try testing.expect(pixels.indexed1.palette.len == 2);
-        try testing.expect(pixels.indexed1.indices.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .indexed1);
+    try testing.expect(pixels.indexed1.palette.len == 2);
+    try testing.expect(pixels.indexed1.indices.len == 24 * 32);
 }
 
 test "Create Image indexed2" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed2);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed2);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed2);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .indexed2);
-        try testing.expect(pixels.indexed2.palette.len == 4);
-        try testing.expect(pixels.indexed2.indices.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .indexed2);
+    try testing.expect(pixels.indexed2.palette.len == 4);
+    try testing.expect(pixels.indexed2.indices.len == 24 * 32);
 }
 
 test "Create Image indexed4" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed4);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed4);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed4);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .indexed4);
-        try testing.expect(pixels.indexed4.palette.len == 16);
-        try testing.expect(pixels.indexed4.indices.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .indexed4);
+    try testing.expect(pixels.indexed4.palette.len == 16);
+    try testing.expect(pixels.indexed4.indices.len == 24 * 32);
 }
 
 test "Create Image indexed8" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed8);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed8);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed8);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .indexed8);
-        try testing.expect(pixels.indexed8.palette.len == 256);
-        try testing.expect(pixels.indexed8.indices.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .indexed8);
+    try testing.expect(pixels.indexed8.palette.len == 256);
+    try testing.expect(pixels.indexed8.indices.len == 24 * 32);
 }
 
 test "Create Image indexed16" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed16);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.indexed16);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed16);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .indexed16);
-        try testing.expect(pixels.indexed16.palette.len == 65536);
-        try testing.expect(pixels.indexed16.indices.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .indexed16);
+    try testing.expect(pixels.indexed16.palette.len == 65536);
+    try testing.expect(pixels.indexed16.indices.len == 24 * 32);
 }
 
 test "Create Image Rgb24" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb24);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb24);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgb24);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .rgb24);
-        try testing.expect(pixels.rgb24.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .rgb24);
+    try testing.expect(pixels.rgb24.len == 24 * 32);
 }
 
 test "Create Image Rgba32" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgba32);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgba32);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgba32);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .rgba32);
-        try testing.expect(pixels.rgba32.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .rgba32);
+    try testing.expect(pixels.rgba32.len == 24 * 32);
 }
 
 test "Create Image Rgb565" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb565);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb565);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgb565);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .rgb565);
-        try testing.expect(pixels.rgb565.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .rgb565);
+    try testing.expect(pixels.rgb565.len == 24 * 32);
 }
 
 test "Create Image Rgb555" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb555);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.rgb555);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgb555);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .rgb555);
-        try testing.expect(pixels.rgb555.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .rgb555);
+    try testing.expect(pixels.rgb555.len == 24 * 32);
 }
 
 test "Create Image Bgra32" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.bgra32);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.bgra32);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.bgra32);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .bgra32);
-        try testing.expect(pixels.bgra32.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .bgra32);
+    try testing.expect(pixels.bgra32.len == 24 * 32);
 }
 
 test "Create Image float32" {
-    const test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.float32);
+    var test_image = try Image.create(helpers.zigimg_test_allocator, 24, 32, PixelFormat.float32);
     defer test_image.deinit();
 
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.float32);
-    try testing.expect(test_image.pixels != null);
+    try testing.expect(test_image.data == .image);
 
-    if (test_image.pixels) |pixels| {
-        try testing.expect(pixels == .float32);
-        try testing.expect(pixels.float32.len == 24 * 32);
-    }
+    const pixels = test_image.data.image;
+
+    try testing.expect(pixels == .float32);
+    try testing.expect(pixels.float32.len == 24 * 32);
 }
 
 test "Should detect BMP properly" {
@@ -184,7 +184,7 @@ test "Should detect BMP properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -193,7 +193,7 @@ test "Should detect Memory BMP properly" {
     var MemoryRGBABitmap: [200 * 1024]u8 = undefined;
     var buffer = try helpers.testReadFile(helpers.fixtures_path ++ "bmp/windows_rgba_v5.bmp", MemoryRGBABitmap[0..]);
 
-    const test_image = try Image.fromMemory(helpers.zigimg_test_allocator, buffer);
+    var test_image = try Image.fromMemory(helpers.zigimg_test_allocator, buffer);
     defer test_image.deinit();
 }
 
@@ -206,7 +206,7 @@ test "Should detect PCX properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -218,7 +218,7 @@ test "Should detect PBM properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -232,7 +232,7 @@ test "Should detect PGM properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -244,7 +244,7 @@ test "Should detect PPM properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -256,7 +256,7 @@ test "Should detect PNG properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -274,7 +274,7 @@ test "Should detect TGA properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -283,7 +283,7 @@ test "Should detect QOI properly" {
     const image_tests = &[_][]const u8{helpers.fixtures_path ++ "qoi/zero.qoi"};
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -295,7 +295,7 @@ test "Should detect JPEG properly" {
     };
 
     for (image_tests) |image_path| {
-        const test_image = try helpers.testImageFromFile(image_path);
+        var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();
     }
 }
@@ -312,7 +312,9 @@ test "Should read a 24-bit bitmap" {
     try helpers.expectEq(test_image.width, 8);
     try helpers.expectEq(test_image.height, 1);
 
-    if (test_image.pixels) |pixels| {
+    if (test_image.data == .image) {
+        const pixels = test_image.data.image;
+
         try testing.expect(pixels == .bgr24);
 
         const red = pixels.bgr24[0];

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -14,9 +14,8 @@ test "Create Image indexed1" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed1);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .indexed1);
     try testing.expect(pixels.indexed1.palette.len == 2);
@@ -30,9 +29,8 @@ test "Create Image indexed2" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed2);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .indexed2);
     try testing.expect(pixels.indexed2.palette.len == 4);
@@ -46,9 +44,8 @@ test "Create Image indexed4" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed4);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .indexed4);
     try testing.expect(pixels.indexed4.palette.len == 16);
@@ -62,9 +59,8 @@ test "Create Image indexed8" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed8);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .indexed8);
     try testing.expect(pixels.indexed8.palette.len == 256);
@@ -78,9 +74,8 @@ test "Create Image indexed16" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.indexed16);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .indexed16);
     try testing.expect(pixels.indexed16.palette.len == 65536);
@@ -94,9 +89,8 @@ test "Create Image Rgb24" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgb24);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .rgb24);
     try testing.expect(pixels.rgb24.len == 24 * 32);
@@ -109,9 +103,8 @@ test "Create Image Rgba32" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgba32);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .rgba32);
     try testing.expect(pixels.rgba32.len == 24 * 32);
@@ -124,9 +117,8 @@ test "Create Image Rgb565" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgb565);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .rgb565);
     try testing.expect(pixels.rgb565.len == 24 * 32);
@@ -139,9 +131,8 @@ test "Create Image Rgb555" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.rgb555);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .rgb555);
     try testing.expect(pixels.rgb555.len == 24 * 32);
@@ -154,9 +145,8 @@ test "Create Image Bgra32" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.bgra32);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .bgra32);
     try testing.expect(pixels.bgra32.len == 24 * 32);
@@ -169,9 +159,8 @@ test "Create Image float32" {
     try helpers.expectEq(test_image.width, 24);
     try helpers.expectEq(test_image.height, 32);
     try helpers.expectEq(test_image.pixelFormat(), PixelFormat.float32);
-    try testing.expect(test_image.data == .image);
 
-    const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
     try testing.expect(pixels == .float32);
     try testing.expect(pixels.float32.len == 24 * 32);
@@ -312,51 +301,49 @@ test "Should read a 24-bit bitmap" {
     try helpers.expectEq(test_image.width, 8);
     try helpers.expectEq(test_image.height, 1);
 
-    if (test_image.data == .image) {
-        const pixels = test_image.data.image;
+    const pixels = test_image.pixels;
 
-        try testing.expect(pixels == .bgr24);
+    try testing.expect(pixels == .bgr24);
 
-        const red = pixels.bgr24[0];
-        try helpers.expectEq(red.r, 0xFF);
-        try helpers.expectEq(red.g, 0x00);
-        try helpers.expectEq(red.b, 0x00);
+    const red = pixels.bgr24[0];
+    try helpers.expectEq(red.r, 0xFF);
+    try helpers.expectEq(red.g, 0x00);
+    try helpers.expectEq(red.b, 0x00);
 
-        const green = pixels.bgr24[1];
-        try helpers.expectEq(green.r, 0x00);
-        try helpers.expectEq(green.g, 0xFF);
-        try helpers.expectEq(green.b, 0x00);
+    const green = pixels.bgr24[1];
+    try helpers.expectEq(green.r, 0x00);
+    try helpers.expectEq(green.g, 0xFF);
+    try helpers.expectEq(green.b, 0x00);
 
-        const blue = pixels.bgr24[2];
-        try helpers.expectEq(blue.r, 0x00);
-        try helpers.expectEq(blue.g, 0x00);
-        try helpers.expectEq(blue.b, 0xFF);
+    const blue = pixels.bgr24[2];
+    try helpers.expectEq(blue.r, 0x00);
+    try helpers.expectEq(blue.g, 0x00);
+    try helpers.expectEq(blue.b, 0xFF);
 
-        const cyan = pixels.bgr24[3];
-        try helpers.expectEq(cyan.r, 0x00);
-        try helpers.expectEq(cyan.g, 0xFF);
-        try helpers.expectEq(cyan.b, 0xFF);
+    const cyan = pixels.bgr24[3];
+    try helpers.expectEq(cyan.r, 0x00);
+    try helpers.expectEq(cyan.g, 0xFF);
+    try helpers.expectEq(cyan.b, 0xFF);
 
-        const magenta = pixels.bgr24[4];
-        try helpers.expectEq(magenta.r, 0xFF);
-        try helpers.expectEq(magenta.g, 0x00);
-        try helpers.expectEq(magenta.b, 0xFF);
+    const magenta = pixels.bgr24[4];
+    try helpers.expectEq(magenta.r, 0xFF);
+    try helpers.expectEq(magenta.g, 0x00);
+    try helpers.expectEq(magenta.b, 0xFF);
 
-        const yellow = pixels.bgr24[5];
-        try helpers.expectEq(yellow.r, 0xFF);
-        try helpers.expectEq(yellow.g, 0xFF);
-        try helpers.expectEq(yellow.b, 0x00);
+    const yellow = pixels.bgr24[5];
+    try helpers.expectEq(yellow.r, 0xFF);
+    try helpers.expectEq(yellow.g, 0xFF);
+    try helpers.expectEq(yellow.b, 0x00);
 
-        const black = pixels.bgr24[6];
-        try helpers.expectEq(black.r, 0x00);
-        try helpers.expectEq(black.g, 0x00);
-        try helpers.expectEq(black.b, 0x00);
+    const black = pixels.bgr24[6];
+    try helpers.expectEq(black.r, 0x00);
+    try helpers.expectEq(black.g, 0x00);
+    try helpers.expectEq(black.b, 0x00);
 
-        const white = pixels.bgr24[7];
-        try helpers.expectEq(white.r, 0xFF);
-        try helpers.expectEq(white.g, 0xFF);
-        try helpers.expectEq(white.b, 0xFF);
-    }
+    const white = pixels.bgr24[7];
+    try helpers.expectEq(white.r, 0xFF);
+    try helpers.expectEq(white.g, 0xFF);
+    try helpers.expectEq(white.b, 0xFF);
 }
 
 test "Test Colorf32 iterator" {


### PR DESCRIPTION
As discusted in the gist: https://gist.github.com/mlarouche/a919a14cb12b01392da0338acd61b997, I needed to have support for animation data in `Image`. With your feedback and from the community I decided to opt for Option 2. 

At the same time, I refactored all format (expect JPEG) `read()` function to return `color.PixelStorage` directly like your PNG code. 

I decided to submit this separately from the GIF read support branch to pay the interface change now and not wait until I've done with GIF read support.