### PR TITLE
Create buffered wrapper around std.io.StreamSource for reading and writing to buffer I/O

### DIFF
--- a/src/buffered_stream_source.zig
+++ b/src/buffered_stream_source.zig
@@ -1,0 +1,243 @@
+const std = @import("std");
+
+const DefaultBufferSize = 4 * 1024;
+
+// An buffered stream that can read and seek StreamSource
+pub fn BufferedStreamSourceReader(comptime BufferSize: usize) type {
+    return struct {
+        buffered_reader: std.io.BufferedReader(BufferSize, std.io.StreamSource.Reader),
+
+        pub const ReadError = std.io.StreamSource.ReadError;
+        pub const SeekError = std.io.StreamSource.SeekError;
+        pub const GetSeekPosError = std.io.StreamSource.GetSeekPosError;
+
+        const Self = @This();
+
+        pub const Reader = std.io.Reader(*Self, ReadError, read);
+        pub const SeekableStream = std.io.SeekableStream(
+            *Self,
+            SeekError,
+            GetSeekPosError,
+            seekTo,
+            seekBy,
+            getPos,
+            getEndPos,
+        );
+
+        pub fn read(self: *Self, dest: []u8) ReadError!usize {
+            return switch (self.buffered_reader.unbuffered_reader.context.*) {
+                .buffer => |*actual_reader| actual_reader.read(dest),
+                .const_buffer => |*actual_reader| actual_reader.read(dest),
+                .file => self.buffered_reader.read(dest),
+            };
+        }
+
+        pub fn seekTo(self: *Self, pos: u64) SeekError!void {
+            switch (self.buffered_reader.unbuffered_reader.context.*) {
+                .buffer => |*actual_reader| {
+                    return actual_reader.seekTo(pos);
+                },
+                .const_buffer => |*actual_reader| {
+                    return actual_reader.seekTo(pos);
+                },
+                .file => {
+                    try self.buffered_reader.unbuffered_reader.context.seekTo(pos);
+                    self.resetBufferedReader();
+                },
+            }
+        }
+
+        pub fn seekBy(self: *Self, amt: i64) SeekError!void {
+            switch (self.buffered_reader.unbuffered_reader.context.*) {
+                .buffer => |*actual_reader| {
+                    return actual_reader.seekBy(amt);
+                },
+                .const_buffer => |*actual_reader| {
+                    return actual_reader.seekBy(amt);
+                },
+                .file => {
+                    const bytes_availables = self.buffered_reader.end - self.buffered_reader.start;
+                    if (amt > 0) {
+                        if (amt <= bytes_availables) {
+                            self.buffered_reader.start += @intCast(amt);
+                        } else {
+                            try self.buffered_reader.unbuffered_reader.context.seekBy(amt - @as(i64, @intCast(bytes_availables)));
+                            self.resetBufferedReader();
+                        }
+                    } else if (amt < 0) {
+                        const absolute_amt = @abs(amt);
+                        if (absolute_amt <= self.buffered_reader.start) {
+                            self.buffered_reader.start -%= absolute_amt;
+                        } else {
+                            try self.buffered_reader.unbuffered_reader.context.seekBy(amt - @as(i64, @intCast(bytes_availables)));
+                            self.resetBufferedReader();
+                        }
+                    }
+                },
+            }
+        }
+
+        pub fn getEndPos(self: *Self) GetSeekPosError!u64 {
+            return self.buffered_reader.unbuffered_reader.context.getEndPos();
+        }
+
+        pub fn getPos(self: *Self) GetSeekPosError!u64 {
+            switch (self.buffered_reader.unbuffered_reader.context.*) {
+                .buffer => |*actual_reader| {
+                    return actual_reader.getPos();
+                },
+                .const_buffer => |*actual_reader| {
+                    return actual_reader.getPos();
+                },
+                .file => {
+                    if (self.buffered_reader.unbuffered_reader.context.getPos()) |position| {
+                        return position - (self.buffered_reader.end - self.buffered_reader.start);
+                    } else |err| {
+                        return err;
+                    }
+                },
+            }
+        }
+
+        pub fn reader(self: *Self) Reader {
+            return .{ .context = self };
+        }
+
+        pub fn seekableStream(self: *Self) SeekableStream {
+            return .{ .context = self };
+        }
+
+        fn resetBufferedReader(self: *Self) void {
+            self.buffered_reader.start = 0;
+            self.buffered_reader.end = 0;
+        }
+    };
+}
+
+pub fn bufferedStreamSourceReader(stream: *std.io.StreamSource) BufferedStreamSourceReader(DefaultBufferSize) {
+    return .{ .buffered_reader = .{ .unbuffered_reader = stream.reader() } };
+}
+
+pub fn bufferedStreamSourceReaderWithSize(comptime buffer_size: usize, stream: *std.io.StreamSource) BufferedStreamSourceReader(buffer_size) {
+    return .{ .buffered_reader = .{ .unbuffered_reader = stream.reader() } };
+}
+
+// An buffered stream that can writer and seek StreamSource
+pub fn BufferedStreamSourceWriter(comptime BufferSize: usize) type {
+    return struct {
+        buffered_writer: std.io.BufferedWriter(BufferSize, std.io.StreamSource.Writer),
+
+        pub const WriteError = std.io.StreamSource.WriteError;
+        pub const SeekError = std.io.StreamSource.SeekError;
+        pub const GetSeekPosError = std.io.StreamSource.GetSeekPosError;
+
+        const Self = @This();
+
+        pub const Writer = std.io.Writer(*Self, WriteError, write);
+        pub const SeekableStream = std.io.SeekableStream(
+            *Self,
+            SeekError,
+            GetSeekPosError,
+            seekTo,
+            seekBy,
+            getPos,
+            getEndPos,
+        );
+
+        pub fn write(self: *Self, bytes: []const u8) WriteError!usize {
+            return switch (self.buffered_writer.unbuffered_writer.context.*) {
+                .buffer => |*actual_writer| actual_writer.write(bytes),
+                .const_buffer => error.AccessDenied,
+                .file => self.buffered_writer.write(bytes),
+            };
+        }
+
+        pub fn seekTo(self: *Self, pos: u64) SeekError!void {
+            switch (self.buffered_writer.unbuffered_writer.context.*) {
+                .buffer => |*actual_writer| {
+                    return actual_writer.seekTo(pos);
+                },
+                .const_buffer => |*actual_writer| {
+                    return actual_writer.seekTo(pos);
+                },
+                .file => {
+                    try self.buffered_writer.flush();
+                    try self.buffered_writer.buffered_writer.context.seekTo(pos);
+                },
+            }
+        }
+
+        pub fn seekBy(self: *Self, amt: i64) SeekError!void {
+            switch (self.buffered_writer.unbuffered_writer.context.*) {
+                .buffer => |*actual_writer| {
+                    return actual_writer.seekBy(amt);
+                },
+                .const_buffer => |*actual_writer| {
+                    return actual_writer.seekBy(amt);
+                },
+                .file => {
+                    if (amt < 0) {
+                        const abs_amt = @abs(amt);
+                        if (abs_amt <= self.buffered_writer.end) {
+                            self.buffered_writer.end -= abs_amt;
+                        } else {
+                            self.buffered_writer.flush() catch {
+                                return error.Unseekable;
+                            };
+                            try self.buffered_writer.unbuffered_writer.context.seekBy(amt);
+                        }
+                    } else {
+                        const amt_usize: usize = @intCast(amt);
+
+                        if (self.buffered_writer.end + amt_usize < self.buffered_writer.buf.len) {
+                            self.buffered_writer.end += amt_usize;
+                        } else {
+                            self.buffered_writer.flush() catch {
+                                return error.Unseekable;
+                            };
+                            try self.buffered_writer.unbuffered_writer.context.seekBy(amt);
+                        }
+                    }
+                },
+            }
+        }
+
+        pub fn getEndPos(self: *Self) GetSeekPosError!u64 {
+            return self.buffered_writer.unbuffered_writer.context.getEndPos();
+        }
+
+        pub fn getPos(self: *Self) GetSeekPosError!u64 {
+            switch (self.buffered_writer.unbuffered_writer.context.*) {
+                .buffer => |*actual_writer| {
+                    return actual_writer.getPos();
+                },
+                .const_buffer => |*actual_writer| {
+                    return actual_writer.getPos();
+                },
+                .file => {
+                    if (self.buffered_writer.unbuffered_writer.context.getPos()) |position| {
+                        return position + self.buffered_writer.end;
+                    } else |err| {
+                        return err;
+                    }
+                },
+            }
+        }
+
+        pub fn writer(self: *Self) Writer {
+            return .{ .context = self };
+        }
+
+        pub fn seekableStream(self: *Self) SeekableStream {
+            return .{ .context = self };
+        }
+    };
+}
+
+pub fn bufferedStreamSourceWriter(stream: *std.io.StreamSource) BufferedStreamSourceWriter(DefaultBufferSize) {
+    return .{ .buffered_writer = .{ .unbuffered_writer = stream.writer() } };
+}
+
+pub fn bufferedStreamSourceWriterWithSize(comptime buffer_size: usize, stream: *std.io.StreamSource) BufferedStreamSourceWriter(buffer_size) {
+    return .{ .buffered_writer = .{ .unbuffered_writer = stream.writer() } };
+}

--- a/src/buffered_stream_source.zig
+++ b/src/buffered_stream_source.zig
@@ -234,6 +234,13 @@ pub fn BufferedStreamSourceWriter(comptime BufferSize: usize) type {
         pub fn seekableStream(self: *Self) SeekableStream {
             return .{ .context = self };
         }
+
+        pub fn flush(self: *Self) WriteError!void {
+            return switch (self.buffered_writer.unbuffered_writer.context.*) {
+                .file => self.buffered_writer.flush(),
+                else => {},
+            };
+        }
     };
 }
 

--- a/src/buffered_stream_source.zig
+++ b/src/buffered_stream_source.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 
 const DefaultBufferSize = 4 * 1024;
 
+pub const DefaultBufferedStreamSourceReader = BufferedStreamSourceReader(DefaultBufferSize);
+pub const DefaultBufferedStreamSourceWriter = BufferedStreamSourceWriter(DefaultBufferSize);
+
 // An buffered stream that can read and seek StreamSource
 pub fn BufferedStreamSourceReader(comptime BufferSize: usize) type {
     return struct {

--- a/src/buffered_stream_source.zig
+++ b/src/buffered_stream_source.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const DefaultBufferSize = 4 * 1024;
+const DefaultBufferSize = 8 * 1024;
 
 pub const DefaultBufferedStreamSourceReader = BufferedStreamSourceReader(DefaultBufferSize);
 pub const DefaultBufferedStreamSourceWriter = BufferedStreamSourceWriter(DefaultBufferSize);

--- a/src/formats/netpbm.zig
+++ b/src/formats/netpbm.zig
@@ -1,13 +1,14 @@
 // Adapted from https://github.com/MasterQ32/zig-gamedev-lib/blob/master/src/netbpm.zig
 // with permission from Felix Queißner
 const Allocator = std.mem.Allocator;
-const FormatInterface = @import("../FormatInterface.zig");
-const PixelFormat = @import("../pixel_format.zig").PixelFormat;
+const buffered_stream_source = @import("../buffered_stream_source.zig");
 const color = @import("../color.zig");
+const FormatInterface = @import("../FormatInterface.zig");
+const Image = @import("../Image.zig");
 const ImageError = Image.Error;
 const ImageReadError = Image.ReadError;
 const ImageWriteError = Image.WriteError;
-const Image = @import("../Image.zig");
+const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const std = @import("std");
 const utils = @import("../utils.zig");
 
@@ -36,7 +37,7 @@ pub const Header = struct {
     max_value: usize,
 };
 
-fn parseHeader(reader: Image.Stream.Reader) ImageReadError!Header {
+fn parseHeader(reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!Header {
     var header: Header = undefined;
 
     var magic: [2]u8 = undefined;
@@ -85,7 +86,7 @@ fn isWhitespace(b: u8) bool {
     };
 }
 
-fn readNextByte(reader: Image.Stream.Reader) ImageReadError!u8 {
+fn readNextByte(reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!u8 {
     while (true) {
         var b = try reader.readByte();
         switch (b) {
@@ -112,7 +113,7 @@ fn readNextByte(reader: Image.Stream.Reader) ImageReadError!u8 {
 
 /// skips whitespace and comments, then reads a number from the stream.
 /// this function reads one whitespace behind the number as a terminator.
-fn parseNumber(reader: Image.Stream.Reader, buffer: []u8) ImageReadError!usize {
+fn parseNumber(reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader, buffer: []u8) ImageReadError!usize {
     var input_length: usize = 0;
     while (true) {
         var b = try readNextByte(reader);
@@ -131,7 +132,7 @@ fn parseNumber(reader: Image.Stream.Reader, buffer: []u8) ImageReadError!usize {
     }
 }
 
-fn loadBinaryBitmap(header: Header, data: []color.Grayscale1, reader: Image.Stream.Reader) ImageReadError!void {
+fn loadBinaryBitmap(header: Header, data: []color.Grayscale1, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var bit_reader = std.io.bitReader(.Big, reader);
 
     for (0..header.height) |row_index| {
@@ -142,7 +143,7 @@ fn loadBinaryBitmap(header: Header, data: []color.Grayscale1, reader: Image.Stre
     }
 }
 
-fn loadAsciiBitmap(header: Header, data: []color.Grayscale1, reader: Image.Stream.Reader) ImageReadError!void {
+fn loadAsciiBitmap(header: Header, data: []color.Grayscale1, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var data_index: usize = 0;
     const data_end = header.width * header.height;
 
@@ -161,14 +162,14 @@ fn loadAsciiBitmap(header: Header, data: []color.Grayscale1, reader: Image.Strea
     }
 }
 
-fn readLinearizedValue(reader: Image.Stream.Reader, max_value: usize) ImageReadError!u8 {
+fn readLinearizedValue(reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader, max_value: usize) ImageReadError!u8 {
     return if (max_value > 255)
         @truncate(255 * @as(usize, try reader.readIntBig(u16)) / max_value)
     else
         @truncate(255 * @as(usize, try reader.readByte()) / max_value);
 }
 
-fn loadBinaryGraymap(header: Header, pixels: *color.PixelStorage, reader: Image.Stream.Reader) ImageReadError!void {
+fn loadBinaryGraymap(header: Header, pixels: *color.PixelStorage, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var data_index: usize = 0;
     const data_end = header.width * header.height;
     if (header.max_value <= 255) {
@@ -182,7 +183,7 @@ fn loadBinaryGraymap(header: Header, pixels: *color.PixelStorage, reader: Image.
     }
 }
 
-fn loadAsciiGraymap(header: Header, pixels: *color.PixelStorage, reader: Image.Stream.Reader) ImageReadError!void {
+fn loadAsciiGraymap(header: Header, pixels: *color.PixelStorage, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var read_buffer: [16]u8 = undefined;
 
     var data_index: usize = 0;
@@ -199,7 +200,7 @@ fn loadAsciiGraymap(header: Header, pixels: *color.PixelStorage, reader: Image.S
     }
 }
 
-fn loadBinaryRgbmap(header: Header, data: []color.Rgb24, reader: Image.Stream.Reader) ImageReadError!void {
+fn loadBinaryRgbmap(header: Header, data: []color.Rgb24, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var data_index: usize = 0;
     const data_end = header.width * header.height;
 
@@ -212,7 +213,7 @@ fn loadBinaryRgbmap(header: Header, data: []color.Rgb24, reader: Image.Stream.Re
     }
 }
 
-fn loadAsciiRgbmap(header: Header, data: []color.Rgb24, reader: Image.Stream.Reader) ImageReadError!void {
+fn loadAsciiRgbmap(header: Header, data: []color.Rgb24, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var read_buffer: [16]u8 = undefined;
 
     var data_index: usize = 0;
@@ -329,7 +330,8 @@ fn Netpbm(comptime image_format: Image.Format, comptime header_numbers: []const 
         }
 
         pub fn read(self: *Self, allocator: Allocator, stream: *Image.Stream) ImageReadError!color.PixelStorage {
-            const reader = stream.reader();
+            var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
+            const reader = buffered_stream.reader();
             self.header = try parseHeader(reader);
 
             const pixel_format = try self.pixelFormat();
@@ -365,8 +367,10 @@ fn Netpbm(comptime image_format: Image.Format, comptime header_numbers: []const 
         }
 
         pub fn write(self: *Self, write_stream: *Image.Stream, pixels: color.PixelStorage) ImageWriteError!void {
+            var buffered_stream = buffered_stream_source.bufferedStreamSourceWriter(write_stream);
+
             const image_type = if (self.header.binary) header_numbers[1] else header_numbers[0];
-            const writer = write_stream.writer();
+            const writer = buffered_stream.writer();
             try writer.print("P{c}\n", .{image_type});
             _ = try writer.write("# Created by zigimg\n");
 
@@ -486,6 +490,8 @@ fn Netpbm(comptime image_format: Image.Format, comptime header_numbers: []const 
                     },
                 }
             }
+
+            try buffered_stream.flush();
         }
     };
 }

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -1,13 +1,14 @@
 // Adapted from https://github.com/MasterQ32/zig-gamedev-lib/blob/master/src/pcx.zig
 // with permission from Felix Queißner
 const Allocator = std.mem.Allocator;
-const FormatInterface = @import("../FormatInterface.zig");
-const PixelFormat = @import("../pixel_format.zig").PixelFormat;
+const buffered_stream_source = @import("../buffered_stream_source.zig");
 const color = @import("../color.zig");
+const FormatInterface = @import("../FormatInterface.zig");
+const Image = @import("../Image.zig");
 const ImageError = Image.Error;
 const ImageReadError = Image.ReadError;
 const ImageWriteError = Image.WriteError;
-const Image = @import("../Image.zig");
+const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 const std = @import("std");
 const utils = @import("../utils.zig");
 
@@ -44,10 +45,10 @@ const RLEDecoder = struct {
         remaining: usize,
     };
 
-    reader: Image.Stream.Reader,
+    reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader,
     current_run: ?Run,
 
-    fn init(reader: Image.Stream.Reader) RLEDecoder {
+    fn init(reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) RLEDecoder {
         return RLEDecoder{
             .reader = reader,
             .current_run = null,
@@ -168,9 +169,10 @@ pub const PCX = struct {
     }
 
     pub fn read(self: *Self, allocator: Allocator, stream: *Image.Stream) ImageReadError!color.PixelStorage {
-        const reader = stream.reader();
+        var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
+        const reader = buffered_stream.reader();
         self.header = try utils.readStructLittle(reader, PCXHeader);
-        _ = try stream.read(PCXHeader.padding[0..]);
+        _ = try buffered_stream.read(PCXHeader.padding[0..]);
 
         if (self.header.id != 0x0A) {
             return ImageReadError.InvalidData;
@@ -283,8 +285,8 @@ pub const PCX = struct {
             }
 
             if (pixels == .indexed8) {
-                const end_pos = try stream.getEndPos();
-                try stream.seekTo(end_pos - 769);
+                const end_pos = try buffered_stream.getEndPos();
+                try buffered_stream.seekTo(end_pos - 769);
 
                 if ((try reader.readByte()) != 0x0C)
                     return ImageReadError.InvalidData;

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -102,8 +102,7 @@ pub const PNG = struct {
         if (header.filter_method != .adaptive)
             return ImageWriteError.Unsupported;
 
-        var buffered_stream = buffered_stream_source.bufferedStreamSourceWriter(write_stream);
-        var writer = buffered_stream.writer();
+        var writer = write_stream.writer();
 
         try writeSignature(writer);
         try writeHeader(writer, header);
@@ -113,8 +112,6 @@ pub const PNG = struct {
         }
         try writeData(allocator, writer, pixels, header, filter_choice);
         try writeTrailer(writer);
-
-        try buffered_stream.flush();
     }
 
     pub fn ensureWritable(image: Image) !void {

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -2,7 +2,6 @@
 // Last version: https://www.w3.org/TR/PNG/
 
 const Allocator = std.mem.Allocator;
-const buffered_stream_source = @import("../buffered_stream_source.zig");
 const chunk_writer = @import("png/chunk_writer.zig");
 const color = @import("../color.zig");
 const filter = @import("png/filtering.zig");

--- a/src/formats/png/chunk_writer.zig
+++ b/src/formats/png/chunk_writer.zig
@@ -51,7 +51,9 @@ pub fn ChunkWriter(comptime buffer_size: usize, comptime WriterType: type) type 
     };
 }
 
-pub fn chunkWriter(underlying_stream: anytype, comptime id: []const u8) ChunkWriter(1 << 14, @TypeOf(underlying_stream)) {
+const ChunkBufferSize = 1 << 14; // 16 kb
+
+pub fn chunkWriter(underlying_stream: anytype, comptime id: []const u8) ChunkWriter(ChunkBufferSize, @TypeOf(underlying_stream)) {
     if (id.len != 4)
         @compileError("PNG chunk id must be 4 characters");
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -48,17 +48,17 @@ fn checkEnumFields(data: anytype) StructReadError!void {
     }
 }
 
-pub fn readStructNative(reader: std.io.StreamSource.Reader, comptime T: type) StructReadError!T {
+pub fn readStructNative(reader: anytype, comptime T: type) StructReadError!T {
     var result: T = try reader.readStruct(T);
     try checkEnumFields(&result);
     return result;
 }
 
-pub fn writeStructNative(writer: std.io.StreamSource.Writer, value: anytype) StructWriteError!void {
+pub fn writeStructNative(writer: anytype, value: anytype) StructWriteError!void {
     try writer.writeStruct(value);
 }
 
-pub fn writeStructForeign(writer: std.io.StreamSource.Writer, value: anytype) StructWriteError!void {
+pub fn writeStructForeign(writer: anytype, value: anytype) StructWriteError!void {
     const T = @typeInfo(@TypeOf(value));
     inline for (std.meta.fields(T)) |field| {
         switch (@typeInfo(field.type)) {
@@ -115,7 +115,7 @@ fn swapFieldBytes(data: anytype) StructReadError!void {
     }
 }
 
-pub fn readStructForeign(reader: std.io.StreamSource.Reader, comptime T: type) StructReadError!T {
+pub fn readStructForeign(reader: anytype, comptime T: type) StructReadError!T {
     var result: T = try reader.readStruct(T);
     try swapFieldBytes(&result);
     return result;

--- a/tests/buffered_stream_source_test.zig
+++ b/tests/buffered_stream_source_test.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const buffered_stream_source = @import("../src/buffered_stream_source.zig");
+const helpers = @import("helpers.zig");
+
+const TestFileContents = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+test "BufferedStreamReader should read and seek properly with a file" {
+    const TestFilename = "buffered_stream_reader_test.dat";
+
+    var temp_folder = std.testing.tmpDir(.{});
+    defer temp_folder.cleanup();
+
+    try temp_folder.dir.writeFile(TestFilename, TestFileContents);
+
+    var read_file = try temp_folder.dir.openFile(TestFilename, .{});
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+    var buffered_stream = buffered_stream_source.bufferedStreamSourceReaderWithSize(4, &stream_source);
+
+    const reader = buffered_stream.reader();
+    const seek_stream = buffered_stream.seekableStream();
+
+    const read_inside_buffer = try reader.readBytesNoEof(3);
+    try helpers.expectEq(try seek_stream.getPos(), 3);
+    try helpers.expectEqSlice(u8, read_inside_buffer[0..], TestFileContents[0..3]);
+
+    try seek_stream.seekTo(0);
+
+    const read_beginning_again = try reader.readBytesNoEof(3);
+    try helpers.expectEqSlice(u8, read_inside_buffer[0..], read_beginning_again[0..]);
+
+    try seek_stream.seekBy(-3);
+    try helpers.expectEq(try seek_stream.getPos(), 0);
+
+    try seek_stream.seekBy(5);
+    try helpers.expectEq(try seek_stream.getPos(), 5);
+
+    try seek_stream.seekBy(1);
+    try helpers.expectEq(try seek_stream.getPos(), 6);
+
+    const end_pos = try seek_stream.getEndPos();
+    try helpers.expectEq(end_pos, 36);
+
+    const read_remaining = try reader.readBytesNoEof(30);
+    try helpers.expectEq(try seek_stream.getPos(), try seek_stream.getEndPos());
+    try helpers.expectEqSlice(u8, read_remaining[0..], TestFileContents[6..]);
+}
+
+test "BufferedStreamWriter should read and seek properly with a file" {
+    const TestFilename = "buffered_stream_writer_test.dat";
+
+    const DummyThreeBytes = "abc";
+
+    var temp_folder = std.testing.tmpDir(.{});
+    defer temp_folder.cleanup();
+
+    {
+        var write_file = try temp_folder.dir.createFile(TestFilename, .{});
+        defer write_file.close();
+
+        var stream_source = std.io.StreamSource{ .file = write_file };
+        var buffered_stream = buffered_stream_source.bufferedStreamSourceWriterWithSize(4, &stream_source);
+
+        const writer = buffered_stream.writer();
+        const seek_stream = buffered_stream.seekableStream();
+
+        _ = try writer.write(TestFileContents[0..3]);
+        try helpers.expectEq(try seek_stream.getPos(), 3);
+
+        try seek_stream.seekBy(-3);
+
+        _ = try writer.write(DummyThreeBytes[0..]);
+        try helpers.expectEq(try seek_stream.getPos(), 3);
+
+        _ = try writer.write(TestFileContents[3..]);
+    }
+
+    var read_file = try temp_folder.dir.openFile(TestFilename, .{});
+    defer read_file.close();
+
+    const reader = read_file.reader();
+    var read_contents = try reader.readAllAlloc(std.testing.allocator, 128);
+    defer std.testing.allocator.free(read_contents);
+
+    try helpers.expectEqSlice(u8, read_contents[0..3], DummyThreeBytes[0..]);
+    try helpers.expectEqSlice(u8, read_contents[3..], TestFileContents[3..]);
+}

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -21,6 +21,7 @@ test {
     inline for (.{
         @import("src/formats/png/reader.zig"),
         @import("src/compressions/lzw.zig"),
+        @import("tests/buffered_stream_source_test.zig"),
         @import("tests/color_test.zig"),
         @import("tests/formats/bmp_test.zig"),
         @import("tests/formats/gif_test.zig"),


### PR DESCRIPTION
Introduce `buffered_stream_source` struct that contains `BufferedStreamSourceReader` and `BufferedStreamSourceWriter`. Both can accept an given buffer size. I also added default ones that use a buffer of 4KiB.

The idea is that we keep using `Image.Stream` in the public API as most as possible but each format implementation is strongly recommended to buffered reader and writers to save on kernel mode calls. 

I timed the test suite using Intel VTune using `zig build test -Doptimize=ReleaseFast` and running the test executable directly.

Before:
![image](https://github.com/zigimg/zigimg/assets/112917/67009016-228b-4171-bae4-841c46b3a4d7)

After:
![image](https://github.com/zigimg/zigimg/assets/112917/addc134a-e0a2-4b6e-91ec-26141b5b4e1d)

Closes #55 