### PR TITLE
diasable autocrlf

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
+      - name: Prepare git
+        run: |-
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: Checkout zigmimg
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This PR is for fixing https://github.com/zigimg/zigimg/issues/130 .
https://github.com/zigimg/zigimg/issues/130 is caused by git converting LF to CRLF automatically.
So this PR adds to the configuration to disable this auto CRLF conversion.

This modification is derived from the following comment.
https://github.com/actions/checkout/issues/226#issuecomment-854736025