### PR TITLE
port to latest zig

### DIFF
--- a/src/formats/png/chunk_writer.zig
+++ b/src/formats/png/chunk_writer.zig
@@ -44,7 +44,7 @@ pub fn ChunkWriter(comptime buffer_size: usize, comptime WriterType: type) type 
                     return self.unbuffered_writer.write(bytes);
             }
 
-            mem.copy(u8, self.buf[self.end..], bytes);
+            @memcpy(self.buf[self.end..], bytes);
             self.end += bytes.len;
             return bytes.len;
         }

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -72,7 +72,7 @@ const IDatChunksReader = struct {
     }
 
     fn fillBuffer(self: *Self, to_read: usize) Image.ReadError!usize {
-        std.mem.copy(u8, self.buffer[0..self.data.len], self.data);
+        @memcpy(self.buffer[0..self.data.len], self.data);
         var new_start = self.data.len;
         var max = self.buffer.len;
         if (max > self.remaining_chunk_length) {
@@ -96,7 +96,7 @@ const IDatChunksReader = struct {
         if (to_read > self.data.len) {
             to_read = try self.fillBuffer(to_read);
         }
-        std.mem.copy(u8, new_dest[0..to_read], self.data[0..to_read]);
+        @memcpy(new_dest[0..to_read], self.data[0..to_read]);
         self.remaining_chunk_length -= @intCast(u32, to_read);
         self.data = self.data[to_read..];
 

--- a/src/formats/qoi.zig
+++ b/src/formats/qoi.zig
@@ -90,7 +90,7 @@ pub const Header = extern struct {
 
     fn encode(header: Header) [size]u8 {
         var result: [size]u8 = undefined;
-        std.mem.copy(u8, result[0..4], &correct_magic);
+        @memcpy(result[0..4], &correct_magic);
         std.mem.writeIntBig(u32, result[4..8], header.width);
         std.mem.writeIntBig(u32, result[8..12], header.height);
         result[12] = @enumToInt(header.format);

--- a/tests/formats/png_test.zig
+++ b/tests/formats/png_test.zig
@@ -116,7 +116,7 @@ pub fn testWithDir(directory: []const u8, testMd5Sig: bool) !void {
         var it = idir.iterate();
         if (testMd5Sig) std.debug.print("\n", .{});
         while (try it.next()) |entry| {
-            if (entry.kind != .File or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) continue;
+            if (entry.kind != .file or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) continue;
 
             if (testMd5Sig) std.debug.print("Testing file {s} ... ", .{entry.name});
             var tst_file = try idir.dir.openFile(entry.name, .{ .mode = .read_only });
@@ -148,8 +148,8 @@ pub fn testWithDir(directory: []const u8, testMd5Sig: bool) !void {
 
             const len = entry.name.len;
             var tst_data_name: [50]u8 = undefined;
-            std.mem.copy(u8, tst_data_name[0 .. len - 3], entry.name[0 .. len - 3]);
-            std.mem.copy(u8, tst_data_name[len - 3 .. len], "tsd");
+            @memcpy(tst_data_name[0 .. len - 3], entry.name[0 .. len - 3]);
+            @memcpy(tst_data_name[len - 3 .. len], "tsd");
 
             // Read test data and check with it
             if (idir.dir.openFile(tst_data_name[0..len], .{ .mode = .read_only })) |tdata| {
@@ -198,7 +198,7 @@ test "InfoProcessor on Png Test suite" {
         var info_stream = std.io.StreamSource{ .buffer = std.io.fixedBufferStream(info_buffer[0..]) };
 
         while (try it.next()) |entry| {
-            if (entry.kind != .File or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) {
+            if (entry.kind != .file or !std.mem.eql(u8, std.fs.path.extension(entry.name), ".png")) {
                 continue;
             }
 
@@ -220,8 +220,8 @@ test "InfoProcessor on Png Test suite" {
 
             const len = entry.name.len + 1;
             var tst_data_name: [50]u8 = undefined;
-            std.mem.copy(u8, tst_data_name[0 .. len - 4], entry.name[0 .. len - 4]);
-            std.mem.copy(u8, tst_data_name[len - 4 .. len], "info");
+            @memcpy(tst_data_name[0 .. len - 4], entry.name[0 .. len - 4]);
+            @memcpy(tst_data_name[len - 4 .. len], "info");
 
             // Read test data and check with it
             if (idir.dir.openFile(tst_data_name[0..len], .{ .mode = .read_only })) |tdata| {

--- a/tests/formats/qoi_test.zig
+++ b/tests/formats/qoi_test.zig
@@ -53,7 +53,7 @@ test "Write qoi file" {
 
     var buffer: [1025 * 1024]u8 = undefined;
     var zero_raw_pixels = try helpers.testReadFile(zero_raw_file, buffer[0..]);
-    std.mem.copy(u8, std.mem.sliceAsBytes(source_image.pixels.rgba32), std.mem.bytesAsSlice(u8, zero_raw_pixels));
+    @memcpy(std.mem.sliceAsBytes(source_image.pixels.rgba32), std.mem.bytesAsSlice(u8, zero_raw_pixels));
 
     var image_buffer: [100 * 1024]u8 = undefined;
     var zero_qoi = try helpers.testReadFile(zero_qoi_file, buffer[0..]);


### PR DESCRIPTION
This will port zigimg to Zig master by replacing usage of `std.mem.(copy|set)` with `@mem(copy|set)` and replacing PascalCase enum entries with snake_case enum entries (like #117). 