### PR TITLE
fix bug where encoding png would fail because of memcpy sizes being different

### DIFF
--- a/src/formats/png/chunk_writer.zig
+++ b/src/formats/png/chunk_writer.zig
@@ -44,7 +44,7 @@ pub fn ChunkWriter(comptime buffer_size: usize, comptime WriterType: type) type 
                     return self.unbuffered_writer.write(bytes);
             }
 
-            @memcpy(self.buf[self.end..], bytes);
+            @memcpy(self.buf[self.end..][0..bytes.len], bytes);
             self.end += bytes.len;
             return bytes.len;
         }


### PR DESCRIPTION
We don't seem to have any encode tests for now, todo?