### PR TITLE
Add grayscale JPEG image decoding support

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -438,6 +438,11 @@ const FrameHeader = struct {
     }
 
     pub fn getBlockCount(self: FrameHeader, component_id: usize) usize {
+        // MCU of non-interleaved is just one block.
+        if (self.components.len == 1) {
+            return 1;
+        }
+
         const horizontal_block_count = self.components[component_id].horizontal_sampling_factor;
         const vertical_block_count = self.components[component_id].vertical_sampling_factor;
         return horizontal_block_count * vertical_block_count;
@@ -629,8 +634,11 @@ const Scan = struct {
 
     fn calculateMCUCountInFrame(frame_header: *const FrameHeader) usize {
         // FIXME: This is very naive and probably only works for Baseline DCT.
-        const mcu_width = 8 * frame_header.getMaxHorizontalSamplingFactor();
-        const mcu_height = 8 * frame_header.getMaxVerticalSamplingFactor();
+        // MCU of non-interleaved is just one block.
+        const horizontal_block_count = if (1 < frame_header.components.len) frame_header.getMaxHorizontalSamplingFactor() else 1;
+        const vertical_block_count = if (1 < frame_header.components.len) frame_header.getMaxVerticalSamplingFactor() else 1;
+        const mcu_width = 8 * horizontal_block_count;
+        const mcu_height = 8 * vertical_block_count;
         const mcu_count_per_row = (frame_header.samples_per_row + mcu_width - 1) / mcu_width;
         const mcu_count_per_column = (frame_header.row_count + mcu_height - 1) / mcu_height;
         return mcu_count_per_row * mcu_count_per_column;
@@ -835,16 +843,41 @@ const Frame = struct {
 
     pub fn renderToPixels(self: *const Frame, mcu_storage: *[MAX_COMPONENTS][MAX_BLOCKS]MCU, mcu_id: usize, pixels: *color.PixelStorage) ImageReadError!void {
         switch (self.frame_header.components.len) {
-            1 => try self.renderToPixelsGrayscale(pixels.grayscale8),
+            1 => try self.renderToPixelsGrayscale(&mcu_storage[0][0], mcu_id, pixels.grayscale8), // Grayscale images is non-interleaved
             3 => try self.renderToPixelsRgb(mcu_storage, mcu_id, pixels.rgb24),
             else => unreachable,
         }
     }
 
-    fn renderToPixelsGrayscale(self: *const Frame, pixels: []color.Grayscale8) ImageReadError!void {
-        _ = self;
-        _ = pixels;
-        return ImageError.Unsupported;
+    fn renderToPixelsGrayscale(self: *const Frame, mcu_storage: *MCU, mcu_id: usize, pixels: []color.Grayscale8) ImageReadError!void {
+        const mcu_width = 8;
+        const mcu_height = 8;
+        const width = self.frame_header.samples_per_row;
+        const mcus_per_row = (width + mcu_width - 1) / mcu_width;
+        const mcu_origin_x = (mcu_id % mcus_per_row) * mcu_width;
+        const mcu_origin_y = (mcu_id / mcus_per_row) * mcu_height;
+
+        for (0..mcu_height) |mcu_y| {
+            const y = mcu_origin_y + mcu_y;
+            if (y >= pixels.len / width) continue;
+
+            // y coordinates in the block
+            const block_y = mcu_y % 8;
+
+            for (0..mcu_width) |mcu_x| {
+                const x = mcu_origin_x + mcu_x;
+                if (x >= width) continue;
+
+                // x coordinates in the block
+                const block_x = mcu_x % 8;
+
+                const reconstructed_Y = idct(mcu_storage, @intCast(u3, block_x), @intCast(u3, block_y), mcu_id, 0);
+                const Y = @intToFloat(f32, reconstructed_Y);
+                pixels[y * width + x] = .{
+                    .value = @floatToInt(u8, std.math.clamp(Y + 128.0, 0.0, 255.0)),
+                };
+            }
+        }
     }
 
     fn renderToPixelsRgb(self: *const Frame, mcu_storage: *[MAX_COMPONENTS][MAX_BLOCKS]MCU, mcu_id: usize, pixels: []color.Rgb24) ImageReadError!void {

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -853,16 +853,19 @@ const Frame = struct {
         const mcu_width = 8;
         const mcu_height = 8;
         const width = self.frame_header.samples_per_row;
+        const height = pixels.len / width;
         const mcus_per_row = (width + mcu_width - 1) / mcu_width;
         const mcu_origin_x = (mcu_id % mcus_per_row) * mcu_width;
         const mcu_origin_y = (mcu_id / mcus_per_row) * mcu_height;
 
         for (0..mcu_height) |mcu_y| {
             const y = mcu_origin_y + mcu_y;
-            if (y >= pixels.len / width) continue;
+            if (y >= height) continue;
 
             // y coordinates in the block
             const block_y = mcu_y % 8;
+
+            const stride = y * width;
 
             for (0..mcu_width) |mcu_x| {
                 const x = mcu_origin_x + mcu_x;
@@ -873,7 +876,7 @@ const Frame = struct {
 
                 const reconstructed_Y = idct(mcu_storage, @intCast(u3, block_x), @intCast(u3, block_y), mcu_id, 0);
                 const Y = @intToFloat(f32, reconstructed_Y);
-                pixels[y * width + x] = .{
+                pixels[stride + x] = .{
                     .value = @floatToInt(u8, std.math.clamp(Y + 128.0, 0.0, 255.0)),
                 };
             }
@@ -886,6 +889,7 @@ const Frame = struct {
         const mcu_width = 8 * max_horizontal_sampling_factor;
         const mcu_height = 8 * max_vertical_sampling_factor;
         const width = self.frame_header.samples_per_row;
+        const height = pixels.len / width;
         const mcus_per_row = (width + mcu_width - 1) / mcu_width;
 
         const mcu_origin_x = (mcu_id % mcus_per_row) * mcu_width;
@@ -893,7 +897,7 @@ const Frame = struct {
 
         for (0..mcu_height) |mcu_y| {
             const y = mcu_origin_y + mcu_y;
-            if (y >= pixels.len / width) continue;
+            if (y >= height) continue;
 
             // y coordinates of each component applied to the sampling factor
             const y_sampled_y = (mcu_y * self.frame_header.components[0].vertical_sampling_factor) / max_vertical_sampling_factor;
@@ -904,6 +908,8 @@ const Frame = struct {
             const y_block_y = y_sampled_y % 8;
             const cb_block_y = cb_sampled_y % 8;
             const cr_block_y = cr_sampled_y % 8;
+
+            const stride = y * width;
 
             for (0..mcu_width) |mcu_x| {
                 const x = mcu_origin_x + mcu_x;
@@ -943,7 +949,7 @@ const Frame = struct {
                 const b = Cb * (2 - 2 * Co_blue) + Y;
                 const g = (Y - Co_blue * b - Co_red * r) / Co_green;
 
-                pixels[y * width + x] = .{
+                pixels[stride + x] = .{
                     .r = @floatToInt(u8, std.math.clamp(r + 128.0, 0.0, 255.0)),
                     .g = @floatToInt(u8, std.math.clamp(g + 128.0, 0.0, 255.0)),
                     .b = @floatToInt(u8, std.math.clamp(b + 128.0, 0.0, 255.0)),

--- a/tests/formats/jpeg_test.zig
+++ b/tests/formats/jpeg_test.zig
@@ -16,10 +16,10 @@ test "Should error on non JPEG images" {
     var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
     defer jpeg_file.deinit();
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    const invalidFile = jpeg_file.read(&stream_source, &pixelsOpt);
+    var pixels_opt: ?color.PixelStorage = null;
+    const invalidFile = jpeg_file.read(&stream_source, &pixels_opt);
     defer {
-        if (pixelsOpt) |pixels| {
+        if (pixels_opt) |pixels| {
             pixels.deinit(helpers.zigimg_test_allocator);
         }
     }
@@ -36,11 +36,11 @@ test "Read JFIF header properly and decode simple Huffman stream" {
     var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
     defer jpeg_file.deinit();
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    const frame = try jpeg_file.read(&stream_source, &pixelsOpt);
+    var pixels_opt: ?color.PixelStorage = null;
+    const frame = try jpeg_file.read(&stream_source, &pixels_opt);
 
     defer {
-        if (pixelsOpt) |pixels| {
+        if (pixels_opt) |pixels| {
             pixels.deinit(helpers.zigimg_test_allocator);
         }
     }
@@ -50,9 +50,9 @@ test "Read JFIF header properly and decode simple Huffman stream" {
     try helpers.expectEq(frame.frame_header.sample_precision, 8);
     try helpers.expectEq(frame.frame_header.components.len, 3);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels_opt != null);
 
-    if (pixelsOpt) |pixels| {
+    if (pixels_opt) |pixels| {
         try testing.expect(pixels == .rgb24);
     }
 }
@@ -66,11 +66,11 @@ test "Read the tuba properly" {
     var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
     defer jpeg_file.deinit();
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    const frame = try jpeg_file.read(&stream_source, &pixelsOpt);
+    var pixels_opt: ?color.PixelStorage = null;
+    const frame = try jpeg_file.read(&stream_source, &pixels_opt);
 
     defer {
-        if (pixelsOpt) |pixels| {
+        if (pixels_opt) |pixels| {
             pixels.deinit(helpers.zigimg_test_allocator);
         }
     }
@@ -80,9 +80,9 @@ test "Read the tuba properly" {
     try helpers.expectEq(frame.frame_header.sample_precision, 8);
     try helpers.expectEq(frame.frame_header.components.len, 3);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels_opt != null);
 
-    if (pixelsOpt) |pixels| {
+    if (pixels_opt) |pixels| {
         try testing.expect(pixels == .rgb24);
 
         // Just for fun, let's sample a few pixels. :^)
@@ -101,11 +101,11 @@ test "Read grayscale images" {
     var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
     defer jpeg_file.deinit();
 
-    var pixelsOpt: ?color.PixelStorage = null;
-    const frame = try jpeg_file.read(&stream_source, &pixelsOpt);
+    var pixels_opt: ?color.PixelStorage = null;
+    const frame = try jpeg_file.read(&stream_source, &pixels_opt);
 
     defer {
-        if (pixelsOpt) |pixels| {
+        if (pixels_opt) |pixels| {
             pixels.deinit(helpers.zigimg_test_allocator);
         }
     }
@@ -115,9 +115,9 @@ test "Read grayscale images" {
     try helpers.expectEq(frame.frame_header.sample_precision, 8);
     try helpers.expectEq(frame.frame_header.components.len, 1);
 
-    try testing.expect(pixelsOpt != null);
+    try testing.expect(pixels_opt != null);
 
-    if (pixelsOpt) |pixels| {
+    if (pixels_opt) |pixels| {
         try testing.expect(pixels == .grayscale8);
 
         // Just for fun, let's sample a few pixels. :^)
@@ -146,17 +146,17 @@ test "Read subsampling images" {
             var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
             defer jpeg_file.deinit();
 
-            var pixelsOpt: ?color.PixelStorage = null;
-            _ = try jpeg_file.read(&stream, &pixelsOpt);
+            var pixels_opt: ?color.PixelStorage = null;
+            _ = try jpeg_file.read(&stream, &pixels_opt);
 
             defer {
-                if (pixelsOpt) |pixels| {
+                if (pixels_opt) |pixels| {
                     pixels.deinit(helpers.zigimg_test_allocator);
                 }
             }
 
-            try testing.expect(pixelsOpt != null);
-            if (pixelsOpt) |pixels| {
+            try testing.expect(pixels_opt != null);
+            if (pixels_opt) |pixels| {
                 try testing.expect(pixels == .rgb24);
 
                 // Just for fun, let's sample a few pixels. :^)


### PR DESCRIPTION
This PR targets adding grayscale JPEG image decoding support.
The key modifications are the followings.

* Make `getBlockCount` and `calculateMCUCountInFrame` handle grayscale images correctly
* Implement `renderToPixelsGrayscale`

`grayscale_sample0.jpg` will be added in the associated PR(https://github.com/zigimg/test-suite/pull/10)