### PR TITLE
Fix issues encountered with zig 0.11.0/wasm32

### DIFF
--- a/src/formats/qoi.zig
+++ b/src/formats/qoi.zig
@@ -126,7 +126,7 @@ pub const QOI = struct {
     }
 
     pub fn formatDetect(stream: *Image.Stream) ImageReadError!bool {
-        var magic_buffer: [std.mem.len(Header.correct_magic)]u8 = undefined;
+        var magic_buffer: [Header.correct_magic.len]u8 = undefined;
 
         _ = try stream.read(magic_buffer[0..]);
 
@@ -186,7 +186,7 @@ pub const QOI = struct {
     }
 
     pub fn read(self: *Self, allocator: Allocator, stream: *Image.Stream) ImageReadError!color.PixelStorage {
-        var magic_buffer: [std.mem.len(Header.correct_magic)]u8 = undefined;
+        var magic_buffer: [Header.correct_magic.len]u8 = undefined;
 
         const reader = stream.reader();
 


### PR DESCRIPTION
Fixes for two issues encountered with zig 0.11.0-dev.1507+6f13a725a building for wasm32.

Saturating arithmetic is broken in llvm (https://github.com/llvm/llvm-project/issues/58557), add workaround

Use .len to find length of fixed sized array, as zig 0.11.0 complains on use of std.mem.len()