### PR TITLE
Change the test block in zigimg.zig to catch more errors like #119

### DIFF
--- a/src/Image.zig
+++ b/src/Image.zig
@@ -168,7 +168,7 @@ pub fn imageByteSize(self: Self) usize {
 
 /// Is this image is an animation?
 pub fn isAnimation(self: Self) bool {
-    return self.animation.frames.len > 0;
+    return self.animation.frames.items.len > 0;
 }
 
 /// Write the image to an image format to the specified path

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -13,16 +13,19 @@ pub const qoi = @import("src/formats/qoi.zig");
 pub const tga = @import("src/formats/tga.zig");
 
 test {
-    @import("std").testing.refAllDecls(@This());
-    _ = @import("src/formats/png/reader.zig");
-    _ = @import("tests/color_test.zig");
-    _ = @import("tests/formats/bmp_test.zig");
-    _ = @import("tests/formats/jpeg_test.zig");
-    _ = @import("tests/formats/netpbm_test.zig");
-    _ = @import("tests/formats/pcx_test.zig");
-    _ = @import("tests/formats/png_test.zig");
-    _ = @import("tests/formats/qoi_test.zig");
-    _ = @import("tests/formats/tga_test.zig");
-    _ = @import("tests/image_test.zig");
-    _ = @import("tests/octree_quantizer_test.zig");
+    const std = @import("std");
+    std.testing.refAllDeclsRecursive(@This());
+    inline for (.{
+        @import("src/formats/png/reader.zig"),
+        @import("tests/color_test.zig"),
+        @import("tests/formats/bmp_test.zig"),
+        @import("tests/formats/jpeg_test.zig"),
+        @import("tests/formats/netpbm_test.zig"),
+        @import("tests/formats/pcx_test.zig"),
+        @import("tests/formats/png_test.zig"),
+        @import("tests/formats/qoi_test.zig"),
+        @import("tests/formats/tga_test.zig"),
+        @import("tests/image_test.zig"),
+        @import("tests/octree_quantizer_test.zig"),
+    }) |source_file| std.testing.refAllDeclsRecursive(source_file);
 }


### PR DESCRIPTION
This catches #119:
```
src/Image.zig:172:34: error: no field named 'len' in struct 'array_list.ArrayListAlignedUnmanaged(src.Image.AnimationFrame,null)'
    return self.animation.frames.len > 0;
```