### PR TITLE
Use the new std library zlib compression/decompression from https://github.com/ziglang/zig/pull/18923

### DIFF
--- a/src/formats/png/InfoProcessor.zig
+++ b/src/formats/png/InfoProcessor.zig
@@ -95,7 +95,7 @@ fn processChunk(self: *Self, data: *ChunkProcessData) Image.ReadError!PixelForma
                     self.writer.print("           Compression: Zlib Deflate\n", .{}) catch return result_format;
                     self.writer.print("                  Text: ", .{}) catch return result_format;
                     try data.stream.seekBy(@as(i64, @intCast(strEnd)) + 2 - to_read);
-                    var decompressStream = std.compress.zlib.decompressStream(data.temp_allocator, reader) catch return error.InvalidData;
+                    var decompressStream = std.compress.zlib.decompressor(reader);
                     var print_buf: [1024]u8 = undefined;
                     var got = decompressStream.read(print_buf[0..]) catch return error.InvalidData;
                     while (got > 0) {

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -46,7 +46,11 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
             .specified => |f| f,
         };
 
-        writer.writeByte(@intFromEnum(filter_type)) catch unreachable;
+        writer.writeByte(@intFromEnum(filter_type)) catch |err| {
+            switch (err) {
+                else => return error.AccessDenied,
+            }
+        };
 
         for (0..scanline.asBytes().len) |byte_index| {
             const i = if (builtin.target.cpu.arch.endian() == .little) pixelByteSwappedIndex(scanline, byte_index) else byte_index;
@@ -64,7 +68,11 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
                 .paeth => sample -% paeth(previous, above, above_previous),
             };
 
-            writer.writeByte(byte) catch unreachable;
+            writer.writeByte(byte) catch |err| {
+                switch (err) {
+                    else => return error.AccessDenied,
+                }
+            };
         }
         previous_scanline = scanline;
     }

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -46,7 +46,7 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
             .specified => |f| f,
         };
 
-        try writer.writeByte(@intFromEnum(filter_type));
+        writer.writeByte(@intFromEnum(filter_type)) catch unreachable;
 
         for (0..scanline.asBytes().len) |byte_index| {
             const i = if (builtin.target.cpu.arch.endian() == .little) pixelByteSwappedIndex(scanline, byte_index) else byte_index;
@@ -64,7 +64,7 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
                 .paeth => sample -% paeth(previous, above, above_previous),
             };
 
-            try writer.writeByte(byte);
+            writer.writeByte(byte) catch unreachable;
         }
         previous_scanline = scanline;
     }

--- a/src/formats/png/zlib_compressor.zig
+++ b/src/formats/png/zlib_compressor.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const io = std.io;
-const deflate = std.compress.deflate;
+const deflate = std.compress.flate;
 
 /// Zlib Compressor (Deflate) with a writer interface
 pub fn ZlibCompressor(comptime WriterType: type) type {
@@ -15,8 +15,9 @@ pub fn ZlibCompressor(comptime WriterType: type) type {
         /// Inits a zlibcompressor
         /// This is made this way because not doing it in place segfaults for a reason
         pub fn init(self: *Self, alloc: std.mem.Allocator, stream: WriterType) !void {
+            _ = alloc; // autofix
             self.raw_writer = stream;
-            self.compressor = try deflate.compressor(alloc, self.raw_writer, .{});
+            self.compressor = try deflate.compressor(self.raw_writer, .{});
             self.adler = std.hash.Adler32.init();
         }
 
@@ -38,7 +39,7 @@ pub fn ZlibCompressor(comptime WriterType: type) type {
             try wr.writeByte(compression_flags);
         }
 
-        pub const Error = WriterType.Error;
+        pub const Error = WriterType.Error || error{UnfinishedBits};
         pub const Writer = std.io.Writer(*Self, Error, write);
 
         pub fn writer(self: *Self) Writer {
@@ -53,8 +54,8 @@ pub fn ZlibCompressor(comptime WriterType: type) type {
 
         /// Ends a zlib block with the checksum
         pub fn end(self: *Self) !void {
-            try self.compressor.close();
-            self.compressor.deinit();
+            // try self.compressor.close();
+            // self.compressor.deinit();
             // Write the checksum
             try self.raw_writer.writeInt(u32, self.adler.final(), .big);
         }


### PR DESCRIPTION
As you may or may not be aware, a first principles rewrite of zlib and deflate has been implemented in a recent PR to the std library (https://github.com/ziglang/zig/pull/18923). This has replaced the old implementation that zigimg was using. 

I don't know if you want zigimg to be this up to date with zig master but this is how I'm using it anyhow. 

Excuse my naivety (or incompetence) but I have had issues getting the rather lengthy error set for ```png.reader.readAllData()``` to cohere with the new error sets for the new decompressor functions. As such, there is still a single failing test in the test-suite for pngs, which expects a certain error which isn't being returned for some reason, so I could use some help there. 