### PR TITLE
Update for zig.0.11.0-dev.3132

### DIFF
--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -428,7 +428,8 @@ pub const TGA = struct {
                 // Read color map
                 switch (self.header.color_map_spec.bit_depth) {
                     15, 16 => {
-                        try self.readColorMap16(pixels.indexed8, (TargaStream{ .image = reader }).reader());
+                        var temp_targa_stream = TargaStream{ .image = reader };
+                        try self.readColorMap16(pixels.indexed8, temp_targa_stream.reader());
                     },
                     else => {
                         return ImageError.Unsupported;


### PR DESCRIPTION
This commit fixes a compile error generated by Zig 0.11.0-dev.3132

Previously we were calling the reader function (Which takes a mutable pointer) on a temporary TargaStream that was constructed in-place as an argument.

This caused the compile error as all temporary variables are constant. Defining it as an actual variable allows it to be mutable