### PR TITLE
Optimize PNG writing

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+	.name = "zigimg",
+	.version = "0.1.0",
+	.dependencies = .{
+		.tracy = .{
+			.url = "https://github.com/leroycep/tracy/archive/b8738156fc1a57605d4fbd07c814c4dd040d6204.tar.gz",
+			.hash = "1220d1ba194989118dc26ba2a912fe7bf8246843788407cc5a51aea620c109dbcb9b",
+		},
+	}
+}
+
+

--- a/examples/to_png.zig
+++ b/examples/to_png.zig
@@ -11,19 +11,24 @@ pub fn main() !void {
     defer std.process.argsFree(gpa, args);
 
     if (args.len < 3) {
-        std.debug.print("Correct usage:\n\tto_png <input file> <output file>", .{});
+        std.debug.print("Correct usage:\n\tto_png  <output file> <input files...>", .{});
         std.process.exit(1);
     }
 
-    const input_filepath = args[1];
-    const output_filepath = args[2];
+    const output_filepath = args[1];
+    const input_filepaths = args[2..];
 
-    const read_trace = tracy.trace(@src(), "read image");
-    var image = try zigimg.Image.fromFilePath(gpa, input_filepath);
-    defer image.deinit();
-    read_trace.end();
+    for (input_filepaths) |input_filepath| {
+        const f = tracy.frame(null);
+        defer f.end();
 
-    const write_trace = tracy.trace(@src(), "write image");
-    try image.writeToFilePath(output_filepath, .{ .png = .{} });
-    write_trace.end();
+        const read_trace = tracy.trace(@src(), "read image");
+        var image = try zigimg.Image.fromFilePath(gpa, input_filepath);
+        defer image.deinit();
+        read_trace.end();
+
+        const write_trace = tracy.trace(@src(), "write image");
+        try image.writeToFilePath(output_filepath, .{ .png = .{} });
+        write_trace.end();
+    }
 }

--- a/examples/to_png.zig
+++ b/examples/to_png.zig
@@ -1,0 +1,29 @@
+const std = @import("std");
+const zigimg = @import("zigimg");
+const tracy = @import("tracy");
+
+pub fn main() !void {
+    var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = general_purpose_allocator.deinit();
+    const gpa = general_purpose_allocator.allocator();
+
+    const args = try std.process.argsAlloc(gpa);
+    defer std.process.argsFree(gpa, args);
+
+    if (args.len < 3) {
+        std.debug.print("Correct usage:\n\tto_png <input file> <output file>", .{});
+        std.process.exit(1);
+    }
+
+    const input_filepath = args[1];
+    const output_filepath = args[2];
+
+    const read_trace = tracy.trace(@src(), "read image");
+    var image = try zigimg.Image.fromFilePath(gpa, input_filepath);
+    defer image.deinit();
+    read_trace.end();
+
+    const write_trace = tracy.trace(@src(), "write image");
+    try image.writeToFilePath(output_filepath, .{ .png = .{} });
+    write_trace.end();
+}

--- a/src/Image.zig
+++ b/src/Image.zig
@@ -8,6 +8,7 @@ const color = @import("color.zig");
 const io = std.io;
 const std = @import("std");
 const utils = @import("utils.zig");
+const tracy = @import("tracy");
 
 pub const Error = error{
     Unsupported,
@@ -213,6 +214,9 @@ fn internalRead(allocator: Allocator, stream: *Stream) !Self {
 }
 
 fn internalWrite(self: Self, stream: *Stream, encoder_options: EncoderOptions) WriteError!void {
+    const t = tracy.trace(@src(), null);
+    defer t.end();
+
     const image_format = std.meta.activeTag(encoder_options);
 
     var format_interface = try findImageInterfaceFromImageFormat(image_format);

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -14,6 +14,7 @@ const FormatInterface = @import("../format_interface.zig").FormatInterface;
 const ImageReadError = Image.ReadError;
 const ImageWriteError = Image.WriteError;
 const Allocator = std.mem.Allocator;
+const tracy = @import("tracy");
 
 pub const HeaderData = types.HeaderData;
 pub const ColorType = types.ColorType;
@@ -74,6 +75,9 @@ pub const PNG = struct {
     }
 
     pub fn writeImage(allocator: Allocator, write_stream: *Image.Stream, image: Image, encoder_options: Image.EncoderOptions) ImageWriteError!void {
+        const t = tracy.trace(@src(), null);
+        defer t.end();
+
         const options = encoder_options.png;
 
         try ensureWritable(image);
@@ -152,6 +156,9 @@ pub const PNG = struct {
 
     // IDAT (multiple maybe)
     fn writeData(allocator: Allocator, writer: anytype, pixels: color.PixelStorage, header: HeaderData, filter_choice: filter.FilterChoice) ImageWriteError!void {
+        const t = tracy.trace(@src(), null);
+        defer t.end();
+
         // Note: there may be more than 1 chunk
         // TODO: provide choice of how much it buffers (how much data per idat chunk)
         var chunks = chunk_writer.chunkWriter(writer, "IDAT");

--- a/src/formats/png/chunk_writer.zig
+++ b/src/formats/png/chunk_writer.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const tracy = @import("tracy");
 
 const io = std.io;
 const mem = std.mem;
@@ -19,15 +20,13 @@ pub fn ChunkWriter(comptime buffer_size: usize, comptime WriterType: type) type 
         const Self = @This();
 
         pub fn flush(self: *Self) !void {
-            try self.unbuffered_writer.writeIntBig(u32, @as(u32, @truncate(self.end)));
-
             var crc = Crc.init();
-
             crc.update(&self.section_id);
-            try self.unbuffered_writer.writeAll(&self.section_id);
             crc.update(self.buf[0..self.end]);
-            try self.unbuffered_writer.writeAll(self.buf[0..self.end]);
 
+            try self.unbuffered_writer.writeIntBig(u32, @as(u32, @truncate(self.end)));
+            try self.unbuffered_writer.writeAll(&self.section_id);
+            try self.unbuffered_writer.writeAll(self.buf[0..self.end]);
             try self.unbuffered_writer.writeIntBig(u32, crc.final());
 
             self.end = 0;

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -56,10 +56,9 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
 
         switch (scanline) {
             .rgba32 => {
-                {
+                for (scanline.asBytes()[0..pixel_len], 0..) |sample, i| {
                     // start off the scanline
-                    const sample = scanline.asBytes()[0];
-                    const above: u8 = if (previous_scanline) |b| b.asBytes()[0] else 0;
+                    const above: u8 = if (previous_scanline) |b| b.asBytes()[i] else 0;
 
                     const byte: u8 = switch (filter_type) {
                         .none, .sub => sample,
@@ -72,11 +71,11 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
                 }
 
                 // Write out the rest of the bytes
-                const bytes = scanline.asBytes()[1..];
-                const previous_bytes = scanline.asBytes()[0 .. scanline.asBytes().len - 1];
+                const bytes = scanline.asBytes()[pixel_len..];
+                const previous_bytes = scanline.asBytes()[0 .. scanline.asBytes().len - pixel_len];
                 if (previous_scanline) |prev_line| {
-                    const above_bytes = prev_line.asBytes()[1..];
-                    const above_previous_bytes = prev_line.asBytes()[0 .. scanline.asBytes().len - 1];
+                    const above_bytes = prev_line.asBytes()[pixel_len..];
+                    const above_previous_bytes = prev_line.asBytes()[0 .. scanline.asBytes().len - pixel_len];
                     switch (filter_type) {
                         .none => try writer.writeAll(bytes),
                         .sub => for (bytes, previous_bytes) |sample, previous| {

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -4,6 +4,7 @@ const PixelFormat = @import("../../pixel_format.zig").PixelFormat;
 const Image = @import("../../Image.zig");
 const HeaderData = @import("types.zig").HeaderData;
 const builtin = @import("builtin");
+const tracy = @import("tracy");
 
 pub const FilterType = enum(u8) {
     none = 0,
@@ -26,6 +27,9 @@ pub const FilterChoice = union(FilterChoiceStrategies) {
 };
 
 pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: FilterChoice, header: HeaderData) Image.WriteError!void {
+    const t = tracy.trace(@src(), null);
+    defer t.end();
+
     var scanline: color.PixelStorage = undefined;
     var previous_scanline: ?color.PixelStorage = null;
 
@@ -102,6 +106,9 @@ fn byteSwappedIndex(comptime T: type, byte_index: usize) usize {
 }
 
 fn filterChoiceHeuristic(scanline: color.PixelStorage, previous_scanline: ?color.PixelStorage) FilterType {
+    const t = tracy.trace(@src(), null);
+    defer t.end();
+
     const pixel_len = @as(PixelFormat, scanline).pixelStride();
     var max_score: usize = 0;
     var best: FilterType = .none;


### PR DESCRIPTION
This pull request isn't ready to be merged (and I think it would be a good idea to pull out the optimization commits from code that just adds profiling), but I've started optimizing the PNG writing code. I still need to run the test cases to ensure that I haven't broken anything.

I have a project that involves writing out 3096 x 2080 PNG images, and it takes forever to export them. Part of this is because the project crashes the Zig compiler when I build it in `ReleaseFast` or `ReleaseSafe`.