### PR TITLE
Add sampling factor support

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -214,9 +214,9 @@ const HuffmanTable = struct {
 
                 const byte = try reader.readByte();
                 try huffman_code_map.put(.{ .length_minus_one = @intCast(u4, i), .code = code }, byte);
-                code += 1;
 
                 if (JPEG_VERY_DEBUG) std.debug.print("      {b} => 0x{X}\n", .{ code, byte });
+                code += 1;
             }
 
             code <<= 1;


### PR DESCRIPTION
This PR is for jpeg sampling factor support.
To achieve the above motivation, this contains the following modifications.

* Perform decoding of AC and DC coefficients for all blocks, which are regions consisting of 8x8 pixels in the MCU
* Increase the size of mcu_storage to support blocks in MCU
* Improve the calculation of the count of MCU for support sampling factor.
* Improve rendering algorithm for support sampling factor.