### PR TITLE
Fixes #152 loding of trns after plte

### DIFF
--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -670,7 +670,7 @@ pub const TrnsProcessor = struct {
             return result_format;
         }
         var reader = data.stream.reader();
-        switch (result_format) {
+        switch (data.header.getPixelFormat()) {
             .grayscale1, .grayscale2, .grayscale4, .grayscale8, .grayscale16 => {
                 if (data.chunk_length == 2) {
                     self.trns_data = .{ .gray = try reader.readInt(u16, .big) };

--- a/tests/formats/png_test.zig
+++ b/tests/formats/png_test.zig
@@ -171,8 +171,8 @@ pub fn testWithDir(directory: []const u8, testMd5Sig: bool) !void {
             if (testMd5Sig) std.debug.print("OK\n", .{});
 
             // Write Raw bytes
-            // std.mem.copy(u8, tst_data_name[len - 3 .. len + 1], "data");
-            // var rawoutput = try idir.dir.createFile(tst_data_name[0 .. len + 1], .{});
+            // std.mem.copyForwards(u8, tst_data_name[len - 3 .. len + 1], "data");
+            // var rawoutput = try idir.createFile(tst_data_name[0 .. len + 1], .{});
             // defer rawoutput.close();
             // try rawoutput.writeAll(result_bytes);
         }


### PR DESCRIPTION
The issue was for the image that has PLTE and  tRNS chunk. PlteProcessor would would modify the destination format to rgba32 but when it came turn for TrnsProcessor to run it would see rgba32 and not do anything. The fix was for TrnsProcessor to look at the source format instead of destination format.