### PR TITLE
Struct utils refactor

### DIFF
--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -281,7 +281,7 @@ pub const BMP = struct {
 
         // Read file header
         const reader = buffered_stream.reader();
-        self.file_header = try utils.readStructLittle(reader, BitmapFileHeader);
+        self.file_header = try utils.readStruct(reader, BitmapFileHeader, .little);
         if (!std.mem.eql(u8, self.file_header.magic_header[0..], BitmapMagicHeader[0..])) {
             return Image.ReadError.InvalidData;
         }
@@ -291,9 +291,9 @@ pub const BMP = struct {
 
         // Read info header
         self.info_header = switch (header_size) {
-            BitmapInfoHeaderWindows31.HeaderSize => BitmapInfoHeader{ .windows31 = try utils.readStructLittle(reader, BitmapInfoHeaderWindows31) },
-            BitmapInfoHeaderV4.HeaderSize => BitmapInfoHeader{ .v4 = try utils.readStructLittle(reader, BitmapInfoHeaderV4) },
-            BitmapInfoHeaderV5.HeaderSize => BitmapInfoHeader{ .v5 = try utils.readStructLittle(reader, BitmapInfoHeaderV5) },
+            BitmapInfoHeaderWindows31.HeaderSize => BitmapInfoHeader{ .windows31 = try utils.readStruct(reader, BitmapInfoHeaderWindows31, .little) },
+            BitmapInfoHeaderV4.HeaderSize => BitmapInfoHeader{ .v4 = try utils.readStruct(reader, BitmapInfoHeaderV4, .little) },
+            BitmapInfoHeaderV5.HeaderSize => BitmapInfoHeader{ .v5 = try utils.readStruct(reader, BitmapInfoHeaderV5, .little) },
             else => return Image.Error.Unsupported,
         };
 
@@ -385,7 +385,7 @@ pub const BMP = struct {
 
             x = 0;
             while (x < pixel_width) : (x += 1) {
-                pixels[@intCast(scanline + x)] = try utils.readStructLittle(reader, ColorBufferType);
+                pixels[@intCast(scanline + x)] = try utils.readStruct(reader, ColorBufferType, .little);
             }
         }
     }

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -30,10 +30,10 @@ pub const CompressionMethod = enum(u32) {
 
 pub const BitmapColorSpace = enum(u32) {
     calibrated_rgb = 0,
-    srgb = utils.toMagicNumberBig("sRGB"),
-    windows_color_space = utils.toMagicNumberBig("Win "),
-    profile_linked = utils.toMagicNumberBig("LINK"),
-    profile_embedded = utils.toMagicNumberBig("MBED"),
+    srgb = utils.toMagicNumber("sRGB", .big),
+    windows_color_space = utils.toMagicNumber("Win ", .big),
+    profile_linked = utils.toMagicNumber("LINK", .big),
+    profile_embedded = utils.toMagicNumber("MBED", .big),
 };
 
 pub const BitmapIntent = enum(u32) {

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -332,14 +332,14 @@ pub const BMP = struct {
 
         const writer = buffered_stream.writer();
 
-        try utils.writeStructLittle(writer, self.file_header);
+        try utils.writeStruct(writer, self.file_header, .little);
 
         switch (self.info_header) {
             .v4 => |v4| {
-                try utils.writeStructLittle(writer, v4);
+                try utils.writeStruct(writer, v4, .little);
             },
             .v5 => |v5| {
-                try utils.writeStructLittle(writer, v5);
+                try utils.writeStruct(writer, v5, .little);
             },
             else => {
                 return Image.WriteError.InvalidData;
@@ -412,7 +412,7 @@ pub const BMP = struct {
 
             x = 0;
             while (x < pixel_width) : (x += 1) {
-                try utils.writeStructLittle(writer, pixels[@intCast(scanline + x)]);
+                try utils.writeStruct(writer, pixels[@intCast(scanline + x)], .little);
             }
         }
     }

--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -268,7 +268,7 @@ pub const GIF = struct {
             .reader = buffered_stream.reader(),
         };
 
-        self.header = try utils.readStructLittle(context.reader, Header);
+        self.header = try utils.readStruct(context.reader, Header, .little);
 
         if (!std.mem.eql(u8, self.header.magic[0..], Magic)) {
             return Image.ReadError.InvalidData;
@@ -295,7 +295,7 @@ pub const GIF = struct {
             var index: usize = 0;
 
             while (index < global_color_table_size) : (index += 1) {
-                self.global_color_table.data[index] = try utils.readStructLittle(context.reader, color.Rgb24);
+                self.global_color_table.data[index] = try utils.readStruct(context.reader, color.Rgb24, .little);
             }
         }
 
@@ -374,7 +374,7 @@ pub const GIF = struct {
                     // Eat block size
                     _ = try context.reader.readByte();
 
-                    graphics_control.flags = try utils.readStructLittle(context.reader, GraphicControlExtensionFlags);
+                    graphics_control.flags = try utils.readStruct(context.reader, GraphicControlExtensionFlags, .little);
                     graphics_control.delay_time = try context.reader.readInt(u16, .little);
 
                     if (graphics_control.flags.has_transparent_color) {
@@ -522,7 +522,7 @@ pub const GIF = struct {
     fn readImageDescriptorAndData(self: *GIF, context: *ReaderContext) Image.ReadError!void {
         if (context.current_frame_data) |current_frame_data| {
             var sub_image = try current_frame_data.allocNewSubImage(self.allocator);
-            sub_image.image_descriptor = try utils.readStructLittle(context.reader, ImageDescriptor);
+            sub_image.image_descriptor = try utils.readStruct(context.reader, ImageDescriptor, .little);
 
             // Don't read any futher if the local width or height is zero
             if (sub_image.image_descriptor.width == 0 or sub_image.image_descriptor.height == 0) {
@@ -537,7 +537,7 @@ pub const GIF = struct {
                 var index: usize = 0;
 
                 while (index < local_color_table_size) : (index += 1) {
-                    sub_image.local_color_table.data[index] = try utils.readStructLittle(context.reader, color.Rgb24);
+                    sub_image.local_color_table.data[index] = try utils.readStruct(context.reader, color.Rgb24, .little);
                 }
             }
 

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -415,7 +415,7 @@ pub const PCX = struct {
     pub fn read(self: *PCX, allocator: Allocator, stream: *Image.Stream) ImageReadError!color.PixelStorage {
         var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
         const reader = buffered_stream.reader();
-        self.header = try utils.readStructLittle(reader, PCXHeader);
+        self.header = try utils.readStruct(reader, PCXHeader, .little);
 
         if (self.header.id != 0x0A) {
             return ImageReadError.InvalidData;

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -565,7 +565,7 @@ pub const PCX = struct {
 
         const writer = buffered_stream.writer();
 
-        try utils.writeStructLittle(writer, self.header);
+        try utils.writeStruct(writer, self.header, .little);
 
         const actual_width = self.width();
         const is_even = ((actual_width & 0x1) == 0);
@@ -588,7 +588,7 @@ pub const PCX = struct {
                 try writer.writeByte(VGAPaletteIdentifier);
                 for (pixels.indexed8.palette) |current_entry| {
                     const rgb24_color = color.Rgb24.fromU32Rgba(current_entry.toU32Rgba());
-                    try utils.writeStructLittle(writer, rgb24_color);
+                    try utils.writeStruct(writer, rgb24_color, .little);
                 }
             },
             .rgb24 => |data| {

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -115,7 +115,7 @@ const IDatChunksReader = struct {
             self.crc.update(png.Chunks.IDAT.name);
 
             // Try to load the next IDAT chunk
-            const chunk = try utils.readStructBig(reader, png.ChunkHeader);
+            const chunk = try utils.readStruct(reader, png.ChunkHeader, .big);
             if (chunk.type == png.Chunks.IDAT.id) {
                 self.remaining_chunk_length = chunk.length;
             } else {
@@ -138,7 +138,7 @@ pub fn loadHeader(stream: *Image.Stream) Image.ReadError!png.HeaderData {
         return Image.ReadError.InvalidData;
     }
 
-    const chunk = try utils.readStructBig(reader, png.ChunkHeader);
+    const chunk = try utils.readStruct(reader, png.ChunkHeader, .big);
     if (chunk.type != png.Chunks.IHDR.id) return Image.ReadError.InvalidData;
     if (chunk.length != @sizeOf(png.HeaderData)) return Image.ReadError.InvalidData;
 
@@ -147,7 +147,7 @@ pub fn loadHeader(stream: *Image.Stream) Image.ReadError!png.HeaderData {
 
     var struct_stream = std.io.fixedBufferStream(&header_data);
 
-    const header = try utils.readStructBig(struct_stream.reader(), png.HeaderData);
+    const header = try utils.readStruct(struct_stream.reader(), png.HeaderData, .big);
     if (!header.isValid()) return Image.ReadError.InvalidData;
 
     const expected_crc = try reader.readInt(u32, .big);
@@ -213,7 +213,7 @@ pub fn loadWithHeader(
     var reader = buffered_stream.reader();
 
     while (true) {
-        const chunk = (try utils.readStructBig(reader, png.ChunkHeader));
+        const chunk = (try utils.readStruct(reader, png.ChunkHeader, .big));
         chunk_process_data.chunk_id = chunk.type;
         chunk_process_data.chunk_length = chunk.length;
 
@@ -689,7 +689,7 @@ pub const TrnsProcessor = struct {
             },
             .rgb24, .rgb48 => {
                 if (data.chunk_length == @sizeOf(color.Rgb48)) {
-                    self.trns_data = .{ .rgb = try utils.readStructBig(reader, color.Rgb48) };
+                    self.trns_data = .{ .rgb = try utils.readStruct(reader, color.Rgb48, .big) };
                     result_format = if (result_format == .rgb48) .rgba64 else .rgba32;
                 } else {
                     try data.stream.seekBy(data.chunk_length); // Skip invalid

--- a/src/formats/qoi.zig
+++ b/src/formats/qoi.zig
@@ -199,7 +199,7 @@ pub const QOI = struct {
             return ImageReadError.InvalidData;
         }
 
-        self.header = utils.readStructBig(reader, Header) catch return ImageReadError.InvalidData;
+        self.header = utils.readStruct(reader, Header, .big) catch return ImageReadError.InvalidData;
 
         const pixel_format = try self.pixelFormat();
 

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -1077,7 +1077,7 @@ pub const TGA = struct {
         var buffered_stream = buffered_stream_source.bufferedStreamSourceWriter(stream);
         const writer = buffered_stream.writer();
 
-        try utils.writeStructLittle(writer, self.header);
+        try utils.writeStruct(writer, self.header, .little);
 
         if (self.header.id_length > 0) {
             if (self.id.data.len != self.header.id_length) {
@@ -1113,13 +1113,13 @@ pub const TGA = struct {
         if (self.extension) |extension| {
             extension_offset = @truncate(try buffered_stream.getPos());
 
-            try utils.writeStructLittle(writer, extension);
+            try utils.writeStruct(writer, extension, .little);
         }
 
         var footer = TGAFooter{};
         footer.extension_offset = extension_offset;
         std.mem.copyForwards(u8, footer.signature[0..], TGASignature[0..]);
-        try utils.writeStructLittle(writer, footer);
+        try utils.writeStruct(writer, footer, .little);
 
         try buffered_stream.flush();
     }
@@ -1357,7 +1357,7 @@ pub const TGA = struct {
                 .b = indexed.palette[data_index].b,
             };
 
-            try utils.writeStructLittle(writer, converted_color);
+            try utils.writeStruct(writer, converted_color, .little);
         }
     }
 };

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -186,7 +186,7 @@ const TargaRLEDecoder = struct {
         var read_count: usize = 0;
 
         if (self.state == .read_header) {
-            const packet_header = try utils.readStructLittle(self.source_reader, RLEPacketHeader);
+            const packet_header = try utils.readStruct(self.source_reader, RLEPacketHeader, .little);
 
             if (packet_header.packet_type == .repeated) {
                 self.state = .repeated;
@@ -587,7 +587,7 @@ pub const TGA = struct {
                 const footer_position = end_pos - @sizeOf(TGAFooter);
 
                 try buffered_stream.seekTo(footer_position);
-                const footer = try utils.readStructLittle(buffered_stream.reader(), TGAFooter);
+                const footer = try utils.readStruct(buffered_stream.reader(), TGAFooter, .little);
 
                 if (footer.dot != '.') {
                     break :blk false;
@@ -610,7 +610,7 @@ pub const TGA = struct {
             if (!is_valid_tga_v2 and @sizeOf(TGAHeader) < end_pos) {
                 try buffered_stream.seekTo(0);
 
-                const header = try utils.readStructLittle(buffered_stream.reader(), TGAHeader);
+                const header = try utils.readStruct(buffered_stream.reader(), TGAHeader, .little);
                 break :blk header.isValid();
             }
 
@@ -786,7 +786,7 @@ pub const TGA = struct {
 
         const reader = buffered_stream.reader();
         try buffered_stream.seekTo(end_pos - @sizeOf(TGAFooter));
-        const footer = try utils.readStructLittle(reader, TGAFooter);
+        const footer = try utils.readStruct(reader, TGAFooter, .little);
 
         var is_tga_version2 = true;
 
@@ -798,12 +798,12 @@ pub const TGA = struct {
         if (is_tga_version2 and footer.extension_offset > 0) {
             const extension_pos: u64 = @intCast(footer.extension_offset);
             try buffered_stream.seekTo(extension_pos);
-            self.extension = try utils.readStructLittle(reader, TGAExtension);
+            self.extension = try utils.readStruct(reader, TGAExtension, .little);
         }
 
         // Read header
         try buffered_stream.seekTo(0);
-        self.header = try utils.readStructLittle(reader, TGAHeader);
+        self.header = try utils.readStruct(reader, TGAHeader, .little);
 
         if (!self.header.isValid()) {
             return Image.ReadError.InvalidData;
@@ -954,7 +954,7 @@ pub const TGA = struct {
         const data_end: usize = self.header.color_map_spec.first_entry_index + self.header.color_map_spec.length;
 
         while (data_index < data_end) : (data_index += 1) {
-            const read_color = try utils.readStructLittle(reader, color.Rgb555);
+            const read_color = try utils.readStruct(reader, color.Rgb555, .little);
 
             data.palette[data_index].r = color.scaleToIntColor(u8, read_color.r);
             data.palette[data_index].g = color.scaleToIntColor(u8, read_color.g);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -136,16 +136,15 @@ pub fn readStructForeign(reader: anytype, comptime T: type) StructReadError!T {
 }
 
 pub inline fn readStruct(reader: anytype, comptime T: type, comptime wanted_endian: std.builtin.Endian) StructReadError!T {
-    return switch(native_endian)
-    {
+    return switch (native_endian) {
         .little => {
-            return switch(wanted_endian) {
+            return switch (wanted_endian) {
                 .little => readStructNative(reader, T),
                 .big => readStructForeign(reader, T),
             };
         },
         .big => {
-            return switch(wanted_endian) {
+            return switch (wanted_endian) {
                 .little => readStructForeign(reader, T),
                 .big => readStructNative(reader, T),
             };
@@ -153,12 +152,19 @@ pub inline fn readStruct(reader: anytype, comptime T: type, comptime wanted_endi
     };
 }
 
-pub const writeStructLittle = switch (native_endian) {
-    .little => writeStructNative,
-    .big => writeStructForeign,
-};
-
-pub const writeStructBig = switch (native_endian) {
-    .little => writeStructForeign,
-    .big => writeStructNative,
-};
+pub inline fn writeStruct(writer: anytype, value: anytype, comptime wanted_endian: std.builtin.Endian) StructWriteError!void {
+    return switch (native_endian) {
+        .little => {
+            return switch (wanted_endian) {
+                .little => writeStructNative(writer, value),
+                .big => writeStructForeign(writer, value),
+            };
+        },
+        .big => {
+            return switch (wanted_endian) {
+                .little => writeStructForeign(writer, value),
+                .big => writeStructNative(writer, value),
+            };
+        },
+    };
+}

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -35,15 +35,22 @@ pub fn toMagicNumberForeign(magic: []const u8) u32 {
     return result;
 }
 
-pub const toMagicNumberBig = switch (native_endian) {
-    .little => toMagicNumberForeign,
-    .big => toMagicNumberNative,
-};
-
-pub const toMagicNumberLittle = switch (native_endian) {
-    .little => toMagicNumberNative,
-    .big => toMagicNumberForeign,
-};
+pub inline fn toMagicNumber(magic: []const u8, comptime wanted_endian: std.builtin.Endian) u32 {
+      return switch (native_endian) {
+        .little => {
+            return switch (wanted_endian) {
+                .little => toMagicNumberNative(magic),
+                .big => toMagicNumberForeign(magic),
+            };
+        },
+        .big => {
+            return switch (wanted_endian) {
+                .little => toMagicNumberForeign(magic),
+                .big => toMagicNumberNative(magic),
+            };
+        },
+    };
+}
 
 fn checkEnumFields(data: anytype) StructReadError!void {
     const T = @typeInfo(@TypeOf(data)).Pointer.child;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -36,7 +36,7 @@ pub fn toMagicNumberForeign(magic: []const u8) u32 {
 }
 
 pub inline fn toMagicNumber(magic: []const u8, comptime wanted_endian: std.builtin.Endian) u32 {
-      return switch (native_endian) {
+    return switch (native_endian) {
         .little => {
             return switch (wanted_endian) {
                 .little => toMagicNumberNative(magic),


### PR DESCRIPTION
Refactor the utils `readStruct`, `writeStruct`, `toMagicNumber` to be consistent with the new `readInt`, `writeInt` API in `std.io`