### PR TITLE
make binary encoder options the default for netpbm

### DIFF
--- a/src/formats/netpbm.zig
+++ b/src/formats/netpbm.zig
@@ -241,7 +241,7 @@ fn Netpbm(comptime image_format: Image.Format, comptime header_numbers: []const 
         const Self = @This();
 
         pub const EncoderOptions = struct {
-            binary: bool,
+            binary: bool = true,
         };
 
         pub fn formatInterface() FormatInterface {


### PR DESCRIPTION
- enables usage of one common initializer (`.{}`) for all formats
- mirrors the default of libnetpbm and FFmpeg
- smaller