### PR TITLE
Use snake-case enum

### DIFF
--- a/tests/formats/png_test.zig
+++ b/tests/formats/png_test.zig
@@ -116,7 +116,7 @@ pub fn testWithDir(directory: []const u8, testMd5Sig: bool) !void {
         var it = idir.iterate();
         if (testMd5Sig) std.debug.print("\n", .{});
         while (try it.next()) |entry| {
-            if (entry.kind != .File or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) continue;
+            if (entry.kind != .file or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) continue;
 
             if (testMd5Sig) std.debug.print("Testing file {s} ... ", .{entry.name});
             var tst_file = try idir.dir.openFile(entry.name, .{ .mode = .read_only });
@@ -198,7 +198,7 @@ test "InfoProcessor on Png Test suite" {
         var info_stream = std.io.StreamSource{ .buffer = std.io.fixedBufferStream(info_buffer[0..]) };
 
         while (try it.next()) |entry| {
-            if (entry.kind != .File or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) {
+            if (entry.kind != .file or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) {
                 continue;
             }
 


### PR DESCRIPTION
Hello,

I recently attempted to run tests on my local environment and encountered some issues, which I believe are linked to a recent modification (reference: [PR#15803](https://github.com/ziglang/zig/pull/15803)). I'm working with Zig compiler version 0.11.0-dev.3316+ec58b475b.

Here are the error details I encountered when running `$ zig build test`

```
$ zig build test
zig test zigimgtest Debug native: error: the following command failed with 2 compilation errors:
/snap/zig/7562/zig test /home/argon/workspace/zigimg/zigimg.zig --cache-dir /home/argon/workspace/zigimg/zig-cache --global-cache-dir /home/argon/.cache/zig --name zigimgtest --listen=- 
Build Summary: 0/5 steps succeeded; 1 failed (disable with -fno-summary)
test transitive failure
└─ run zigimgtest transitive failure
   ├─ zig test zigimgtest Debug native 2 errors
   └─ install transitive failure
      └─ install zigimgtest transitive failure
         └─ zig test zigimgtest Debug native (reused)
tests/formats/png_test.zig:119:32: error: no field named 'File' in enum 'fs.file.File.Kind'
            if (entry.kind != .File or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) continue;
                              ~^~~~
/snap/zig/7562/lib/std/fs/file.zig:37:22: note: enum declared here
    pub const Kind = enum {
                     ^~~~
referenced by:
    test.PNG Official Test Suite: tests/formats/png_test.zig:108:9
    remaining reference traces hidden; use '-freference-trace' to see all reference traces

tests/formats/png_test.zig:201:32: error: no field named 'File' in enum 'fs.file.File.Kind'
            if (entry.kind != .File or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) {
                              ~^~~~
/snap/zig/7562/lib/std/fs/file.zig:37:22: note: enum declared here
    pub const Kind = enum {
```

I have created a PR to address these issues. However, as I am still acquainting myself with the Zig language and the zigimg project, I'd appreciate any feedback or direction on whether my approach aligns with the project guidelines. If it's not suitable, feel free to reject the PR, and any pointers for future contributions would be highly appreciated.

Thank you for your time and consideration.