### PR TITLE
Update build.zig for parallel build change

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,6 @@ pub fn build(b: *Build) void {
     const zigimg_build_test = b.addTest(.{
         .name = "zigimgtest",
         .root_source_file = .{ .path = "zigimg.zig" },
-        .kind = .test_exe,
         .target = target,
         .optimize = optimize,
     });


### PR DESCRIPTION
The `.kind` field was removed from `std.Build.TestOptions` as part of the recent build API changes.