### PR TITLE
fix compile error in Image.isAnimation where nonexistant field was accessed

### DIFF
--- a/src/Image.zig
+++ b/src/Image.zig
@@ -168,7 +168,7 @@ pub fn imageByteSize(self: Self) usize {
 
 /// Is this image is an animation?
 pub fn isAnimation(self: Self) bool {
-    return self.animation.frames.len > 0;
+    return self.animation.frames.items.len > 0;
 }
 
 /// Write the image to an image format to the specified path


### PR DESCRIPTION
isAnimation attempts to access the len field of Animation.frames, but frames is an ArrayListUnmanaged and does not have a len field, instead, the length of the items slice is used.