### PR TITLE
Catch up latest zig version

### DIFF
--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -275,7 +275,7 @@ pub const PCX = struct {
             };
 
             var i: usize = 0;
-            while (i < std.math.min(pal.len, self.header.builtin_palette.len / 3)) : (i += 1) {
+            while (i < @min(pal.len, self.header.builtin_palette.len / 3)) : (i += 1) {
                 pal[i].r = self.header.builtin_palette[3 * i + 0];
                 pal[i].g = self.header.builtin_palette[3 * i + 1];
                 pal[i].b = self.header.builtin_palette[3 * i + 2];

--- a/src/formats/png/InfoProcessor.zig
+++ b/src/formats/png/InfoProcessor.zig
@@ -98,7 +98,7 @@ fn processChunk(self: *Self, data: *ChunkProcessData) Image.ReadError!PixelForma
                     self.writer.print("           Compression: Zlib Deflate\n", .{}) catch return result_format;
                     self.writer.print("                  Text: ", .{}) catch return result_format;
                     try data.stream.seekBy(@intCast(i64, strEnd) + 2 - to_read);
-                    var decompressStream = std.compress.zlib.zlibStream(data.temp_allocator, reader) catch return error.InvalidData;
+                    var decompressStream = std.compress.zlib.decompressStream(data.temp_allocator, reader) catch return error.InvalidData;
                     var print_buf: [1024]u8 = undefined;
                     var got = decompressStream.read(print_buf[0..]) catch return error.InvalidData;
                     while (got > 0) {

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -284,7 +284,7 @@ fn readAllData(
     errdefer result.deinit(allocator);
     var idat_chunks_reader = IDatChunksReader.init(stream, options.processors, chunk_process_data);
     var idat_reader: IDATReader = .{ .context = &idat_chunks_reader };
-    var decompress_stream = std.compress.zlib.zlibStream(options.temp_allocator, idat_reader) catch return Image.ReadError.InvalidData;
+    var decompress_stream = std.compress.zlib.decompressStream(options.temp_allocator, idat_reader) catch return Image.ReadError.InvalidData;
 
     if (palette.len > 0) {
         var destination_palette = if (result.getPalette()) |result_palette|


### PR DESCRIPTION
This PR is for catching up with the latest version of zig.
I met the following issues before this PR.

```
$  zig build test
zig test zigimgtest Debug native: error: the following command failed with 3 compilation errors:
/snap/zig/7710/zig test /home/argon/workspace/zigimg/zigimg.zig --cache-dir /home/argon/workspace/zigimg/zig-cache --global-cache-dir /home/argon/.cache/zig --name zigimgtest --listen=-
Build Summary: 0/5 steps succeeded; 1 failed (disable with --summary none)
test transitive failure
└─ run zigimgtest transitive failure
   ├─ zig test zigimgtest Debug native 3 errors
   └─ install transitive failure
      └─ install zigimgtest transitive failure
         └─ zig test zigimgtest Debug native (reused)
/snap/zig/7710/lib/std/math.zig:437:17: error: deprecated; use @min instead
pub const min = @compileError("deprecated; use @min instead");
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
referenced by:
    read: src/formats/pcx.zig:278:32
    refAllDeclsRecursive__anon_6091: /snap/zig/7710/lib/std/testing.zig:1135:18
    remaining reference traces hidden; use '-freference-trace' to see all reference traces

src/formats/png/reader.zig:287:46: error: root struct of file 'compress.zlib' has no member named 'zlibStream'
    var decompress_stream = std.compress.zlib.zlibStream(options.temp_allocator, idat_reader) catch return Image.ReadError.InvalidData;
                            ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
src/formats/png/InfoProcessor.zig:101:61: error: root struct of file 'compress.zlib' has no member named 'zlibStream'
                    var decompressStream = std.compress.zlib.zlibStream(data.temp_allocator, reader) catch returonerror.InvalidData;
                                           ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
src/formats/png/reader.zig:621:24: note: called from here
                return @call(.always_inline, chunkProcessorFn.?, .{ self, data });
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
