### PR TITLE
fix compile error for 32-bit builds like Wasm, "self.buffered_reader.start -%= absolute_amt" expected type 'usize', found 'u64

### DIFF
--- a/src/buffered_stream_source.zig
+++ b/src/buffered_stream_source.zig
@@ -69,8 +69,9 @@ pub fn BufferedStreamSourceReader(comptime BufferSize: usize) type {
                         }
                     } else if (amt < 0) {
                         const absolute_amt = @abs(amt);
-                        if (absolute_amt <= self.buffered_reader.start) {
-                            self.buffered_reader.start -%= absolute_amt;
+                        const absolute_amt_usize = std.math.cast(usize, absolute_amt) orelse std.math.maxInt(usize);
+                        if (absolute_amt_usize <= self.buffered_reader.start) {
+                            self.buffered_reader.start -%= absolute_amt_usize;
                         } else {
                             try self.buffered_reader.unbuffered_reader.context.seekBy(amt - @as(i64, @intCast(bytes_availables)));
                             self.resetBufferedReader();


### PR DESCRIPTION
Fix compile error on `self.buffered_reader.start -%= absolute_amt` expected type 'usize', found 'u64' for 32-bit builds, like Wasm.

Copied the solution from the standard library and how they deal with large amount values:
```zig
const abs_amt = @abs(amt);
const abs_amt_usize = std.math.cast(usize, abs_amt) orelse std.math.maxInt(usize);
```
Source: https://github.com/ziglang/zig/blob/bcf4a1391331e52e4a06528530316970ded75c74/lib/std/io/fixed_buffer_stream.zig#L85