### PR TITLE
Fix order of Rgb555 and Rgb565 structs

### DIFF
--- a/src/color.zig
+++ b/src/color.zig
@@ -353,9 +353,9 @@ fn RgbColor(comptime T: type) type {
 // Vulkan: VK_FORMAT_R5G6B5_UNORM_PACK16
 // Direct3D/DXGI: n/a
 pub const Rgb555 = packed struct {
-    r: u5,
-    g: u5,
     b: u5,
+    g: u5,
+    r: u5,
 
     pub usingnamespace RgbMethods(@This(), u5, u5, u5, void);
 };
@@ -365,9 +365,9 @@ pub const Rgb555 = packed struct {
 // Vulkan: n/a
 // Direct3D/DXGI: n/a
 pub const Rgb565 = packed struct {
-    r: u5,
-    g: u6,
     b: u5,
+    g: u6,
+    r: u5,
 
     pub usingnamespace RgbMethods(@This(), u5, u6, u5, void);
 };


### PR DESCRIPTION
`Rgb555` and `Rgb565` were layed out in the wrong order, likely a mistake due to this line in the [langref](https://ziglang.org/documentation/0.11.0/#packed-struct)
\> `Fields remain in the order declared, least to most significant.`

This caused issues when `memcpy`ing a slice of data in zigimg's `Rgb565` type to a linux FB, causing R and B to be visually swapped since the framebuffer expected `Rgb565` and not `Bgr565` (which is what the `Rgb565` type actually was before my commit)