### PR TITLE
workaround dependency loop with latest Zig version

### DIFF
--- a/src/color.zig
+++ b/src/color.zig
@@ -127,15 +127,16 @@ fn isAll8BitColor(comptime red_type: type, comptime green_type: type, comptime b
     return red_type == u8 and green_type == u8 and blue_type == u8 and (alpha_type == u8 or alpha_type == void);
 }
 
-fn RgbMethods(comptime Self: type) type {
+fn RgbMethods(
+    comptime Self: type,
+    comptime RedT: type,
+    comptime GreenT: type,
+    comptime BlueT: type,
+    comptime AlphaT: type,
+) type {
     const has_alpha_type = @hasField(Self, "a");
 
     return struct {
-        const RedT = std.meta.fieldInfo(Self, .r).type;
-        const GreenT = std.meta.fieldInfo(Self, .g).type;
-        const BlueT = std.meta.fieldInfo(Self, .b).type;
-        const AlphaT = if (has_alpha_type) std.meta.fieldInfo(Self, .a).type else void;
-
         pub fn initRgb(r: RedT, g: GreenT, b: BlueT) Self {
             return Self{
                 .r = r,
@@ -342,7 +343,7 @@ fn RgbColor(comptime T: type) type {
         g: T align(1),
         b: T align(1),
 
-        pub usingnamespace RgbMethods(@This());
+        pub usingnamespace RgbMethods(@This(), T, T, T, void);
     };
 }
 
@@ -355,7 +356,7 @@ pub const Rgb555 = packed struct {
     g: u5,
     b: u5,
 
-    pub usingnamespace RgbMethods(@This());
+    pub usingnamespace RgbMethods(@This(), u5, u5, u5, void);
 };
 
 // Rgb565
@@ -367,7 +368,7 @@ pub const Rgb565 = packed struct {
     g: u6,
     b: u5,
 
-    pub usingnamespace RgbMethods(@This());
+    pub usingnamespace RgbMethods(@This(), u5, u6, u5, void);
 };
 
 fn RgbaColor(comptime T: type) type {
@@ -377,7 +378,7 @@ fn RgbaColor(comptime T: type) type {
         b: T align(1),
         a: T align(1) = math.maxInt(T),
 
-        pub usingnamespace RgbMethods(@This());
+        pub usingnamespace RgbMethods(@This(), T, T, T, T);
         pub usingnamespace RgbaMethods(@This());
     };
 }
@@ -412,7 +413,7 @@ fn BgrColor(comptime T: type) type {
         g: T align(1),
         r: T align(1),
 
-        pub usingnamespace RgbMethods(@This());
+        pub usingnamespace RgbMethods(@This(), T, T, T, void);
     };
 }
 
@@ -423,7 +424,7 @@ fn BgraColor(comptime T: type) type {
         r: T align(1),
         a: T = math.maxInt(T),
 
-        pub usingnamespace RgbMethods(@This());
+        pub usingnamespace RgbMethods(@This(), T, T, T, T);
         pub usingnamespace RgbaMethods(@This());
     };
 }


### PR DESCRIPTION
This feels like maybe a bug/regression in Zig, not really an issue in zigimg, but I don't know that for sure. To workaround the issue I also tried elevating the `std.meta.Field` calls outside of the `return struct {}` block inside of `RgbMethods`, but that led to a segfault:

```
slimsag@hexops-ci zigimg % zig build test
error: zigimgtest...
error: The following command terminated unexpectedly:
/Users/slimsag/zig-macos-aarch64-0.11.0-dev.1314+9856bea34/zig test /Users/slimsag/Desktop/hexops/mach-examples/libs/zigimg/zigimg.zig --cache-dir /Users/slimsag/Desktop/hexops/mach-examples/libs/zigimg/zig-cache --global-cache-dir /Users/slimsag/.cache/zig --name zigimgtest --test-no-exec --enable-cache 
error: the following build command failed with exit code 11:
/Users/slimsag/Desktop/hexops/mach-examples/libs/zigimg/zig-cache/o/329ab1cbcf90d5f4a6bb5213bcea8b59/build /Users/slimsag/zig-macos-aarch64-0.11.0-dev.1314+9856bea34/zig /Users/slimsag/Desktop/hexops/mach-examples/libs/zigimg /Users/slimsag/Desktop/hexops/mach-examples/libs/zigimg/zig-cache /Users/slimsag/.cache/zig test
```

Passing the types in explicitly does workaround the issue, though. Feel free to close this if you prefer to wait for a different solution, I just figured it was worth sending.

Helps hexops/mach#677
Helps zigimg/zigimg#101

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>