### PR TITLE
Use std.Build.installArtifact

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -14,12 +14,11 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
-    zigimg_build_test.install();
+    b.installArtifact(zigimg_build_test);
 
-    const run_test_cmd = zigimg_build_test.run();
+    const run_test_cmd = b.addRunArtifact(zigimg_build_test);
     // Force running of the test command even if you don't have changes
     run_test_cmd.has_side_effects = true;
-    run_test_cmd.step.dependOn(b.getInstallStep());
 
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_test_cmd.step);


### PR DESCRIPTION
I removed the `run_test_cmd.step.dependOn(b.getInstallStep())` line, I wasn't sure if it was necessary. It doesn't seem to rely on anything else being installed, and the run step should work fine without it.