### PR TITLE
Png out of memory fix

### DIFF
--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -191,10 +191,6 @@ pub fn loadWithHeader(
 ) Image.ReadError!PixelStorage {
     var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
     var options = in_options;
-    var temp_allocator = options.temp_allocator;
-    var fb_allocator = std.heap.FixedBufferAllocator.init(try temp_allocator.alloc(u8, required_temp_bytes));
-    defer temp_allocator.free(fb_allocator.buffer);
-    options.temp_allocator = fb_allocator.allocator();
 
     var palette: []color.Rgb24 = &[_]color.Rgb24{};
     var data_found = false;


### PR DESCRIPTION
Png reader used to internally wrap the provided temp_allocator with FixedBufferAllocator so that it can take all the needed memory from it in one allocation and prevent memory fragmentation. This is probably unneeded optimization and it creates a problem now that zig zlib implementation has no fixed bound on memory allocations.

It also returned any error from the decompressor as ImageError.InvalidData so I fixed it so that only InflateErrors are replaced with InvalidData.