### PR TITLE
Fix integer overflow in GIF

### DIFF
--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -541,7 +541,7 @@ pub const GIF = struct {
                 }
             }
 
-            sub_image.pixels = try self.allocator.alloc(u8, sub_image.image_descriptor.height * sub_image.image_descriptor.width);
+            sub_image.pixels = try self.allocator.alloc(u8, @as(usize, sub_image.image_descriptor.height) * @as(usize, sub_image.image_descriptor.width));
             var pixels_buffer = std.io.fixedBufferStream(sub_image.pixels);
 
             const lzw_minimum_code_size = try context.reader.readByte();

--- a/tests/formats/gif_test.zig
+++ b/tests/formats/gif_test.zig
@@ -58,6 +58,32 @@ test "GIF test suite" {
     }
 }
 
+test "Rotating Earth GIF" {
+    const gif_input_file = try helpers.testOpenFile(helpers.fixtures_path ++ "gif/rotating_earth.gif");
+    defer gif_input_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = gif_input_file };
+
+    var gif_file = gif.GIF.init(helpers.zigimg_test_allocator);
+    defer gif_file.deinit();
+
+    var frames = try gif_file.read(&stream_source);
+    defer {
+        for (frames.items) |entry| {
+            entry.pixels.deinit(gif_file.allocator);
+        }
+        frames.deinit(gif_file.allocator);
+    }
+
+    try helpers.expectEq(gif_file.header.width, 400);
+    try helpers.expectEq(gif_file.header.height, 400);
+
+    try helpers.expectEq(frames.items.len, 44);
+
+    try helpers.expectEq(frames.items[0].pixels.indexed8.indices[10], 106);
+    try helpers.expectEq(frames.items[0].pixels.indexed8.indices[399 * 400 + 382], 8);
+}
+
 test "Iterate on a single GIF file" {
     if (!SingleGifFileTest) {
         return error.SkipZigTest;


### PR DESCRIPTION
Fix integer overflow in GIF and add a test that read the rotating earth GIF from the GIF wikipedia entry

Closes #150 