### PR TITLE
Fix building on 32-bit systems with valid left-shift size

### DIFF
--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -123,6 +123,8 @@ const InterlacePasses = [_]struct { start: usize, step: usize }{
     .{ .start = 1, .step = 2 },
 };
 
+const ColorTableShiftType = if (@sizeOf(usize) == 4) u5 else u6;
+
 pub const GIF = struct {
     header: Header = .{},
     global_color_table: utils.FixedStorage(color.Rgb24, 256) = .{},
@@ -287,7 +289,7 @@ pub const GIF = struct {
             return Image.ReadError.InvalidData;
         }
 
-        const global_color_table_size = @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(self.header.flags.global_color_table_size)) + 1);
+        const global_color_table_size = @as(usize, 1) << (@as(ColorTableShiftType, @intCast(self.header.flags.global_color_table_size)) + 1);
 
         self.global_color_table.resize(global_color_table_size);
 
@@ -529,7 +531,7 @@ pub const GIF = struct {
                 return;
             }
 
-            const local_color_table_size = @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
+            const local_color_table_size = @as(usize, 1) << (@as(ColorTableShiftType, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
 
             sub_image.local_color_table.resize(local_color_table_size);
 
@@ -970,7 +972,7 @@ pub const GIF = struct {
         var total_color_count: usize = 0;
 
         if (self.header.flags.use_global_color_table) {
-            total_color_count = @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(self.header.flags.global_color_table_size)) + 1);
+            total_color_count = @as(usize, 1) << (@as(ColorTableShiftType, @intCast(self.header.flags.global_color_table_size)) + 1);
         }
 
         var use_transparency: bool = false;
@@ -988,7 +990,7 @@ pub const GIF = struct {
 
             for (frame.sub_images.items) |sub_image| {
                 if (sub_image.image_descriptor.flags.has_local_color_table) {
-                    color_per_frame += @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
+                    color_per_frame += @as(usize, 1) << (@as(ColorTableShiftType, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
                 }
             }
 

--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -287,7 +287,7 @@ pub const GIF = struct {
             return Image.ReadError.InvalidData;
         }
 
-        const global_color_table_size = @as(usize, 1) << (@as(u6, @intCast(self.header.flags.global_color_table_size)) + 1);
+        const global_color_table_size = @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(self.header.flags.global_color_table_size)) + 1);
 
         self.global_color_table.resize(global_color_table_size);
 
@@ -529,7 +529,7 @@ pub const GIF = struct {
                 return;
             }
 
-            const local_color_table_size = @as(usize, 1) << (@as(u6, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
+            const local_color_table_size = @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
 
             sub_image.local_color_table.resize(local_color_table_size);
 
@@ -970,7 +970,7 @@ pub const GIF = struct {
         var total_color_count: usize = 0;
 
         if (self.header.flags.use_global_color_table) {
-            total_color_count = @as(usize, 1) << (@as(u6, @intCast(self.header.flags.global_color_table_size)) + 1);
+            total_color_count = @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(self.header.flags.global_color_table_size)) + 1);
         }
 
         var use_transparency: bool = false;
@@ -988,7 +988,7 @@ pub const GIF = struct {
 
             for (frame.sub_images.items) |sub_image| {
                 if (sub_image.image_descriptor.flags.has_local_color_table) {
-                    color_per_frame += @as(usize, 1) << (@as(u6, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
+                    color_per_frame += @as(usize, 1) << (@as(if (@sizeOf(usize) == 4) u5 else u6, @intCast(sub_image.image_descriptor.flags.local_color_table_size)) + 1);
                 }
             }
 


### PR DESCRIPTION
I couldn't build the project for WASM (32-bit) as this is the error I would get:
![image](https://github.com/zigimg/zigimg/assets/60631511/7b5fa4d1-7158-427f-9155-9793913ea318)

Presumably this is the same for building to other 32-bit systems.

I am not sure whether my pull request is the right way to do it. I am willing to make changes if there is a better way to do it, this is just what worked for me.