### PR TITLE
Implement RGB colorspaces and various new color model and color spaces

### DIFF
--- a/src/color.zig
+++ b/src/color.zig
@@ -1055,7 +1055,7 @@ pub const CIExyY = struct {
     }
 };
 
-pub const ConversionMatrix = [3]@Vector(3, f32);
+pub const ConversionMatrix = [4]@Vector(4, f32);
 
 // Colorspaces are defined in the CIE xyY colorspace, requiring only the x and y value
 pub const Colorspace = struct {
@@ -1074,10 +1074,42 @@ pub const Colorspace = struct {
         const w = 1.0 - u - v;
 
         return .{
-            u * (self.red.x / self.white.y),   v * (self.green.x / self.white.y),   w * (self.blue.x / self.white.y),
-            u * (self.red.y / self.white.y),   v * (self.green.y / self.white.y),   w * (self.blue.y / self.white.y),
-            u * (self.red.z() / self.white.y), v * (self.green.z() / self.white.y), w * (self.blue.z() / self.white.y),
+            u * (self.red.x / self.white.y),   v * (self.green.x / self.white.y),   w * (self.blue.x / self.white.y),   0.0,
+            u * (self.red.y / self.white.y),   v * (self.green.y / self.white.y),   w * (self.blue.y / self.white.y),   0.0,
+            u * (self.red.z() / self.white.y), v * (self.green.z() / self.white.y), w * (self.blue.z() / self.white.y), 0.0,
+            0.0,                               0.0,                                 0.0,                                1.0,
         };
+    }
+
+    pub fn convertToXYZ(self: Colorspace, color: Colorf32) CIEXYZ {
+        const conversion_matrix = self.toXYZConversionMatrix();
+
+        const color_vertex = @as(@Vector(4, f32), @bitCast(color));
+
+        return .{
+            .x = color_vertex * conversion_matrix[0],
+            .y = color_vertex * conversion_matrix[1],
+            .z = color_vertex * conversion_matrix[2],
+        };
+    }
+
+    pub fn convertColor(self: Colorspace, color: Colorf32) Colorf32 {
+        const conversion_matrix = self.toXYZConversionMatrix();
+
+        const color_vertex = @as(@Vector(4, f32), @bitCast(color));
+
+        const xyz_color: @Vector(4, f32) = undefined;
+        xyz_color[0] = color_vertex * conversion_matrix[0];
+        xyz_color[1] = color_vertex * conversion_matrix[1];
+        xyz_color[2] = color_vertex * conversion_matrix[2];
+        xyz_color[3] = color_vertex[3];
+
+        return color;
+    }
+
+    pub fn convertColors(self: Colorspace, colors: []Colorf32) void {
+        _ = colors;
+        _ = self;
     }
 };
 

--- a/src/color.zig
+++ b/src/color.zig
@@ -112,11 +112,11 @@ pub const Colorf32 = extern struct {
         return self.toRgba(u16);
     }
 
-    pub fn toArray(self: Colorf32) [4]f32 {
+    pub inline fn toArray(self: Colorf32) [4]f32 {
         return @bitCast(self);
     }
 
-    pub fn fromArray(value: [4]f32) Colorf32 {
+    pub inline fn fromArray(value: [4]f32) Colorf32 {
         return @bitCast(value);
     }
 
@@ -1286,8 +1286,32 @@ pub const Colorspace = struct {
         return CIEXYZAlpha.fromFloat4(result);
     }
 
+    pub fn fromLab(self: Colorspace, lab: CIELab) Colorf32 {
+        const xyz = lab.toXYZ(self.white);
+
+        const conversion_matrix = self.toXYZConversionMatrix().inverse();
+
+        const xyz_float4 = math.float4{ xyz.x, xyz.y, xyz.z, 1.0 };
+
+        const result = conversion_matrix.mulVector(xyz_float4);
+
+        return Colorf32.fromArray(result);
+    }
+
     pub fn toLab(self: Colorspace, color: Colorf32) CIELab {
         return CIELab.fromXYZ(self.toXYZ(color), self.white);
+    }
+
+    pub fn fromLabAlpha(self: Colorspace, lab: CIELabAlpha) Colorf32 {
+        const xyza = lab.toXYZAlpha(self.white);
+
+        const conversion_matrix = self.toXYZConversionMatrix().inverse();
+
+        const xyza_float4 = @as(math.float4, @bitCast(xyza));
+
+        const result = conversion_matrix.mulVector(xyza_float4);
+
+        return Colorf32.fromArray(result);
     }
 
     pub fn toLabAlpha(self: Colorspace, color: Colorf32) CIELabAlpha {

--- a/src/color.zig
+++ b/src/color.zig
@@ -1148,7 +1148,7 @@ pub const CIELab = extern struct {
     }
 
     pub fn toXYZ(self: CIELab, white_point: CIExyY) CIEXYZ {
-        // Math from http://www.brucelindbloom.com/index.html?Eqn_RGB_to_XYZ.html
+        // Math from http://www.brucelindbloom.com/Eqn_Lab_to_XYZ.html
         const white_point_xyz = white_point.toXYZ(1.0);
 
         const scaled_l = self.l * 100.0;

--- a/src/color.zig
+++ b/src/color.zig
@@ -1896,10 +1896,6 @@ pub const CIExyY = struct {
     }
 };
 
-pub fn gammaNoTransfer(value: f32) f32 {
-    return value;
-}
-
 // Colorspaces are defined in the CIE xyY colorspace, requiring only the x and y value
 pub const Colorspace = struct {
     red: CIExyY,
@@ -2495,6 +2491,7 @@ pub const Colorspace = struct {
     }
 
     fn toXYZConversionMatrix(self: Colorspace) ConversionMatrix {
+        // Adapted from http://docs-hoffmann.de/ciexyz29082000.pdf
         const D = (self.red.x - self.blue.x) * (self.green.y - self.blue.y) - (self.red.y - self.blue.y) * (self.green.x - self.blue.x);
         const U = (self.white.x - self.blue.x) * (self.green.y - self.blue.y) - (self.white.y - self.blue.y) * (self.green.x - self.blue.x);
         const V = (self.red.x - self.blue.x) * (self.white.y - self.blue.y) - (self.red.y - self.blue.y) * (self.white.x - self.blue.x);
@@ -2552,6 +2549,10 @@ pub const Colorspace = struct {
 
         return target_to_rgb_matrix.mul(chromatic_adaptation_matrix).mul(source_to_xyz_matrix);
     }
+
+    fn gammaNoTransfer(value: f32) f32 {
+        return value;
+    }
 };
 
 pub inline fn applyGamma(value: f32, gamma: f32) f32 {
@@ -2601,7 +2602,7 @@ pub fn NonLinearGammaTransferFunctions(comptime params: GammaFunctionsParameters
     };
 }
 
-pub fn GammaTransferFunctions(comptime gamma: f32) type {
+pub fn CurveGammaTransferFunctions(comptime gamma: f32) type {
     return struct {
         pub fn toGamma(value: f32) f32 {
             return applyGamma(value, gamma);
@@ -2666,8 +2667,8 @@ pub const ProPhotoRGB_TransferFunctions = NonLinearGammaTransferFunctions(.{
     .display_gamma = 1.8,
 });
 
-pub const DCIP3_TransferFuntions = GammaTransferFunctions(13.0 / 5.0);
-pub const AdobeRGB_TransferFunctions = GammaTransferFunctions(563.0 / 256.0);
+pub const DCIP3_TransferFuntions = CurveGammaTransferFunctions(13.0 / 5.0);
+pub const AdobeRGB_TransferFunctions = CurveGammaTransferFunctions(563.0 / 256.0);
 
 pub const WhitePoints = struct {
     pub const D50 = CIExyY{ .x = 0.34567, .y = 0.35850 };

--- a/src/color.zig
+++ b/src/color.zig
@@ -37,18 +37,16 @@ pub const Colorf32 = extern struct {
     b: f32 align(1) = 0.0,
     a: f32 align(1) = 1.0,
 
-    const Self = @This();
-
-    pub fn initRgb(r: f32, g: f32, b: f32) Self {
-        return Self{
+    pub fn initRgb(r: f32, g: f32, b: f32) Colorf32 {
+        return .{
             .r = r,
             .g = g,
             .b = b,
         };
     }
 
-    pub fn initRgba(r: f32, g: f32, b: f32, a: f32) Self {
-        return Self{
+    pub fn initRgba(r: f32, g: f32, b: f32, a: f32) Colorf32 {
+        return .{
             .r = r,
             .g = g,
             .b = b,
@@ -56,8 +54,8 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn fromU32Rgba(value: u32) Self {
-        return Self{
+    pub fn fromU32Rgba(value: u32) Colorf32 {
+        return .{
             .r = toF32Color(@as(u8, @truncate(value >> 24))),
             .g = toF32Color(@as(u8, @truncate(value >> 16))),
             .b = toF32Color(@as(u8, @truncate(value >> 8))),
@@ -65,15 +63,15 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn toU32Rgba(self: Self) u32 {
+    pub fn toU32Rgba(self: Colorf32) u32 {
         return @as(u32, toIntColor(u8, self.r)) << 24 |
             @as(u32, toIntColor(u8, self.g)) << 16 |
             @as(u32, toIntColor(u8, self.b)) << 8 |
             @as(u32, toIntColor(u8, self.a));
     }
 
-    pub fn fromU64Rgba(value: u64) Self {
-        return Self{
+    pub fn fromU64Rgba(value: u64) Colorf32 {
+        return .{
             .r = toF32Color(@as(u16, @truncate(value >> 48))),
             .g = toF32Color(@as(u16, @truncate(value >> 32))),
             .b = toF32Color(@as(u16, @truncate(value >> 16))),
@@ -81,15 +79,15 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn toU64Rgba(self: Self) u64 {
+    pub fn toU64Rgba(self: Colorf32) u64 {
         return @as(u64, toIntColor(u16, self.r)) << 48 |
             @as(u64, toIntColor(u16, self.g)) << 32 |
             @as(u64, toIntColor(u16, self.b)) << 16 |
             @as(u64, toIntColor(u16, self.a));
     }
 
-    pub fn toPremultipliedAlpha(self: Self) Self {
-        return Self{
+    pub fn toPremultipliedAlpha(self: Colorf32) Colorf32 {
+        return .{
             .r = self.r * self.a,
             .g = self.g * self.a,
             .b = self.b * self.a,
@@ -97,7 +95,7 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn toRgba(self: Self, comptime T: type) RgbaColor(T) {
+    pub fn toRgba(self: Colorf32, comptime T: type) RgbaColor(T) {
         return .{
             .r = toIntColor(T, self.r),
             .g = toIntColor(T, self.g),
@@ -106,23 +104,23 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn toRgba32(self: Self) Rgba32 {
+    pub fn toRgba32(self: Colorf32) Rgba32 {
         return self.toRgba(u8);
     }
 
-    pub fn toRgba64(self: Self) Rgba64 {
+    pub fn toRgba64(self: Colorf32) Rgba64 {
         return self.toRgba(u16);
     }
 
-    pub fn toArray(self: Self) [4]f32 {
+    pub fn toArray(self: Colorf32) [4]f32 {
         return @bitCast(self);
     }
 
-    pub fn fromArray(value: [4]f32) Self {
+    pub fn fromArray(value: [4]f32) Colorf32 {
         return @bitCast(value);
     }
 
-    pub fn toLinear(self: Self) Self {
+    pub fn toLinear(self: Colorf32) Colorf32 {
         return .{
             .r = srgbToLinear(self.r),
             .g = srgbToLinear(self.g),
@@ -131,7 +129,7 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn toLinearFast(self: Self) Self {
+    pub fn toLinearFast(self: Colorf32) Colorf32 {
         return .{
             .r = srgbToLinearFast(self.r),
             .g = srgbToLinearFast(self.g),
@@ -140,7 +138,7 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn toSrgb(self: Self) Self {
+    pub fn toSrgb(self: Colorf32) Colorf32 {
         return .{
             .r = linearToSrgb(self.r),
             .g = linearToSrgb(self.g),
@@ -149,7 +147,7 @@ pub const Colorf32 = extern struct {
         };
     }
 
-    pub fn toSrgbFast(self: Self) Self {
+    pub fn toSrgbFast(self: Colorf32) Colorf32 {
         return .{
             .r = linearToSrgbFast(self.r),
             .g = linearToSrgbFast(self.g),

--- a/src/color.zig
+++ b/src/color.zig
@@ -1263,6 +1263,16 @@ pub const Colorspace = struct {
         });
     }
 
+    pub fn fromXYZ(self: Colorspace, xyz: CIEXYZ) Colorf32 {
+        const conversion_matrix = self.toXYZConversionMatrix().inverse();
+
+        const xyz_float4 = math.float4{ xyz.x, xyz.y, xyz.z, 1.0 };
+
+        const result = conversion_matrix.mulVector(xyz_float4);
+
+        return Colorf32.fromArray(result);
+    }
+
     pub fn toXYZ(self: Colorspace, color: Colorf32) CIEXYZ {
         const conversion_matrix = self.toXYZConversionMatrix();
 
@@ -1274,6 +1284,16 @@ pub const Colorspace = struct {
             .y = result[1],
             .z = result[2],
         };
+    }
+
+    pub fn fromXYZAlpha(self: Colorspace, xyza: CIEXYZAlpha) Colorf32 {
+        const conversion_matrix = self.toXYZConversionMatrix().inverse();
+
+        const xyza_float4 = @as(math.float4, @bitCast(xyza));
+
+        const result = conversion_matrix.mulVector(xyza_float4);
+
+        return Colorf32.fromArray(result);
     }
 
     pub fn toXYZAlpha(self: Colorspace, color: Colorf32) CIEXYZAlpha {
@@ -1288,14 +1308,7 @@ pub const Colorspace = struct {
 
     pub fn fromLab(self: Colorspace, lab: CIELab) Colorf32 {
         const xyz = lab.toXYZ(self.white);
-
-        const conversion_matrix = self.toXYZConversionMatrix().inverse();
-
-        const xyz_float4 = math.float4{ xyz.x, xyz.y, xyz.z, 1.0 };
-
-        const result = conversion_matrix.mulVector(xyz_float4);
-
-        return Colorf32.fromArray(result);
+        return self.fromXYZ(xyz);
     }
 
     pub fn toLab(self: Colorspace, color: Colorf32) CIELab {
@@ -1305,13 +1318,7 @@ pub const Colorspace = struct {
     pub fn fromLabAlpha(self: Colorspace, lab: CIELabAlpha) Colorf32 {
         const xyza = lab.toXYZAlpha(self.white);
 
-        const conversion_matrix = self.toXYZConversionMatrix().inverse();
-
-        const xyza_float4 = @as(math.float4, @bitCast(xyza));
-
-        const result = conversion_matrix.mulVector(xyza_float4);
-
-        return Colorf32.fromArray(result);
+        return self.fromXYZAlpha(xyza);
     }
 
     pub fn toLabAlpha(self: Colorspace, color: Colorf32) CIELabAlpha {

--- a/src/color.zig
+++ b/src/color.zig
@@ -1367,6 +1367,33 @@ pub const Colorspace = struct {
         return CIELabAlpha.fromXYZAlpha(self.toXYZAlpha(color), self.white);
     }
 
+    pub fn sliceToXYZAlphaInPlace(self: Colorspace, colors: []Colorf32) []CIEXYZAlpha {
+        const slice_xyza: []CIEXYZAlpha = @ptrCast(colors);
+
+        const conversion_matrix = self.toXYZConversionMatrix();
+
+        for (slice_xyza) |*xyza| {
+            const as_float4 = xyza.toFloat4();
+
+            xyza.* = CIEXYZAlpha.fromFloat4(conversion_matrix.mulVector(as_float4));
+        }
+
+        return slice_xyza;
+    }
+
+    pub fn sliceToXYZAlphaCopy(self: Colorspace, allocator: std.mem.Allocator, colors: []const Colorf32) ![]CIEXYZAlpha {
+        const slice_xyza: []CIEXYZAlpha = try allocator.alloc(CIEXYZAlpha, colors.len);
+
+        const conversion_matrix = self.toXYZConversionMatrix();
+        for (0..colors.len) |index| {
+            const color_float4 = colors[index].toFloat4();
+
+            slice_xyza[index] = CIEXYZAlpha.fromFloat4(conversion_matrix.mulVector(color_float4));
+        }
+
+        return slice_xyza;
+    }
+
     pub fn sliceToLabAlphaInPlace(self: Colorspace, colors: []Colorf32) []CIELabAlpha {
         const slice_lab: []CIELabAlpha = @ptrCast(colors);
 

--- a/src/color.zig
+++ b/src/color.zig
@@ -1172,9 +1172,13 @@ pub const Colorspace = struct {
         return @bitCast(result);
     }
 
-    pub fn convertColors(self: Colorspace, colors: []Colorf32) void {
-        _ = colors;
-        _ = self;
+    pub fn convertColors(source: Colorspace, target: Colorspace, colors: []Colorf32) void {
+        const conversion_matrix = computeConversionMatrix(source, target);
+
+        for (colors) |*color| {
+            const color_float4: math.float4 = @bitCast(color.*);
+            color.* = @bitCast(conversion_matrix.mulVector(color_float4));
+        }
     }
 
     fn computeConversionMatrix(source: Colorspace, target: Colorspace) math.float4x4 {

--- a/src/color.zig
+++ b/src/color.zig
@@ -2670,9 +2670,38 @@ pub const ProPhotoRGB_TransferFunctions = NonLinearGammaTransferFunctions(.{
 pub const DCIP3_TransferFuntions = CurveGammaTransferFunctions(13.0 / 5.0);
 pub const AdobeRGB_TransferFunctions = CurveGammaTransferFunctions(563.0 / 256.0);
 
+// All white points are defined with the CIE 1931 2 degrees
 pub const WhitePoints = struct {
+    pub const A = CIExyY{ .x = 0.44758, .y = 0.40745 };
+    pub const B = CIExyY{ .x = 0.34842, .y = 0.35161 };
+    pub const C = CIExyY{ .x = 0.31006, .y = 0.31616 };
     pub const D50 = CIExyY{ .x = 0.34567, .y = 0.35850 };
+    pub const D55 = CIExyY{ .x = 0.33242, .y = 0.34743 };
     pub const D65 = CIExyY{ .x = 0.31271, .y = 0.32902 };
+    pub const D75 = CIExyY{ .x = 0.29902, .y = 0.31485 };
+    pub const D93 = CIExyY{ .x = 0.28315, .y = 0.29711 };
+    pub const E = CIExyY{ .x = 0.33333, .y = 0.33333 };
+    pub const F1 = CIExyY{ .x = 0.31310, .y = 0.33727 };
+    pub const F2 = CIExyY{ .x = 0.37208, .y = 0.37529 };
+    pub const F3 = CIExyY{ .x = 0.40910, .y = 0.39430 };
+    pub const F4 = CIExyY{ .x = 0.44018, .y = 0.40329 };
+    pub const F5 = CIExyY{ .x = 0.31379, .y = 0.34531 };
+    pub const F6 = CIExyY{ .x = 0.37790, .y = 0.38835 };
+    pub const F7 = CIExyY{ .x = 0.31292, .y = 0.32933 };
+    pub const F8 = CIExyY{ .x = 0.34588, .y = 0.35875 };
+    pub const F9 = CIExyY{ .x = 0.37417, .y = 0.37281 };
+    pub const F10 = CIExyY{ .x = 0.34609, .y = 0.35986 };
+    pub const F11 = CIExyY{ .x = 0.38052, .y = 0.37713 };
+    pub const F12 = CIExyY{ .x = 0.43695, .y = 0.40441 };
+    pub const LED_B1 = CIExyY{ .x = 0.4560, .y = 0.4078 };
+    pub const LED_B2 = CIExyY{ .x = 0.4357, .y = 0.4012 };
+    pub const LED_B3 = CIExyY{ .x = 0.3756, .y = 0.3723 };
+    pub const LED_B4 = CIExyY{ .x = 0.3422, .y = 0.3502 };
+    pub const LED_B5 = CIExyY{ .x = 0.3118, .y = 0.3236 };
+    pub const LED_BH1 = CIExyY{ .x = 0.4474, .y = 0.4066 };
+    pub const LED_RGB1 = CIExyY{ .x = 0.4557, .y = 0.4211 };
+    pub const LED_V1 = CIExyY{ .x = 0.4560, .y = 0.4548 };
+    pub const LED_V2 = CIExyY{ .x = 0.3781, .y = 0.3781 };
 };
 
 // BT.601-6 (NTSC)

--- a/src/math.zig
+++ b/src/math.zig
@@ -21,11 +21,25 @@ pub fn Matrix(comptime T: type) type {
             if (ComponentSize == 2) {
                 return self.matrix[0][0] * self.matrix[1][1] - self.matrix[0][1] * self.matrix[1][0];
             } else {
-                // for(0..ComponentSize) |row| {
-                //     for (0..ComponentSize) |column| {
+                var temp_matrix = self;
 
-                //     }
-                // }
+                for (0..(ComponentSize - 1)) |row| {
+                    for ((row + 1)..ComponentSize) |next_row| {
+                        const factor = temp_matrix.matrix[next_row][row] / temp_matrix.matrix[row][row];
+
+                        for (0..ComponentSize) |column| {
+                            temp_matrix.matrix[next_row][column] = temp_matrix.matrix[next_row][column] - factor * temp_matrix.matrix[row][column];
+                        }
+                    }
+                }
+
+                var result: f32 = temp_matrix.matrix[0][0];
+
+                for (1..ComponentSize) |diagonal| {
+                    result *= temp_matrix.matrix[diagonal][diagonal];
+                }
+
+                return result;
             }
         }
 

--- a/src/math.zig
+++ b/src/math.zig
@@ -1,0 +1,84 @@
+const std = @import("std");
+
+// Using HLSL nomenclature for the vector and matrix types
+pub const float2 = @Vector(2, f32);
+pub const float3 = @Vector(3, f32);
+pub const float4 = @Vector(4, f32);
+
+pub const float2x2 = Matrix([2]float2);
+pub const float3x3 = Matrix([3]float3);
+pub const float4x4 = Matrix([4]float4);
+
+pub fn Matrix(comptime T: type) type {
+    return struct {
+        matrix: T,
+
+        const ComponentSize = @typeInfo(T).Array.len;
+        const VectorType = @Vector(ComponentSize, f32);
+        const Self = @This();
+
+        pub fn determinant(self: Self) f32 {
+            if (ComponentSize == 2) {
+                return self.matrix[0][0] * self.matrix[1][1] - self.matrix[0][1] * self.matrix[1][0];
+            } else {
+                // for(0..ComponentSize) |row| {
+                //     for (0..ComponentSize) |column| {
+
+                //     }
+                // }
+            }
+        }
+
+        pub fn fromArray(array: [ComponentSize * ComponentSize]f32) Self {
+            var result: Self = undefined;
+
+            inline for (0..ComponentSize) |row| {
+                inline for (0..ComponentSize) |column| {
+                    result.matrix[row][column] = array[row * ComponentSize + column];
+                }
+            }
+
+            return result;
+        }
+
+        pub fn identity() Self {
+            var result: Self = undefined;
+
+            inline for (0..ComponentSize) |row| {
+                inline for (0..ComponentSize) |column| {
+                    result.matrix[row][column] = if (row == column) 1 else 0;
+                }
+            }
+
+            return result;
+        }
+
+        pub fn mulVector(self: Self, vector: VectorType) VectorType {
+            var result: VectorType = std.mem.zeroes(VectorType);
+
+            inline for (0..ComponentSize) |row| {
+                result[row] = @reduce(.Add, self.matrix[row] * vector);
+            }
+
+            return result;
+        }
+
+        pub fn mul(self: Self, right: Self) Self {
+            var result = std.mem.zeroes(Self);
+
+            for (0..ComponentSize) |row| {
+                for (0..ComponentSize) |column| {
+                    for (0..ComponentSize) |i| {
+                        result.matrix[row][column] += self.matrix[row][i] * right.matrix[i][column];
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        pub fn transpose(self: Self) Self {
+            return self;
+        }
+    };
+}

--- a/src/math.zig
+++ b/src/math.zig
@@ -148,3 +148,24 @@ pub fn Matrix(comptime T: type) type {
         }
     };
 }
+
+pub fn clamp2(value: float2, min: f32, max: f32) float2 {
+    const all_min: float2 = @splat(min);
+    const all_max: float2 = @splat(max);
+
+    return @min(@max(value, all_min), all_max);
+}
+
+pub fn clamp3(value: float3, min: f32, max: f32) float3 {
+    const all_min: float3 = @splat(min);
+    const all_max: float3 = @splat(max);
+
+    return @min(@max(value, all_min), all_max);
+}
+
+pub fn clamp4(value: float4, min: f32, max: f32) float4 {
+    const all_min: float4 = @splat(min);
+    const all_max: float4 = @splat(max);
+
+    return @min(@max(value, all_min), all_max);
+}

--- a/src/math.zig
+++ b/src/math.zig
@@ -32,9 +32,10 @@ pub fn Matrix(comptime T: type) type {
         pub fn fromArray(array: [ComponentSize * ComponentSize]f32) Self {
             var result: Self = undefined;
 
-            inline for (0..ComponentSize) |row| {
-                inline for (0..ComponentSize) |column| {
-                    result.matrix[row][column] = array[row * ComponentSize + column];
+            for (0..ComponentSize) |row| {
+                const stride = row * ComponentSize;
+                for (0..ComponentSize) |column| {
+                    result.matrix[row][column] = array[stride + column];
                 }
             }
 
@@ -66,11 +67,11 @@ pub fn Matrix(comptime T: type) type {
         pub fn mul(self: Self, right: Self) Self {
             var result = std.mem.zeroes(Self);
 
+            const transposed_right = right.transpose();
+
             for (0..ComponentSize) |row| {
                 for (0..ComponentSize) |column| {
-                    for (0..ComponentSize) |i| {
-                        result.matrix[row][column] += self.matrix[row][i] * right.matrix[i][column];
-                    }
+                    result.matrix[row][column] = @reduce(.Add, self.matrix[row] * transposed_right.matrix[column]);
                 }
             }
 
@@ -78,7 +79,15 @@ pub fn Matrix(comptime T: type) type {
         }
 
         pub fn transpose(self: Self) Self {
-            return self;
+            var result = std.mem.zeroes(Self);
+
+            for (0..ComponentSize) |row| {
+                for (0..ComponentSize) |column| {
+                    result.matrix[row][column] = self.matrix[column][row];
+                }
+            }
+
+            return result;
         }
     };
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -1543,7 +1543,7 @@ test "Convert a HSLuv color to gamma sRGB color" {
 
     const linear = color.sRGB.fromHSLuv(hsluv, .none);
 
-    const result = linear.toSrgb();
+    const result = color.sRGB.toGamma(linear);
 
     // #537da6
     const float_tolerance = 0.0001;
@@ -1562,7 +1562,7 @@ test "Convert a HSLuv color to gamma sRGB color" {
 test "Convert a gamma sRGB color to HSLuv" {
     // #537da6
     const srgb = color.Colorf32{ .r = 0.32549, .g = 0.4902, .b = 0.65098, .a = 1.0 };
-    const source = srgb.toLinear();
+    const source = color.sRGB.toLinear(srgb);
 
     const result = color.sRGB.toHSLuv(source);
 
@@ -1577,7 +1577,7 @@ test "Convert a HSLuv with alpha color to gamma sRGB color with alpha" {
 
     const linear = color.sRGB.fromHSLuvAlpha(hsluv, .none);
 
-    const result = linear.toSrgb();
+    const result = color.sRGB.toGamma(linear);
 
     // #537da6
     const float_tolerance = 0.0001;
@@ -1596,7 +1596,7 @@ test "Convert a HSLuv with alpha color to gamma sRGB color with alpha" {
 test "Convert a gamma sRGB color with alpha to HSLuv with alpha" {
     // #537da6
     const srgb = color.Colorf32{ .r = 0.32549, .g = 0.4902, .b = 0.65098, .a = 0.12345 };
-    const source = srgb.toLinear();
+    const source = color.sRGB.toLinear(srgb);
 
     const result = color.sRGB.toHSLuvAlpha(source);
 
@@ -1835,7 +1835,7 @@ test "Convert OkLCh to gamma sRGB" {
 
     const linear = color.sRGB.fromOkLCh(lch, .none);
 
-    const result = linear.toSrgb();
+    const result = color.sRGB.toGamma(linear);
 
     const float_tolerance = 0.01;
     try helpers.expectApproxEqAbs(result.r, 0.0549, float_tolerance);
@@ -1846,7 +1846,7 @@ test "Convert OkLCh to gamma sRGB" {
 test "Convert gamma sRGB to OKLCh" {
     const srgb = color.Colorf32{ .r = 0.29412, .g = 0.64706, .b = 0.5098, .a = 1.0 };
 
-    const linear = srgb.toLinear();
+    const linear = color.sRGB.toLinear(srgb);
 
     const result = color.sRGB.toOkLCh(linear);
 
@@ -1861,7 +1861,7 @@ test "Convert OkLCh with alpha to gamma sRGB with alpha" {
 
     const linear = color.sRGB.fromOkLChAlpha(lch, .none);
 
-    const result = linear.toSrgb();
+    const result = color.sRGB.toGamma(linear);
 
     const float_tolerance = 0.01;
     try helpers.expectApproxEqAbs(result.r, 0.0549, float_tolerance);
@@ -1873,7 +1873,7 @@ test "Convert OkLCh with alpha to gamma sRGB with alpha" {
 test "Convert gamma sRGB with alpha to OKLCh with alpha" {
     const srgb = color.Colorf32{ .r = 0.29412, .g = 0.64706, .b = 0.5098, .a = 0.12345 };
 
-    const linear = srgb.toLinear();
+    const linear = color.sRGB.toLinear(srgb);
 
     const result = color.sRGB.toOkLChAlpha(linear);
 

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -1254,7 +1254,7 @@ test "Convert Cmykf32 to Colorf32" {
 test "Convert from CIE Lab to CIE LCh" {
     const lab = color.CIELab{ .l = 0.48485, .a = 0.47701, .b = -0.67469 };
 
-    const result = lab.toLch();
+    const result = lab.toLCHab();
 
     const float_tolerance = 0.0001;
     try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
@@ -1263,7 +1263,7 @@ test "Convert from CIE Lab to CIE LCh" {
 }
 
 test "Convert from CIE LCh to CIE Lab" {
-    const lch = color.CIELCh{ .l = 0.48485, .c = 0.82628, .h = 5.32780 };
+    const lch = color.CIELCHab{ .l = 0.48485, .c = 0.82628, .h = 5.32780 };
 
     const result = lch.toLab();
 
@@ -1276,7 +1276,7 @@ test "Convert from CIE LCh to CIE Lab" {
 test "Convert from CIELabAlpha to CIELChAlpha" {
     const lab = color.CIELabAlpha{ .l = 0.48485, .a = 0.47701, .b = -0.67469, .alpha = 0.4567 };
 
-    const result = lab.toLchAlpha();
+    const result = lab.toLCHabAlpha();
 
     const float_tolerance = 0.0001;
     try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
@@ -1286,7 +1286,7 @@ test "Convert from CIELabAlpha to CIELChAlpha" {
 }
 
 test "Convert from CIELChAlpha to CIELabAlpha" {
-    const lch = color.CIELChAlpha{ .l = 0.48485, .c = 0.82628, .h = 5.32780, .alpha = 0.4567 };
+    const lch = color.CIELCHabAlpha{ .l = 0.48485, .c = 0.82628, .h = 5.32780, .alpha = 0.4567 };
 
     const result = lch.toLabAlpha();
 
@@ -1295,4 +1295,199 @@ test "Convert from CIELChAlpha to CIELabAlpha" {
     try helpers.expectApproxEqAbs(result.a, 0.47701, float_tolerance);
     try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
     try helpers.expectApproxEqAbs(result.alpha, 0.4567, float_tolerance);
+}
+
+test "Convert a sRGB RGBA to CIELuv" {
+    const rgba = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.toLuv(rgba);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.u, 0.03422, float_tolerance);
+    try helpers.expectApproxEqAbs(result.v, -1.06609, float_tolerance);
+}
+
+test "Conveert a CIELuv to linear sRGB RGBA" {
+    const luv = color.CIELuv{ .l = 0.48485, .u = 0.03422, .v = -1.06609 };
+
+    const result = color.sRGB.fromLuv(luv, .none);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.2, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.1, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.8, float_tolerance);
+}
+
+test "Convert a sRGB RGBA to CIELuvAlpha" {
+    const rgba = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.toLuvAlpha(rgba);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.u, 0.03422, float_tolerance);
+    try helpers.expectApproxEqAbs(result.v, -1.06609, float_tolerance);
+}
+
+test "Conveert a CIELuvAlpha to linear sRGB RGBA" {
+    const luv = color.CIELuvAlpha{ .l = 0.48485, .u = 0.03422, .v = -1.06609, .alpha = 0.12345 };
+
+    const result = color.sRGB.fromLuvAlpha(luv, .none);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.2, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.1, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.8, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.12345, float_tolerance);
+}
+
+test "Convert a slice of RGBA colors to sRGB CIELuv with alpha, in-place" {
+    var colors = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.CIELuvAlpha{
+        .{ .l = 0.532408, .u = 1.75015, .v = 0.377564, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .u = -0.830776, .v = 1.073985, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .u = -0.094054, .v = -1.303423, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .u = 0.077056, .v = 1.067866, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .u = 0.840714, .v = -1.086834, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .u = -0.704773, .v = -0.152042, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .u = 0.0, .v = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .u = 0.0, .v = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const slice_luv = color.sRGB.sliceToLuvAlphaInPlace(colors[0..]);
+
+    const float_tolerance = 0.001;
+    for (0..results.len) |index| {
+        const result = slice_luv[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(result.u, expected.u, float_tolerance);
+        try helpers.expectApproxEqAbs(result.v, expected.v, float_tolerance);
+        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+    }
+}
+
+test "Convert a slice of RGBA colors to sRGB CIELuv with alpha, copy" {
+    const colors = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.CIELuvAlpha{
+        .{ .l = 0.532408, .u = 1.75015, .v = 0.377564, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .u = -0.830776, .v = 1.073985, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .u = -0.094054, .v = -1.303423, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .u = 0.077056, .v = 1.067866, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .u = 0.840714, .v = -1.086834, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .u = -0.704773, .v = -0.152042, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .u = 0.0, .v = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .u = 0.0, .v = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const slice_luv = try color.sRGB.sliceToLuvAlphaCopy(helpers.zigimg_test_allocator, colors[0..]);
+    defer helpers.zigimg_test_allocator.free(slice_luv);
+
+    const float_tolerance = 0.001;
+    for (0..results.len) |index| {
+        const result = slice_luv[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(result.u, expected.u, float_tolerance);
+        try helpers.expectApproxEqAbs(result.v, expected.v, float_tolerance);
+        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+    }
+}
+
+test "Convert a slice of CIELuvAlpha colors to linear sRGB with alpha, in-place" {
+    var colors = [_]color.CIELuvAlpha{
+        .{ .l = 0.532408, .u = 1.75015, .v = 0.377564, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .u = -0.830776, .v = 1.073985, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .u = -0.094054, .v = -1.303423, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .u = 0.077056, .v = 1.067866, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .u = 0.840714, .v = -1.086834, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .u = -0.704773, .v = -0.152042, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .u = 0.0, .v = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .u = 0.0, .v = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const results = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const slice_rgba = color.sRGB.sliceFromLuvAlphaInPlace(colors[0..], .clamp);
+
+    const float_tolerance = 0.0001;
+    for (0..results.len) |index| {
+        const result = slice_rgba[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
+}
+
+test "Convert a slice of CIELuvAlpha colors to linear sRGB with alpha, copy" {
+    const colors = [_]color.CIELuvAlpha{
+        .{ .l = 0.532408, .u = 1.75015, .v = 0.377564, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .u = -0.830776, .v = 1.073985, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .u = -0.094054, .v = -1.303423, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .u = 0.077056, .v = 1.067866, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .u = 0.840714, .v = -1.086834, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .u = -0.704773, .v = -0.152042, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .u = 0.0, .v = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .u = 0.0, .v = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const results = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const slice_rgba = try color.sRGB.sliceFromLuvAlphaCopy(helpers.zigimg_test_allocator, colors[0..], .clamp);
+    defer helpers.zigimg_test_allocator.free(slice_rgba);
+
+    const float_tolerance = 0.0001;
+    for (0..results.len) |index| {
+        const result = slice_rgba[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -636,7 +636,7 @@ test "HSV to HSL conversion" {
 }
 
 test "Compute Linear sRGB RGB to XYZ matrix" {
-    const result = color.sRGB.toXYZConversionMatrix();
+    const result = color.sRGB.rgba_to_xyza;
 
     const float_tolerance = 0.0001;
 

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -818,6 +818,81 @@ test "Convert a CIELab color to linear sRGB with alpha" {
     try helpers.expectApproxEqAbs(result.a, 0.751534, float_tolerance);
 }
 
+test "Convert a slice of RGBA color to sRGB XYZ with alpha, in-place" {
+    var colors = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.CIEXYZAlpha{
+        .{ .x = 0.412456, .y = 0.212673, .z = 0.019334, .a = 1.0 }, // Red
+        .{ .x = 0.357576, .y = 0.715152, .z = 0.119192, .a = 1.0 }, // Green
+        .{ .x = 0.180437, .y = 0.072175, .z = 0.950304, .a = 1.0 }, // Blue
+        .{ .x = 0.770033, .y = 0.927825, .z = 0.138526, .a = 1.0 }, // Yellow
+        .{ .x = 0.592894, .y = 0.284848, .z = 0.969638, .a = 1.0 }, // Magenta
+        .{ .x = 0.538014, .y = 0.787327, .z = 1.069496, .a = 1.0 }, // Cyan
+        .{ .x = 0.950470, .y = 1.000000, .z = 1.088830, .a = 1.0 }, // White
+        .{ .x = 0.000000, .y = 0.000000, .z = 0.000000, .a = 1.0 }, // Black
+    };
+
+    const slice_xyza = color.sRGB.sliceToXYZAlphaInPlace(colors[0..]);
+
+    const float_tolerance = 0.0001;
+    for (0..results.len) |index| {
+        const result = slice_xyza[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.x, expected.x, float_tolerance);
+        try helpers.expectApproxEqAbs(result.y, expected.y, float_tolerance);
+        try helpers.expectApproxEqAbs(result.z, expected.z, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
+}
+
+test "Convert a slice of RGBA color to sRGB XYZ with alpha, copy" {
+    const colors = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.CIEXYZAlpha{
+        .{ .x = 0.412456, .y = 0.212673, .z = 0.019334, .a = 1.0 }, // Red
+        .{ .x = 0.357576, .y = 0.715152, .z = 0.119192, .a = 1.0 }, // Green
+        .{ .x = 0.180437, .y = 0.072175, .z = 0.950304, .a = 1.0 }, // Blue
+        .{ .x = 0.770033, .y = 0.927825, .z = 0.138526, .a = 1.0 }, // Yellow
+        .{ .x = 0.592894, .y = 0.284848, .z = 0.969638, .a = 1.0 }, // Magenta
+        .{ .x = 0.538014, .y = 0.787327, .z = 1.069496, .a = 1.0 }, // Cyan
+        .{ .x = 0.950470, .y = 1.000000, .z = 1.088830, .a = 1.0 }, // White
+        .{ .x = 0.000000, .y = 0.000000, .z = 0.000000, .a = 1.0 }, // Black
+    };
+
+    const slice_xyza = try color.sRGB.sliceToXYZAlphaCopy(helpers.zigimg_test_allocator, colors[0..]);
+    defer helpers.zigimg_test_allocator.free(slice_xyza);
+
+    const float_tolerance = 0.0001;
+    for (0..results.len) |index| {
+        const result = slice_xyza[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.x, expected.x, float_tolerance);
+        try helpers.expectApproxEqAbs(result.y, expected.y, float_tolerance);
+        try helpers.expectApproxEqAbs(result.z, expected.z, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
+}
+
 test "Convert a slice of RGBA color to sRGB CIELab with alpha, in-place" {
     var colors = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -521,3 +521,59 @@ test "Non u8 Rgb colors should not have fromHtmlHex" {
     try helpers.expectEq(@hasDecl(color.Rgba64, "fromHtmlHex"), false);
     try helpers.expectEq(@hasDecl(color.Rgb565, "fromHtmlHex"), false);
 }
+
+const RgbHslTestDataEntry = struct {
+    rgb: color.Colorf32 = .{},
+    hsl: color.Hsl = .{},
+};
+
+const RgbHslTestData = [_]RgbHslTestDataEntry{
+    .{ .rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 }, .hsl = .{ .hue = 0.0, .saturation = 0.0, .luminance = 1.0 } },
+    .{ .rgb = .{ .r = 0.5, .g = 0.5, .b = 0.5 }, .hsl = .{ .hue = 0.0, .saturation = 0.0, .luminance = 0.5 } },
+    .{ .rgb = .{ .r = 0.0, .g = 0.0, .b = 0.0 }, .hsl = .{ .hue = 0.0, .saturation = 0.0, .luminance = 0.0 } },
+    .{ .rgb = .{ .r = 1.0, .g = 0.0, .b = 0.0 }, .hsl = .{ .hue = 0.0, .saturation = 1.0, .luminance = 0.5 } },
+    .{ .rgb = .{ .r = 0.750, .g = 0.750, .b = 0.000 }, .hsl = .{ .hue = 60.0, .saturation = 1.000, .luminance = 0.375 } },
+    .{ .rgb = .{ .r = 0.000, .g = 0.500, .b = 0.000 }, .hsl = .{ .hue = 120.0, .saturation = 1.000, .luminance = 0.250 } },
+    .{ .rgb = .{ .r = 0.500, .g = 1.000, .b = 1.000 }, .hsl = .{ .hue = 180.0, .saturation = 1.000, .luminance = 0.750 } },
+    .{ .rgb = .{ .r = 0.500, .g = 0.500, .b = 1.000 }, .hsl = .{ .hue = 240.0, .saturation = 1.000, .luminance = 0.750 } },
+    .{ .rgb = .{ .r = 0.750, .g = 0.250, .b = 0.750 }, .hsl = .{ .hue = 300.0, .saturation = 0.500, .luminance = 0.500 } },
+    .{ .rgb = .{ .r = 0.628, .g = 0.643, .b = 0.142 }, .hsl = .{ .hue = 61.8, .saturation = 0.638, .luminance = 0.393 } },
+    .{ .rgb = .{ .r = 0.255, .g = 0.104, .b = 0.918 }, .hsl = .{ .hue = 251.1, .saturation = 0.832, .luminance = 0.511 } },
+    .{ .rgb = .{ .r = 0.116, .g = 0.675, .b = 0.255 }, .hsl = .{ .hue = 134.9, .saturation = 0.707, .luminance = 0.396 } },
+    .{ .rgb = .{ .r = 0.941, .g = 0.785, .b = 0.053 }, .hsl = .{ .hue = 49.5, .saturation = 0.893, .luminance = 0.497 } },
+    .{ .rgb = .{ .r = 0.704, .g = 0.187, .b = 0.897 }, .hsl = .{ .hue = 283.7, .saturation = 0.775, .luminance = 0.542 } },
+    .{ .rgb = .{ .r = 0.931, .g = 0.463, .b = 0.316 }, .hsl = .{ .hue = 14.3, .saturation = 0.817, .luminance = 0.624 } },
+    .{ .rgb = .{ .r = 0.998, .g = 0.974, .b = 0.532 }, .hsl = .{ .hue = 56.9, .saturation = 0.991, .luminance = 0.765 } },
+    .{ .rgb = .{ .r = 0.099, .g = 0.795, .b = 0.591 }, .hsl = .{ .hue = 162.4, .saturation = 0.779, .luminance = 0.447 } },
+    .{ .rgb = .{ .r = 0.211, .g = 0.149, .b = 0.597 }, .hsl = .{ .hue = 248.3, .saturation = 0.601, .luminance = 0.373 } },
+    .{ .rgb = .{ .r = 0.495, .g = 0.493, .b = 0.721 }, .hsl = .{ .hue = 240.5, .saturation = 0.290, .luminance = 0.607 } },
+};
+
+test "RGB to HSL conversion" {
+    for (RgbHslTestData) |entry| {
+        const converted_hsl = color.Hsl.fromRgb(entry.rgb);
+
+        try helpers.expectApproxEqAbs(converted_hsl.hue, entry.hsl.hue, 0.1);
+        try helpers.expectApproxEqAbs(converted_hsl.saturation, entry.hsl.saturation, 0.1);
+        try helpers.expectApproxEqAbs(converted_hsl.luminance, entry.hsl.luminance, 0.1);
+    }
+}
+
+test "HSL to RGB conversion" {
+    for (RgbHslTestData) |entry| {
+        const converted_rgb = color.Hsl.toRgb(entry.hsl);
+
+        try helpers.expectApproxEqAbs(converted_rgb.r, entry.rgb.r, 0.1);
+        try helpers.expectApproxEqAbs(converted_rgb.g, entry.rgb.g, 0.1);
+        try helpers.expectApproxEqAbs(converted_rgb.b, entry.rgb.b, 0.1);
+    }
+}
+
+test "HSL to HSV conversion" {
+    const hsl = color.Hsl{ .hue = 300.0, .saturation = 0.53, .luminance = 0.67 };
+    const converted_hsv = hsl.toHsv();
+
+    try helpers.expectApproxEqAbs(converted_hsv.hue, 300.0, 0.0001);
+    try helpers.expectApproxEqAbs(converted_hsv.saturation, 0.4140, 0.0001);
+    try helpers.expectApproxEqAbs(converted_hsv.value, 0.8449, 0.0001);
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -749,7 +749,7 @@ test "Convert an array of Linear sRGB to ProPhotoRGB" {
     }
 }
 
-test "Convert a sRGB color to CIELAB" {
+test "Convert a sRGB color to CIELab" {
     const source_color = color.Colorf32.initRgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.toLab(source_color);
@@ -760,7 +760,7 @@ test "Convert a sRGB color to CIELAB" {
     try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
 }
 
-test "Convert a sRGB color to CIELAB with alpha" {
+test "Convert a sRGB color to CIELab with alpha" {
     const source_color = color.Colorf32.initRgba(0.2, 0.1, 0.8, 0.5);
 
     const result = color.sRGB.toLabAlpha(source_color);
@@ -772,7 +772,7 @@ test "Convert a sRGB color to CIELAB with alpha" {
     try helpers.expectApproxEqAbs(result.alpha, 0.5, float_tolerance);
 }
 
-test "Convert a LAB color to sRGB XYZ" {
+test "Convert a CIELab color to sRGB XYZ" {
     const source_color = color.CIELab{ .l = 0.48485, .a = 0.47701, .b = -0.67469 };
 
     const result = source_color.toXYZ(color.sRGB.white);
@@ -783,7 +783,7 @@ test "Convert a LAB color to sRGB XYZ" {
     try helpers.expectApproxEqAbs(result.z, 0.776029, float_tolerance);
 }
 
-test "Convert a LAB color to sRGB XYZ with alpha" {
+test "Convert a CIELab color to sRGB XYZ with alpha" {
     const source_color = color.CIELabAlpha{ .l = 0.48485, .a = 0.47701, .b = -0.67469, .alpha = 0.751534 };
 
     const result = source_color.toXYZAlpha(color.sRGB.white);
@@ -792,5 +792,28 @@ test "Convert a LAB color to sRGB XYZ with alpha" {
     try helpers.expectApproxEqAbs(result.x, 0.262599, float_tolerance);
     try helpers.expectApproxEqAbs(result.y, 0.171790, float_tolerance);
     try helpers.expectApproxEqAbs(result.z, 0.776029, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.751534, float_tolerance);
+}
+
+test "Convert a CIELab color to linear sRGB" {
+    const source_color = color.CIELab{ .l = 0.48485, .a = 0.47701, .b = -0.67469 };
+
+    const result = color.sRGB.fromLab(source_color);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.2, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.1, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.8, float_tolerance);
+}
+
+test "Convert a CIELab color to linear sRGB with alpha" {
+    const source_color = color.CIELabAlpha{ .l = 0.48485, .a = 0.47701, .b = -0.67469, .alpha = 0.751534 };
+
+    const result = color.sRGB.fromLabAlpha(source_color);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.2, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.1, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.8, float_tolerance);
     try helpers.expectApproxEqAbs(result.a, 0.751534, float_tolerance);
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -816,9 +816,23 @@ test "Convert a CIELab color to linear sRGB with alpha" {
     try helpers.expectApproxEqAbs(result.g, 0.1, float_tolerance);
     try helpers.expectApproxEqAbs(result.b, 0.8, float_tolerance);
     try helpers.expectApproxEqAbs(result.a, 0.751534, float_tolerance);
+
+    const red_lab = color.CIELabAlpha{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 };
+
+    const red_rgba_float = color.sRGB.fromLabAlpha(red_lab);
+    try helpers.expectApproxEqAbs(red_rgba_float.r, 1.0, 0.1);
+    try helpers.expectApproxEqAbs(red_rgba_float.g, 0.0, 0.1);
+    try helpers.expectApproxEqAbs(red_rgba_float.b, 0.0, 0.1);
+    try helpers.expectApproxEqAbs(red_rgba_float.a, 1.0, 0.1);
+
+    const red_rgba = red_rgba_float.toRgba32();
+    try helpers.expectEq(red_rgba.r, 255);
+    try helpers.expectEq(red_rgba.g, 0);
+    try helpers.expectEq(red_rgba.b, 0);
+    try helpers.expectEq(red_rgba.a, 255);
 }
 
-test "Convert a slice of RGBA color to sRGB XYZ with alpha, in-place" {
+test "Convert a slice of RGBA colors to sRGB XYZ with alpha, in-place" {
     var colors = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
@@ -855,7 +869,7 @@ test "Convert a slice of RGBA color to sRGB XYZ with alpha, in-place" {
     }
 }
 
-test "Convert a slice of RGBA color to sRGB XYZ with alpha, copy" {
+test "Convert a slice of RGBA colors to sRGB XYZ with alpha, copy" {
     const colors = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
@@ -893,7 +907,7 @@ test "Convert a slice of RGBA color to sRGB XYZ with alpha, copy" {
     }
 }
 
-test "Convert a slice of RGBA color to sRGB CIELab with alpha, in-place" {
+test "Convert a slice of RGBA colors to sRGB CIELab with alpha, in-place" {
     var colors = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
@@ -930,7 +944,7 @@ test "Convert a slice of RGBA color to sRGB CIELab with alpha, in-place" {
     }
 }
 
-test "Convert a slice of RGBA color to sRGB CIELab with alpha, copy" {
+test "Convert a slice of RGBA colors to sRGB CIELab with alpha, copy" {
     const colors = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
@@ -965,5 +979,80 @@ test "Convert a slice of RGBA color to sRGB CIELab with alpha, copy" {
         try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
         try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
         try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+    }
+}
+
+test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, In-place" {
+    var colors = [_]color.CIELabAlpha{
+        .{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .a = -0.861827, .b = 0.831793, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .a = 0.791875, .b = -1.078602, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .a = -0.215537, .b = 0.944780, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .a = 0.982343, .b = -0.608249, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .a = -0.480875, .b = -0.141312, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .a = 0.0, .b = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .a = 0.0, .b = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const results = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const slice_rgba = color.sRGB.sliceFromLabAlphaInPlace(colors[0..]);
+
+    const float_tolerance = 0.001;
+    for (0..results.len) |index| {
+        const result = slice_rgba[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
+}
+
+test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, Copy" {
+    const colors = [_]color.CIELabAlpha{
+        .{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .a = -0.861827, .b = 0.831793, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .a = 0.791875, .b = -1.078602, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .a = -0.215537, .b = 0.944780, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .a = 0.982343, .b = -0.608249, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .a = -0.480875, .b = -0.141312, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .a = 0.0, .b = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .a = 0.0, .b = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const results = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const slice_rgba = try color.sRGB.sliceFromLabAlphaCopy(helpers.zigimg_test_allocator, colors[0..]);
+    defer helpers.zigimg_test_allocator.free(slice_rgba);
+
+    const float_tolerance = 0.001;
+    for (0..results.len) |index| {
+        const result = slice_rgba[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
     }
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -982,7 +982,82 @@ test "Convert a slice of RGBA colors to sRGB CIELab with alpha, copy" {
     }
 }
 
-test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, In-place" {
+test "Convert a slice of CIEXYZAlpha colors to linear sRGB RGBA, in-place" {
+    var colors = [_]color.CIEXYZAlpha{
+        .{ .x = 0.412456, .y = 0.212673, .z = 0.019334, .a = 1.0 }, // Red
+        .{ .x = 0.357576, .y = 0.715152, .z = 0.119192, .a = 1.0 }, // Green
+        .{ .x = 0.180437, .y = 0.072175, .z = 0.950304, .a = 1.0 }, // Blue
+        .{ .x = 0.770033, .y = 0.927825, .z = 0.138526, .a = 1.0 }, // Yellow
+        .{ .x = 0.592894, .y = 0.284848, .z = 0.969638, .a = 1.0 }, // Magenta
+        .{ .x = 0.538014, .y = 0.787327, .z = 1.069496, .a = 1.0 }, // Cyan
+        .{ .x = 0.950470, .y = 1.000000, .z = 1.088830, .a = 1.0 }, // White
+        .{ .x = 0.000000, .y = 0.000000, .z = 0.000000, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const slice_rgba = color.sRGB.sliceFromXYZAlphaInPlace(colors[0..]);
+
+    const float_tolerance = 0.001;
+    for (0..results.len) |index| {
+        const result = slice_rgba[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
+}
+
+test "Convert a slice of CIEXYZAlpha colors to linear sRGB RGBA, copy" {
+    const colors = [_]color.CIEXYZAlpha{
+        .{ .x = 0.412456, .y = 0.212673, .z = 0.019334, .a = 1.0 }, // Red
+        .{ .x = 0.357576, .y = 0.715152, .z = 0.119192, .a = 1.0 }, // Green
+        .{ .x = 0.180437, .y = 0.072175, .z = 0.950304, .a = 1.0 }, // Blue
+        .{ .x = 0.770033, .y = 0.927825, .z = 0.138526, .a = 1.0 }, // Yellow
+        .{ .x = 0.592894, .y = 0.284848, .z = 0.969638, .a = 1.0 }, // Magenta
+        .{ .x = 0.538014, .y = 0.787327, .z = 1.069496, .a = 1.0 }, // Cyan
+        .{ .x = 0.950470, .y = 1.000000, .z = 1.088830, .a = 1.0 }, // White
+        .{ .x = 0.000000, .y = 0.000000, .z = 0.000000, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const slice_rgba = try color.sRGB.sliceFromXYZAlphaCopy(helpers.zigimg_test_allocator, colors[0..]);
+    defer helpers.zigimg_test_allocator.free(slice_rgba);
+
+    const float_tolerance = 0.001;
+    for (0..results.len) |index| {
+        const result = slice_rgba[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
+}
+
+test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, in-place" {
     var colors = [_]color.CIELabAlpha{
         .{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 }, // Red
         .{ .l = 0.877347, .a = -0.861827, .b = 0.831793, .alpha = 1.0 }, // Green

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -1250,3 +1250,49 @@ test "Convert Cmykf32 to Colorf32" {
         try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
     }
 }
+
+test "Convert from CIE Lab to CIE LCh" {
+    const lab = color.CIELab{ .l = 0.48485, .a = 0.47701, .b = -0.67469 };
+
+    const result = lab.toLch();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.c, 0.82628, float_tolerance);
+    try helpers.expectApproxEqAbs(result.h, 5.32780, float_tolerance);
+}
+
+test "Convert from CIE LCh to CIE Lab" {
+    const lch = color.CIELCh{ .l = 0.48485, .c = 0.82628, .h = 5.32780 };
+
+    const result = lch.toLab();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.47701, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
+}
+
+test "Convert from CIELabAlpha to CIELChAlpha" {
+    const lab = color.CIELabAlpha{ .l = 0.48485, .a = 0.47701, .b = -0.67469, .alpha = 0.4567 };
+
+    const result = lab.toLchAlpha();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.c, 0.82628, float_tolerance);
+    try helpers.expectApproxEqAbs(result.h, 5.32780, float_tolerance);
+    try helpers.expectApproxEqAbs(result.alpha, 0.4567, float_tolerance);
+}
+
+test "Convert from CIELChAlpha to CIELabAlpha" {
+    const lch = color.CIELChAlpha{ .l = 0.48485, .c = 0.82628, .h = 5.32780, .alpha = 0.4567 };
+
+    const result = lch.toLabAlpha();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.47701, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
+    try helpers.expectApproxEqAbs(result.alpha, 0.4567, float_tolerance);
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -714,8 +714,37 @@ test "Convert Linear sRGB to BT2020" {
     const result = color.sRGB.convertColor(color.BT2020, color_to_convert);
 
     const float_tolerance = 0.0001;
-    try helpers.expectApproxEqAbs(result.r, 0.193054512, float_tolerance); 
+    try helpers.expectApproxEqAbs(result.r, 0.193054512, float_tolerance);
     try helpers.expectApproxEqAbs(result.g, 0.114861697, float_tolerance);
     try helpers.expectApproxEqAbs(result.b, 0.728544116, float_tolerance);
     try helpers.expectApproxEqAbs(result.a, 1.0, float_tolerance);
+}
+
+test "Convert an array of Linear sRGB to ProPhotoRGB" {
+    var colors = [_]color.Colorf32{
+        color.Colorf32.initRgb(0.2, 0.1, 0.8),
+        color.Colorf32.initRgb(1.0, 1.0, 1.0),
+        color.Colorf32.initRgb(0.5, 0.5, 0.0),
+        color.Colorf32.initRgb(0.0, 0.0, 0.0),
+        color.Colorf32.initRgb(0.0, 0.2, 0.4),
+    };
+
+    const expected_results = [_]color.Colorf32{
+        color.Colorf32.initRgb(0.251338661, 0.129547358, 0.707502544),
+        color.Colorf32.initRgb(1.0, 1.0, 1.0),
+        color.Colorf32.initRgb(0.429706693, 0.485920370, 0.0672753304),
+        color.Colorf32.initRgb(0.0, 0.0, 0.0),
+        color.Colorf32.initRgb(0.122260347, 0.185960293, 0.369714200),
+    };
+
+    color.sRGB.convertColors(color.ProPhotoRGB, colors[0..]);
+
+    const float_tolerance = 0.0001;
+    for (expected_results, 0..) |expected, index| {
+        const result = colors[index];
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -1829,3 +1829,57 @@ test "Convert a slice of Oklab with alph colors to linear sRGB, copy" {
         try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
+
+test "Convert OkLCh to gamma sRGB" {
+    const lch = color.OkLCh{ .l = 0.56, .c = 0.20, .h = 4.502949 };
+
+    const linear = color.sRGB.fromOkLCh(lch, .none);
+
+    const result = linear.toSrgb();
+
+    const float_tolerance = 0.01;
+    try helpers.expectApproxEqAbs(result.r, 0.0549, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.43137, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.90196, float_tolerance);
+}
+
+test "Convert gamma sRGB to OKLCh" {
+    const srgb = color.Colorf32{ .r = 0.29412, .g = 0.64706, .b = 0.5098, .a = 1.0 };
+
+    const linear = srgb.toLinear();
+
+    const result = color.sRGB.toOkLCh(linear);
+
+    const float_tolerance = 0.01;
+    try helpers.expectApproxEqAbs(result.l, 0.6573, float_tolerance);
+    try helpers.expectApproxEqAbs(result.c, 0.1027, float_tolerance);
+    try helpers.expectApproxEqAbs(result.h, 2.88276, float_tolerance);
+}
+
+test "Convert OkLCh with alpha to gamma sRGB with alpha" {
+    const lch = color.OkLChAlpha{ .l = 0.56, .c = 0.20, .h = 4.502949, .alpha = 0.12345 };
+
+    const linear = color.sRGB.fromOkLChAlpha(lch, .none);
+
+    const result = linear.toSrgb();
+
+    const float_tolerance = 0.01;
+    try helpers.expectApproxEqAbs(result.r, 0.0549, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.43137, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.90196, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.12345, float_tolerance);
+}
+
+test "Convert gamma sRGB with alpha to OKLCh with alpha" {
+    const srgb = color.Colorf32{ .r = 0.29412, .g = 0.64706, .b = 0.5098, .a = 0.12345 };
+
+    const linear = srgb.toLinear();
+
+    const result = color.sRGB.toOkLChAlpha(linear);
+
+    const float_tolerance = 0.01;
+    try helpers.expectApproxEqAbs(result.l, 0.6573, float_tolerance);
+    try helpers.expectApproxEqAbs(result.c, 0.1027, float_tolerance);
+    try helpers.expectApproxEqAbs(result.h, 2.88276, float_tolerance);
+    try helpers.expectApproxEqAbs(result.alpha, 0.12345, float_tolerance);
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -1251,7 +1251,7 @@ test "Convert Cmykf32 to Colorf32" {
     }
 }
 
-test "Convert from CIE Lab to CIE LCh" {
+test "Convert from CIE Lab to CIE LCh(ab)" {
     const lab = color.CIELab{ .l = 0.48485, .a = 0.47701, .b = -0.67469 };
 
     const result = lab.toLCHab();
@@ -1262,7 +1262,7 @@ test "Convert from CIE Lab to CIE LCh" {
     try helpers.expectApproxEqAbs(result.h, 5.32780, float_tolerance);
 }
 
-test "Convert from CIE LCh to CIE Lab" {
+test "Convert from CIE LCh(ab) to CIE Lab" {
     const lch = color.CIELCHab{ .l = 0.48485, .c = 0.82628, .h = 5.32780 };
 
     const result = lch.toLab();
@@ -1273,7 +1273,7 @@ test "Convert from CIE LCh to CIE Lab" {
     try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
 }
 
-test "Convert from CIELabAlpha to CIELChAlpha" {
+test "Convert from CIE Lab with alpha to CIELCh(ab) with alpha" {
     const lab = color.CIELabAlpha{ .l = 0.48485, .a = 0.47701, .b = -0.67469, .alpha = 0.4567 };
 
     const result = lab.toLCHabAlpha();
@@ -1285,7 +1285,7 @@ test "Convert from CIELabAlpha to CIELChAlpha" {
     try helpers.expectApproxEqAbs(result.alpha, 0.4567, float_tolerance);
 }
 
-test "Convert from CIELChAlpha to CIELabAlpha" {
+test "Convert from CIELCh(ab) with alpha to CIE Lab with alpha" {
     const lch = color.CIELCHabAlpha{ .l = 0.48485, .c = 0.82628, .h = 5.32780, .alpha = 0.4567 };
 
     const result = lch.toLabAlpha();
@@ -1490,4 +1490,50 @@ test "Convert a slice of CIELuvAlpha colors to linear sRGB with alpha, copy" {
         try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
         try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
+}
+
+test "Convert from CIE Luv to CIE LCh(uv)" {
+    const luv = color.CIELuv{ .l = 0.48485, .u = 0.034216, .v = -1.066091 };
+
+    const result = luv.toLCHuv();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.c, 1.066640, float_tolerance);
+    try helpers.expectApproxEqAbs(result.h, 4.744472, float_tolerance);
+}
+
+test "Convert from CIE LCh(uv) to CIE Luv" {
+    const lch = color.CIELCHuv{ .l = 0.48485, .c = 1.066640, .h = 4.744472 };
+
+    const result = lch.toLuv();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.u, 0.034216, float_tolerance);
+    try helpers.expectApproxEqAbs(result.v, -1.066091, float_tolerance);
+}
+
+test "Convert from CIE Luv with alpha to CIE LCh(uv) with alpha" {
+    const luv = color.CIELuvAlpha{ .l = 0.48485, .u = 0.034216, .v = -1.066091, .alpha = 0.12345 };
+
+    const result = luv.toLCHuvAlpha();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.c, 1.066640, float_tolerance);
+    try helpers.expectApproxEqAbs(result.h, 4.744472, float_tolerance);
+    try helpers.expectApproxEqAbs(result.alpha, 0.12345, float_tolerance);
+}
+
+test "Convert from CIE LCh(uv) with alpha to CIE Luv with alpha" {
+    const lch = color.CIELCHuvAlpha{ .l = 0.48485, .c = 1.066640, .h = 4.744472, .alpha = 0.12345 };
+
+    const result = lch.toLuvAlpha();
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.u, 0.034216, float_tolerance);
+    try helpers.expectApproxEqAbs(result.v, -1.066091, float_tolerance);
+    try helpers.expectApproxEqAbs(result.alpha, 0.12345, float_tolerance);
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -817,3 +817,78 @@ test "Convert a CIELab color to linear sRGB with alpha" {
     try helpers.expectApproxEqAbs(result.b, 0.8, float_tolerance);
     try helpers.expectApproxEqAbs(result.a, 0.751534, float_tolerance);
 }
+
+test "Convert a slice of RGBA color to sRGB CIELab with alpha, in-place" {
+    var colors = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.CIELabAlpha{
+        .{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .a = -0.861827, .b = 0.831793, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .a = 0.791875, .b = -1.078602, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .a = -0.215537, .b = 0.944780, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .a = 0.982343, .b = -0.608249, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .a = -0.480875, .b = -0.141312, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .a = 0.0, .b = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .a = 0.0, .b = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const slice_lab = color.sRGB.sliceToLabAlphaInPlace(colors[0..]);
+
+    const float_tolerance = 0.0001;
+    for (0..results.len) |index| {
+        const result = slice_lab[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+    }
+}
+
+test "Convert a slice of RGBA color to sRGB CIELab with alpha, copy" {
+    const colors = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+    };
+
+    const results = [_]color.CIELabAlpha{
+        .{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 }, // Red
+        .{ .l = 0.877347, .a = -0.861827, .b = 0.831793, .alpha = 1.0 }, // Green
+        .{ .l = 0.322970, .a = 0.791875, .b = -1.078602, .alpha = 1.0 }, // Blue
+        .{ .l = 0.971393, .a = -0.215537, .b = 0.944780, .alpha = 1.0 }, // Yellow
+        .{ .l = 0.603242, .a = 0.982343, .b = -0.608249, .alpha = 1.0 }, // Magenta
+        .{ .l = 0.911132, .a = -0.480875, .b = -0.141312, .alpha = 1.0 }, // Cyan
+        .{ .l = 1.000000, .a = 0.0, .b = -0.0, .alpha = 1.0 }, // White
+        .{ .l = 0.000000, .a = 0.0, .b = 0.0, .alpha = 1.0 }, // Black
+    };
+
+    const slice_lab = try color.sRGB.sliceToLabAlphaCopy(helpers.zigimg_test_allocator, colors[0..]);
+    defer helpers.zigimg_test_allocator.free(slice_lab);
+
+    const float_tolerance = 0.0001;
+    for (0..results.len) |index| {
+        const result = slice_lab[index];
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+    }
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -1174,3 +1174,79 @@ test "Reduce brightness by 25% of a slice of sRGB RGBA color using CIELab as a i
         try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
     }
 }
+
+test "Convert Colorf32 to Cmykf32" {
+    const colors = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+        .{ .r = 0.2, .g = 0.1, .b = 0.8, .a = 1.0 }, // #3319cc
+    };
+
+    const results = [_]color.Cmykf32{
+        .{ .c = 0.0000, .m = 1.0000, .y = 1.0000, .k = 0.00 }, // Red
+        .{ .c = 1.0000, .m = 0.0000, .y = 1.0000, .k = 0.00 }, // Green
+        .{ .c = 1.0000, .m = 1.0000, .y = 0.0000, .k = 0.00 }, // Blue
+        .{ .c = 0.0000, .m = 0.0000, .y = 1.0000, .k = 0.00 }, // Yellow
+        .{ .c = 0.0000, .m = 1.0000, .y = 0.0000, .k = 0.00 }, // Magenta
+        .{ .c = 1.0000, .m = 0.0000, .y = 0.0000, .k = 0.00 }, // Cyan
+        .{ .c = 0.0000, .m = 0.0000, .y = 0.0000, .k = 0.00 }, // White
+        .{ .c = 0.0000, .m = 0.0000, .y = 0.0000, .k = 1.00 }, // Black
+        .{ .c = 0.7500, .m = 0.8750, .y = 0.0000, .k = 0.20 }, // #3319cc
+    };
+
+    const float_tolerance = 0.0001;
+
+    for (0..results.len) |index| {
+        const result = color.Cmykf32.fromColorf32(colors[index]);
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.c, expected.c, float_tolerance);
+        try helpers.expectApproxEqAbs(result.m, expected.m, float_tolerance);
+        try helpers.expectApproxEqAbs(result.y, expected.y, float_tolerance);
+        try helpers.expectApproxEqAbs(result.k, expected.k, float_tolerance);
+    }
+}
+
+test "Convert Cmykf32 to Colorf32" {
+    const colors = [_]color.Cmykf32{
+        .{ .c = 0.0000, .m = 1.0000, .y = 1.0000, .k = 0.00 }, // Red
+        .{ .c = 1.0000, .m = 0.0000, .y = 1.0000, .k = 0.00 }, // Green
+        .{ .c = 1.0000, .m = 1.0000, .y = 0.0000, .k = 0.00 }, // Blue
+        .{ .c = 0.0000, .m = 0.0000, .y = 1.0000, .k = 0.00 }, // Yellow
+        .{ .c = 0.0000, .m = 1.0000, .y = 0.0000, .k = 0.00 }, // Magenta
+        .{ .c = 1.0000, .m = 0.0000, .y = 0.0000, .k = 0.00 }, // Cyan
+        .{ .c = 0.0000, .m = 0.0000, .y = 0.0000, .k = 0.00 }, // White
+        .{ .c = 0.0000, .m = 0.0000, .y = 0.0000, .k = 1.00 }, // Black
+        .{ .c = 0.7500, .m = 0.8750, .y = 0.0000, .k = 0.20 }, // #3319cc
+    };
+
+    const results = [_]color.Colorf32{
+        .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
+        .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
+        .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
+        .{ .r = 1.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Yellow
+        .{ .r = 1.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Magenta
+        .{ .r = 0.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // Cyan
+        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 }, // White
+        .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
+        .{ .r = 0.2, .g = 0.1, .b = 0.8, .a = 1.0 }, // #3319cc
+    };
+
+    const float_tolerance = 0.0001;
+
+    for (0..results.len) |index| {
+        const result = color.Cmykf32.toColorF32(colors[index]);
+        const expected = results[index];
+
+        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+    }
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -820,10 +820,10 @@ test "Convert a CIELab color to linear sRGB with alpha" {
     const red_lab = color.CIELabAlpha{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 };
 
     const red_rgba_float = color.sRGB.fromLabAlpha(red_lab);
-    try helpers.expectApproxEqAbs(red_rgba_float.r, 1.0, 0.1);
-    try helpers.expectApproxEqAbs(red_rgba_float.g, 0.0, 0.1);
-    try helpers.expectApproxEqAbs(red_rgba_float.b, 0.0, 0.1);
-    try helpers.expectApproxEqAbs(red_rgba_float.a, 1.0, 0.1);
+    try helpers.expectApproxEqAbs(red_rgba_float.r, 1.0, 0.001);
+    try helpers.expectApproxEqAbs(red_rgba_float.g, 0.0, 0.001);
+    try helpers.expectApproxEqAbs(red_rgba_float.b, 0.0, 0.001);
+    try helpers.expectApproxEqAbs(red_rgba_float.a, 1.0, 0.001);
 
     const red_rgba = red_rgba_float.toRgba32();
     try helpers.expectEq(red_rgba.r, 255);

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -771,3 +771,26 @@ test "Convert a sRGB color to CIELAB with alpha" {
     try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
     try helpers.expectApproxEqAbs(result.alpha, 0.5, float_tolerance);
 }
+
+test "Convert a LAB color to sRGB XYZ" {
+    const source_color = color.CIELab{ .l = 0.48485, .a = 0.47701, .b = -0.67469 };
+
+    const result = source_color.toXYZ(color.sRGB.white);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.x, 0.262599, float_tolerance);
+    try helpers.expectApproxEqAbs(result.y, 0.171790, float_tolerance);
+    try helpers.expectApproxEqAbs(result.z, 0.776029, float_tolerance);
+}
+
+test "Convert a LAB color to sRGB XYZ with alpha" {
+    const source_color = color.CIELabAlpha{ .l = 0.48485, .a = 0.47701, .b = -0.67469, .alpha = 0.751534 };
+
+    const result = source_color.toXYZAlpha(color.sRGB.white);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.x, 0.262599, float_tolerance);
+    try helpers.expectApproxEqAbs(result.y, 0.171790, float_tolerance);
+    try helpers.expectApproxEqAbs(result.z, 0.776029, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.751534, float_tolerance);
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -629,7 +629,45 @@ test "HSV to HSL conversion" {
     const hsv = color.Hsv{ .hue = 300.0, .saturation = 0.4140, .value = 0.8449 };
     const converted_hsl = hsv.toHsl();
 
-    try helpers.expectApproxEqAbs(converted_hsl.hue, 300.0, 0.0001);
-    try helpers.expectApproxEqAbs(converted_hsl.saturation, 0.53, 0.0001);
-    try helpers.expectApproxEqAbs(converted_hsl.luminance, 0.67, 0.0001);
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(converted_hsl.hue, 300.0, float_tolerance);
+    try helpers.expectApproxEqAbs(converted_hsl.saturation, 0.53, float_tolerance);
+    try helpers.expectApproxEqAbs(converted_hsl.luminance, 0.67, float_tolerance);
+}
+
+test "Compute Linear sRGB RGB to XYZ matrix" {
+    const result = color.sRGB.toXYZConversionMatrix();
+
+    const float_tolerance = 0.0001;
+
+    try helpers.expectApproxEqAbs(result.matrix[0][0], 0.4124564, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[0][1], 0.3575761, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[0][2], 0.1804375, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[0][3], 0, float_tolerance);
+
+    try helpers.expectApproxEqAbs(result.matrix[1][0], 0.2126729, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[1][1], 0.7151522, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[1][2], 0.0721750, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[1][3], 0, float_tolerance);
+
+    try helpers.expectApproxEqAbs(result.matrix[2][0], 0.0193339, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[2][1], 0.1191920, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[2][2], 0.9503041, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[2][3], 0, float_tolerance);
+
+    try helpers.expectApproxEqAbs(result.matrix[3][0], 0, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[3][1], 0, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[3][2], 0, float_tolerance);
+    try helpers.expectApproxEqAbs(result.matrix[3][3], 1, float_tolerance);
+}
+
+test "Linear sRGB to CIE XYZ" {
+    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.convertToXYZ(color_to_convert);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.x, 0.262599, float_tolerance);
+    try helpers.expectApproxEqAbs(result.y, 0.171790, float_tolerance);
+    try helpers.expectApproxEqAbs(result.z, 0.776029, float_tolerance);
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -1537,3 +1537,72 @@ test "Convert from CIE LCh(uv) with alpha to CIE Luv with alpha" {
     try helpers.expectApproxEqAbs(result.v, -1.066091, float_tolerance);
     try helpers.expectApproxEqAbs(result.alpha, 0.12345, float_tolerance);
 }
+
+test "Convert a HSLuv color to gamma sRGB color" {
+    const hsluv = color.HSLuv{ .h = std.math.degreesToRadians(f32, 243.0), .s = 0.61, .l = 0.51 };
+
+    const linear = color.sRGB.fromHSLuv(hsluv, .none);
+
+    const result = linear.toSrgb();
+
+    // #537da6
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.324444026, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.490519762, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.651108801, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 1.0, float_tolerance);
+
+    const rgba = result.toRgba32();
+    try helpers.expectEq(rgba.r, 0x53);
+    try helpers.expectEq(rgba.g, 0x7d);
+    try helpers.expectEq(rgba.b, 0xa6);
+    try helpers.expectEq(rgba.a, 0xFF);
+}
+
+test "Convert a gamma sRGB color to HSLuv" {
+    // #537da6
+    const srgb = color.Colorf32{ .r = 0.32549, .g = 0.4902, .b = 0.65098, .a = 1.0 };
+    const source = srgb.toLinear();
+
+    const result = color.sRGB.toHSLuv(source);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.h, 4.24362755, float_tolerance);
+    try helpers.expectApproxEqAbs(result.s, 0.607237875, float_tolerance);
+    try helpers.expectApproxEqAbs(result.l, 0.509887099, float_tolerance);
+}
+
+test "Convert a HSLuv with alpha color to gamma sRGB color with alpha" {
+    const hsluv = color.HSLuvAlpha{ .h = std.math.degreesToRadians(f32, 243.0), .s = 0.61, .l = 0.51, .alpha = 0.12345 };
+
+    const linear = color.sRGB.fromHSLuvAlpha(hsluv, .none);
+
+    const result = linear.toSrgb();
+
+    // #537da6
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.324444026, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.490519762, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.651108801, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.12345, float_tolerance);
+
+    const rgba = result.toRgba32();
+    try helpers.expectEq(rgba.r, 0x53);
+    try helpers.expectEq(rgba.g, 0x7d);
+    try helpers.expectEq(rgba.b, 0xa6);
+    try helpers.expectEq(rgba.a, 0x1f);
+}
+
+test "Convert a gamma sRGB color with alpha to HSLuv with alpha" {
+    // #537da6
+    const srgb = color.Colorf32{ .r = 0.32549, .g = 0.4902, .b = 0.65098, .a = 0.12345 };
+    const source = srgb.toLinear();
+
+    const result = color.sRGB.toHSLuvAlpha(source);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.h, 4.24362755, float_tolerance);
+    try helpers.expectApproxEqAbs(result.s, 0.607237875, float_tolerance);
+    try helpers.expectApproxEqAbs(result.l, 0.509887099, float_tolerance);
+    try helpers.expectApproxEqAbs(result.alpha, 0.12345, float_tolerance);
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -844,7 +844,7 @@ test "Convert a slice of RGBA colors to sRGB XYZ with alpha, in-place" {
         .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.CIEXYZAlpha{
+    const expected_results = [_]color.CIEXYZAlpha{
         .{ .x = 0.412456, .y = 0.212673, .z = 0.019334, .a = 1.0 }, // Red
         .{ .x = 0.357576, .y = 0.715152, .z = 0.119192, .a = 1.0 }, // Green
         .{ .x = 0.180437, .y = 0.072175, .z = 0.950304, .a = 1.0 }, // Blue
@@ -858,14 +858,14 @@ test "Convert a slice of RGBA colors to sRGB XYZ with alpha, in-place" {
     const slice_xyza = color.sRGB.sliceToXYZAlphaInPlace(colors[0..]);
 
     const float_tolerance = 0.0001;
-    for (0..results.len) |index| {
-        const result = slice_xyza[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_xyza[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.x, expected.x, float_tolerance);
-        try helpers.expectApproxEqAbs(result.y, expected.y, float_tolerance);
-        try helpers.expectApproxEqAbs(result.z, expected.z, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.x, expected.x, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.y, expected.y, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.z, expected.z, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -881,7 +881,7 @@ test "Convert a slice of RGBA colors to sRGB XYZ with alpha, copy" {
         .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.CIEXYZAlpha{
+    const expected_results = [_]color.CIEXYZAlpha{
         .{ .x = 0.412456, .y = 0.212673, .z = 0.019334, .a = 1.0 }, // Red
         .{ .x = 0.357576, .y = 0.715152, .z = 0.119192, .a = 1.0 }, // Green
         .{ .x = 0.180437, .y = 0.072175, .z = 0.950304, .a = 1.0 }, // Blue
@@ -896,14 +896,14 @@ test "Convert a slice of RGBA colors to sRGB XYZ with alpha, copy" {
     defer helpers.zigimg_test_allocator.free(slice_xyza);
 
     const float_tolerance = 0.0001;
-    for (0..results.len) |index| {
-        const result = slice_xyza[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_xyza[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.x, expected.x, float_tolerance);
-        try helpers.expectApproxEqAbs(result.y, expected.y, float_tolerance);
-        try helpers.expectApproxEqAbs(result.z, expected.z, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.x, expected.x, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.y, expected.y, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.z, expected.z, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -919,7 +919,7 @@ test "Convert a slice of RGBA colors to sRGB CIELab with alpha, in-place" {
         .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.CIELabAlpha{
+    const expected_results = [_]color.CIELabAlpha{
         .{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 }, // Red
         .{ .l = 0.877347, .a = -0.861827, .b = 0.831793, .alpha = 1.0 }, // Green
         .{ .l = 0.322970, .a = 0.791875, .b = -1.078602, .alpha = 1.0 }, // Blue
@@ -933,14 +933,14 @@ test "Convert a slice of RGBA colors to sRGB CIELab with alpha, in-place" {
     const slice_lab = color.sRGB.sliceToLabAlphaInPlace(colors[0..]);
 
     const float_tolerance = 0.0001;
-    for (0..results.len) |index| {
-        const result = slice_lab[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_lab[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.alpha, expected.alpha, float_tolerance);
     }
 }
 
@@ -956,7 +956,7 @@ test "Convert a slice of RGBA colors to sRGB CIELab with alpha, copy" {
         .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.CIELabAlpha{
+    const expected_results = [_]color.CIELabAlpha{
         .{ .l = 0.532408, .a = 0.800925, .b = 0.672032, .alpha = 1.0 }, // Red
         .{ .l = 0.877347, .a = -0.861827, .b = 0.831793, .alpha = 1.0 }, // Green
         .{ .l = 0.322970, .a = 0.791875, .b = -1.078602, .alpha = 1.0 }, // Blue
@@ -971,14 +971,14 @@ test "Convert a slice of RGBA colors to sRGB CIELab with alpha, copy" {
     defer helpers.zigimg_test_allocator.free(slice_lab);
 
     const float_tolerance = 0.0001;
-    for (0..results.len) |index| {
-        const result = slice_lab[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_lab[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.alpha, expected.alpha, float_tolerance);
     }
 }
 
@@ -994,7 +994,7 @@ test "Convert a slice of CIEXYZAlpha colors to linear sRGB RGBA, in-place" {
         .{ .x = 0.000000, .y = 0.000000, .z = 0.000000, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
         .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
@@ -1008,14 +1008,14 @@ test "Convert a slice of CIEXYZAlpha colors to linear sRGB RGBA, in-place" {
     const slice_rgba = color.sRGB.sliceFromXYZAlphaInPlace(colors[0..]);
 
     const float_tolerance = 0.001;
-    for (0..results.len) |index| {
-        const result = slice_rgba[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_rgba[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -1031,7 +1031,7 @@ test "Convert a slice of CIEXYZAlpha colors to linear sRGB RGBA, copy" {
         .{ .x = 0.000000, .y = 0.000000, .z = 0.000000, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
         .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
@@ -1046,14 +1046,14 @@ test "Convert a slice of CIEXYZAlpha colors to linear sRGB RGBA, copy" {
     defer helpers.zigimg_test_allocator.free(slice_rgba);
 
     const float_tolerance = 0.001;
-    for (0..results.len) |index| {
-        const result = slice_rgba[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_rgba[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -1069,7 +1069,7 @@ test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, in-place" {
         .{ .l = 0.000000, .a = 0.0, .b = 0.0, .alpha = 1.0 }, // Black
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
         .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
@@ -1083,14 +1083,14 @@ test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, in-place" {
     const slice_rgba = color.sRGB.sliceFromLabAlphaInPlace(colors[0..], .none);
 
     const float_tolerance = 0.001;
-    for (0..results.len) |index| {
-        const result = slice_rgba[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_rgba[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -1106,7 +1106,7 @@ test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, Copy" {
         .{ .l = 0.000000, .a = 0.0, .b = 0.0, .alpha = 1.0 }, // Black
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
         .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
@@ -1121,14 +1121,14 @@ test "Convert a slice of CIELabAlpha colors to linear sRGB RGBA, Copy" {
     defer helpers.zigimg_test_allocator.free(slice_rgba);
 
     const float_tolerance = 0.001;
-    for (0..results.len) |index| {
-        const result = slice_rgba[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_rgba[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -1144,7 +1144,7 @@ test "Reduce brightness by 25% of a slice of sRGB RGBA color using CIELab as a i
         .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 0.6434, .g = 0.0000, .b = 0.0000, .a = 1.0 }, // Red
         .{ .r = 0.0000, .g = 0.5196, .b = 0.0000, .a = 1.0 }, // Green
         .{ .r = 0.0000, .g = 0.0000, .b = 0.7990, .a = 1.0 }, // Blue
@@ -1164,14 +1164,14 @@ test "Reduce brightness by 25% of a slice of sRGB RGBA color using CIELab as a i
     const slice_rgba = color.sRGB.sliceFromLabAlphaInPlace(slice_lab, .clamp);
 
     const float_tolerance = 0.0001;
-    for (0..results.len) |index| {
-        const result = slice_rgba[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_rgba[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -1188,7 +1188,7 @@ test "Convert Colorf32 to Cmykf32" {
         .{ .r = 0.2, .g = 0.1, .b = 0.8, .a = 1.0 }, // #3319cc
     };
 
-    const results = [_]color.Cmykf32{
+    const expected_results = [_]color.Cmykf32{
         .{ .c = 0.0000, .m = 1.0000, .y = 1.0000, .k = 0.00 }, // Red
         .{ .c = 1.0000, .m = 0.0000, .y = 1.0000, .k = 0.00 }, // Green
         .{ .c = 1.0000, .m = 1.0000, .y = 0.0000, .k = 0.00 }, // Blue
@@ -1202,14 +1202,14 @@ test "Convert Colorf32 to Cmykf32" {
 
     const float_tolerance = 0.0001;
 
-    for (0..results.len) |index| {
-        const result = color.Cmykf32.fromColorf32(colors[index]);
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = color.Cmykf32.fromColorf32(colors[index]);
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.c, expected.c, float_tolerance);
-        try helpers.expectApproxEqAbs(result.m, expected.m, float_tolerance);
-        try helpers.expectApproxEqAbs(result.y, expected.y, float_tolerance);
-        try helpers.expectApproxEqAbs(result.k, expected.k, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.c, expected.c, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.m, expected.m, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.y, expected.y, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.k, expected.k, float_tolerance);
     }
 }
 
@@ -1226,7 +1226,7 @@ test "Convert Cmykf32 to Colorf32" {
         .{ .c = 0.7500, .m = 0.8750, .y = 0.0000, .k = 0.20 }, // #3319cc
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
         .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
@@ -1240,14 +1240,14 @@ test "Convert Cmykf32 to Colorf32" {
 
     const float_tolerance = 0.0001;
 
-    for (0..results.len) |index| {
-        const result = color.Cmykf32.toColorF32(colors[index]);
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = color.Cmykf32.toColorF32(colors[index]);
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -1354,7 +1354,7 @@ test "Convert a slice of RGBA colors to sRGB CIELuv with alpha, in-place" {
         .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.CIELuvAlpha{
+    const expected_results = [_]color.CIELuvAlpha{
         .{ .l = 0.532408, .u = 1.75015, .v = 0.377564, .alpha = 1.0 }, // Red
         .{ .l = 0.877347, .u = -0.830776, .v = 1.073985, .alpha = 1.0 }, // Green
         .{ .l = 0.322970, .u = -0.094054, .v = -1.303423, .alpha = 1.0 }, // Blue
@@ -1368,14 +1368,14 @@ test "Convert a slice of RGBA colors to sRGB CIELuv with alpha, in-place" {
     const slice_luv = color.sRGB.sliceToLuvAlphaInPlace(colors[0..]);
 
     const float_tolerance = 0.001;
-    for (0..results.len) |index| {
-        const result = slice_luv[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_luv[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
-        try helpers.expectApproxEqAbs(result.u, expected.u, float_tolerance);
-        try helpers.expectApproxEqAbs(result.v, expected.v, float_tolerance);
-        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.u, expected.u, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.v, expected.v, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.alpha, expected.alpha, float_tolerance);
     }
 }
 
@@ -1391,7 +1391,7 @@ test "Convert a slice of RGBA colors to sRGB CIELuv with alpha, copy" {
         .{ .r = 0.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Black
     };
 
-    const results = [_]color.CIELuvAlpha{
+    const expected_results = [_]color.CIELuvAlpha{
         .{ .l = 0.532408, .u = 1.75015, .v = 0.377564, .alpha = 1.0 }, // Red
         .{ .l = 0.877347, .u = -0.830776, .v = 1.073985, .alpha = 1.0 }, // Green
         .{ .l = 0.322970, .u = -0.094054, .v = -1.303423, .alpha = 1.0 }, // Blue
@@ -1406,14 +1406,14 @@ test "Convert a slice of RGBA colors to sRGB CIELuv with alpha, copy" {
     defer helpers.zigimg_test_allocator.free(slice_luv);
 
     const float_tolerance = 0.001;
-    for (0..results.len) |index| {
-        const result = slice_luv[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_luv[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.l, expected.l, float_tolerance);
-        try helpers.expectApproxEqAbs(result.u, expected.u, float_tolerance);
-        try helpers.expectApproxEqAbs(result.v, expected.v, float_tolerance);
-        try helpers.expectApproxEqAbs(result.alpha, expected.alpha, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.l, expected.l, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.u, expected.u, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.v, expected.v, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.alpha, expected.alpha, float_tolerance);
     }
 }
 
@@ -1429,7 +1429,7 @@ test "Convert a slice of CIELuvAlpha colors to linear sRGB with alpha, in-place"
         .{ .l = 0.000000, .u = 0.0, .v = 0.0, .alpha = 1.0 }, // Black
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
         .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
@@ -1443,14 +1443,14 @@ test "Convert a slice of CIELuvAlpha colors to linear sRGB with alpha, in-place"
     const slice_rgba = color.sRGB.sliceFromLuvAlphaInPlace(colors[0..], .clamp);
 
     const float_tolerance = 0.0001;
-    for (0..results.len) |index| {
-        const result = slice_rgba[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_rgba[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }
 
@@ -1466,7 +1466,7 @@ test "Convert a slice of CIELuvAlpha colors to linear sRGB with alpha, copy" {
         .{ .l = 0.000000, .u = 0.0, .v = 0.0, .alpha = 1.0 }, // Black
     };
 
-    const results = [_]color.Colorf32{
+    const expected_results = [_]color.Colorf32{
         .{ .r = 1.0, .g = 0.0, .b = 0.0, .a = 1.0 }, // Red
         .{ .r = 0.0, .g = 1.0, .b = 0.0, .a = 1.0 }, // Green
         .{ .r = 0.0, .g = 0.0, .b = 1.0, .a = 1.0 }, // Blue
@@ -1481,13 +1481,13 @@ test "Convert a slice of CIELuvAlpha colors to linear sRGB with alpha, copy" {
     defer helpers.zigimg_test_allocator.free(slice_rgba);
 
     const float_tolerance = 0.0001;
-    for (0..results.len) |index| {
-        const result = slice_rgba[index];
-        const expected = results[index];
+    for (0..expected_results.len) |index| {
+        const actual = slice_rgba[index];
+        const expected = expected_results[index];
 
-        try helpers.expectApproxEqAbs(result.r, expected.r, float_tolerance);
-        try helpers.expectApproxEqAbs(result.g, expected.g, float_tolerance);
-        try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
-        try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.r, expected.r, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.g, expected.g, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.b, expected.b, float_tolerance);
+        try helpers.expectApproxEqAbs(actual.a, expected.a, float_tolerance);
     }
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -577,3 +577,59 @@ test "HSL to HSV conversion" {
     try helpers.expectApproxEqAbs(converted_hsv.saturation, 0.4140, 0.0001);
     try helpers.expectApproxEqAbs(converted_hsv.value, 0.8449, 0.0001);
 }
+
+const RgbHsvTestDataEntry = struct {
+    rgb: color.Colorf32 = .{},
+    hsv: color.Hsv = .{},
+};
+
+const RgbHsvTestData = [_]RgbHsvTestDataEntry{
+    .{ .rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 }, .hsv = .{ .hue = 0.0, .saturation = 0.0, .value = 1.0 } },
+    .{ .rgb = .{ .r = 0.5, .g = 0.5, .b = 0.5 }, .hsv = .{ .hue = 0.0, .saturation = 0.0, .value = 0.5 } },
+    .{ .rgb = .{ .r = 0.0, .g = 0.0, .b = 0.0 }, .hsv = .{ .hue = 0.0, .saturation = 0.0, .value = 0.0 } },
+    .{ .rgb = .{ .r = 1.0, .g = 0.0, .b = 0.0 }, .hsv = .{ .hue = 0.0, .saturation = 1.0, .value = 1.0 } },
+    .{ .rgb = .{ .r = 0.750, .g = 0.750, .b = 0.000 }, .hsv = .{ .hue = 60.0, .saturation = 1.000, .value = 0.750 } },
+    .{ .rgb = .{ .r = 0.000, .g = 0.500, .b = 0.000 }, .hsv = .{ .hue = 120.0, .saturation = 1.000, .value = 0.500 } },
+    .{ .rgb = .{ .r = 0.500, .g = 1.000, .b = 1.000 }, .hsv = .{ .hue = 180.0, .saturation = 0.500, .value = 1.00 } },
+    .{ .rgb = .{ .r = 0.500, .g = 0.500, .b = 1.000 }, .hsv = .{ .hue = 240.0, .saturation = 0.500, .value = 1.00 } },
+    .{ .rgb = .{ .r = 0.750, .g = 0.250, .b = 0.750 }, .hsv = .{ .hue = 300.0, .saturation = 0.667, .value = 0.750 } },
+    .{ .rgb = .{ .r = 0.628, .g = 0.643, .b = 0.142 }, .hsv = .{ .hue = 61.8, .saturation = 0.779, .value = 0.643 } },
+    .{ .rgb = .{ .r = 0.255, .g = 0.104, .b = 0.918 }, .hsv = .{ .hue = 251.1, .saturation = 0.887, .value = 0.918 } },
+    .{ .rgb = .{ .r = 0.116, .g = 0.675, .b = 0.255 }, .hsv = .{ .hue = 134.9, .saturation = 0.828, .value = 0.675 } },
+    .{ .rgb = .{ .r = 0.941, .g = 0.785, .b = 0.053 }, .hsv = .{ .hue = 49.5, .saturation = 0.944, .value = 0.941 } },
+    .{ .rgb = .{ .r = 0.704, .g = 0.187, .b = 0.897 }, .hsv = .{ .hue = 283.7, .saturation = 0.792, .value = 0.897 } },
+    .{ .rgb = .{ .r = 0.931, .g = 0.463, .b = 0.316 }, .hsv = .{ .hue = 14.3, .saturation = 0.661, .value = 0.931 } },
+    .{ .rgb = .{ .r = 0.998, .g = 0.974, .b = 0.532 }, .hsv = .{ .hue = 56.9, .saturation = 0.467, .value = 0.998 } },
+    .{ .rgb = .{ .r = 0.099, .g = 0.795, .b = 0.591 }, .hsv = .{ .hue = 162.4, .saturation = 0.875, .value = 0.795 } },
+    .{ .rgb = .{ .r = 0.211, .g = 0.149, .b = 0.597 }, .hsv = .{ .hue = 248.3, .saturation = 0.750, .value = 0.597 } },
+    .{ .rgb = .{ .r = 0.495, .g = 0.493, .b = 0.721 }, .hsv = .{ .hue = 240.5, .saturation = 0.316, .value = 0.721 } },
+};
+
+test "RGB to HSV conversion" {
+    for (RgbHsvTestData) |entry| {
+        const converted_hsv = color.Hsv.fromRgb(entry.rgb);
+
+        try helpers.expectApproxEqAbs(converted_hsv.hue, entry.hsv.hue, 0.1);
+        try helpers.expectApproxEqAbs(converted_hsv.saturation, entry.hsv.saturation, 0.1);
+        try helpers.expectApproxEqAbs(converted_hsv.value, entry.hsv.value, 0.1);
+    }
+}
+
+test "HSV to RGB conversion" {
+    for (RgbHsvTestData) |entry| {
+        const converted_rgb = color.Hsv.toRgb(entry.hsv);
+
+        try helpers.expectApproxEqAbs(converted_rgb.r, entry.rgb.r, 0.1);
+        try helpers.expectApproxEqAbs(converted_rgb.g, entry.rgb.g, 0.1);
+        try helpers.expectApproxEqAbs(converted_rgb.b, entry.rgb.b, 0.1);
+    }
+}
+
+test "HSV to HSL conversion" {
+    const hsv = color.Hsv{ .hue = 300.0, .saturation = 0.4140, .value = 0.8449 };
+    const converted_hsl = hsv.toHsl();
+
+    try helpers.expectApproxEqAbs(converted_hsl.hue, 300.0, 0.0001);
+    try helpers.expectApproxEqAbs(converted_hsl.saturation, 0.53, 0.0001);
+    try helpers.expectApproxEqAbs(converted_hsl.luminance, 0.67, 0.0001);
+}

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -664,7 +664,7 @@ test "Compute Linear sRGB RGB to XYZ matrix" {
 test "Linear sRGB to CIE XYZ" {
     const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
 
-    const result = color.sRGB.convertToXYZ(color_to_convert);
+    const result = color.sRGB.toXYZ(color_to_convert);
 
     const float_tolerance = 0.0001;
     try helpers.expectApproxEqAbs(result.x, 0.262599, float_tolerance);
@@ -747,4 +747,27 @@ test "Convert an array of Linear sRGB to ProPhotoRGB" {
         try helpers.expectApproxEqAbs(result.b, expected.b, float_tolerance);
         try helpers.expectApproxEqAbs(result.a, expected.a, float_tolerance);
     }
+}
+
+test "Convert a sRGB color to CIELAB" {
+    const source_color = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.toLab(source_color);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.47701, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
+}
+
+test "Convert a sRGB color to CIELAB with alpha" {
+    const source_color = color.Colorf32.initRgba(0.2, 0.1, 0.8, 0.5);
+
+    const result = color.sRGB.toLabAlpha(source_color);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.l, 0.48485, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 0.47701, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, -0.67469, float_tolerance);
+    try helpers.expectApproxEqAbs(result.alpha, 0.5, float_tolerance);
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -671,3 +671,51 @@ test "Linear sRGB to CIE XYZ" {
     try helpers.expectApproxEqAbs(result.y, 0.171790, float_tolerance);
     try helpers.expectApproxEqAbs(result.z, 0.776029, float_tolerance);
 }
+
+test "Convert Linear sRGB color to AdobeWideGamutRGB" {
+    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.convertColor(color.AdobeWideGamutRGB, color_to_convert);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.161246270, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.152638555, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.744218409, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 1.0, float_tolerance);
+}
+
+test "Convert Linear sRGB to DCI-P3 Display" {
+    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.convertColor(color.DCIP3.Display, color_to_convert);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.182245, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.103319, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.739062, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 1.0, float_tolerance);
+}
+
+test "Convert Linear sRGB to BT709 (sanity check)" {
+    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.convertColor(color.BT709, color_to_convert);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.2, float_tolerance);
+    try helpers.expectApproxEqAbs(result.g, 0.1, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.8, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 1.0, float_tolerance);
+}
+
+test "Convert Linear sRGB to BT2020" {
+    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+
+    const result = color.sRGB.convertColor(color.BT2020, color_to_convert);
+
+    const float_tolerance = 0.0001;
+    try helpers.expectApproxEqAbs(result.r, 0.193054512, float_tolerance); 
+    try helpers.expectApproxEqAbs(result.g, 0.114861697, float_tolerance);
+    try helpers.expectApproxEqAbs(result.b, 0.728544116, float_tolerance);
+    try helpers.expectApproxEqAbs(result.a, 1.0, float_tolerance);
+}

--- a/tests/helpers.zig
+++ b/tests/helpers.zig
@@ -11,16 +11,24 @@ pub const TestInput = struct {
     hex: u32 = 0,
 };
 
-pub fn expectEq(actual: anytype, expected: anytype) !void {
+pub inline fn expectEq(actual: anytype, expected: anytype) !void {
     try testing.expectEqual(@as(@TypeOf(actual), expected), actual);
 }
 
-pub fn expectEqSlice(comptime T: type, actual: []const T, expected: []const T) !void {
+pub inline fn expectEqSlice(comptime T: type, actual: []const T, expected: []const T) !void {
     try testing.expectEqualSlices(T, expected, actual);
 }
 
-pub fn expectError(actual: anytype, expected: anyerror) !void {
+pub inline fn expectError(actual: anytype, expected: anyerror) !void {
     try testing.expectError(expected, actual);
+}
+
+pub inline fn expectApproxEqAbs(actual: anytype, expected: anytype, tolerance: anytype) !void {
+    return try testing.expectApproxEqAbs(expected, actual, tolerance);
+}
+
+pub inline fn expectApproxEqRel(actual: anytype, expected: anytype, tolerance: anytype) !void {
+    return try testing.expectApproxEqRel(expected, actual, tolerance);
 }
 
 pub fn testOpenFile(file_path: []const u8) !std.fs.File {

--- a/tests/math_test.zig
+++ b/tests/math_test.zig
@@ -12,6 +12,19 @@ test "2x2 matrix identity" {
     try helpers.expectEq(identity_matrix.matrix[1][1], 1);
 }
 
+test "load 2x2 matrix from array" {
+    const result = math.float2x2.fromArray(.{
+        1, 2,
+        3, 4,
+    });
+
+    try helpers.expectEq(result.matrix[0][0], 1);
+    try helpers.expectEq(result.matrix[0][1], 2);
+
+    try helpers.expectEq(result.matrix[1][0], 3);
+    try helpers.expectEq(result.matrix[1][1], 4);
+}
+
 test "2x2 matrix determinant" {
     const matrix = math.float2x2.fromArray(.{
         1, 2,
@@ -54,4 +67,120 @@ test "2x2 matrix multiply to matrix" {
     try helpers.expectEq(result.matrix[0][1], 22);
     try helpers.expectEq(result.matrix[1][0], 43);
     try helpers.expectEq(result.matrix[1][1], 50);
+}
+
+test "2x2 matrix transpose" {
+    const matrix = math.float2x2.fromArray(.{
+        1, 2,
+        3, 4,
+    });
+
+    const result = matrix.transpose();
+
+    try helpers.expectEq(result.matrix[0][0], 1);
+    try helpers.expectEq(result.matrix[0][1], 3);
+    try helpers.expectEq(result.matrix[1][0], 2);
+    try helpers.expectEq(result.matrix[1][1], 4);
+}
+
+test "3x3 matrix identity" {
+    const identity_matrix = math.float3x3.identity();
+
+    try helpers.expectEq(identity_matrix.matrix[0][0], 1);
+    try helpers.expectEq(identity_matrix.matrix[0][1], 0);
+    try helpers.expectEq(identity_matrix.matrix[0][2], 0);
+
+    try helpers.expectEq(identity_matrix.matrix[1][0], 0);
+    try helpers.expectEq(identity_matrix.matrix[1][1], 1);
+    try helpers.expectEq(identity_matrix.matrix[1][2], 0);
+
+    try helpers.expectEq(identity_matrix.matrix[2][0], 0);
+    try helpers.expectEq(identity_matrix.matrix[2][1], 0);
+    try helpers.expectEq(identity_matrix.matrix[2][2], 1);
+}
+
+test "load 3x3 matrix from array" {
+    const result = math.float3x3.fromArray(.{
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9,
+    });
+
+    try helpers.expectEq(result.matrix[0][0], 1);
+    try helpers.expectEq(result.matrix[0][1], 2);
+    try helpers.expectEq(result.matrix[0][2], 3);
+
+    try helpers.expectEq(result.matrix[1][0], 4);
+    try helpers.expectEq(result.matrix[1][1], 5);
+    try helpers.expectEq(result.matrix[1][2], 6);
+
+    try helpers.expectEq(result.matrix[2][0], 7);
+    try helpers.expectEq(result.matrix[2][1], 8);
+    try helpers.expectEq(result.matrix[2][2], 9);
+}
+
+test "3x3 matrix multiply to vector" {
+    const matrix = math.float3x3.fromArray(.{
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9,
+    });
+
+    const vector: math.float3 = .{ 5, 6, 7 };
+
+    const result = matrix.mulVector(vector);
+
+    try helpers.expectEq(result[0], 38);
+    try helpers.expectEq(result[1], 92);
+    try helpers.expectEq(result[2], 146);
+}
+
+test "3x3 matrix multiply to matrix" {
+    const left_matrix = math.float3x3.fromArray(.{
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9,
+    });
+
+    const right_matrix = math.float3x3.fromArray(.{
+        9, 8, 7,
+        6, 5, 4,
+        3, 2, 11,
+    });
+
+    const result = left_matrix.mul(right_matrix);
+
+    try helpers.expectEq(result.matrix[0][0], 30);
+    try helpers.expectEq(result.matrix[0][1], 24);
+    try helpers.expectEq(result.matrix[0][2], 48);
+
+    try helpers.expectEq(result.matrix[1][0], 84);
+    try helpers.expectEq(result.matrix[1][1], 69);
+    try helpers.expectEq(result.matrix[1][2], 114);
+
+    try helpers.expectEq(result.matrix[2][0], 138);
+    try helpers.expectEq(result.matrix[2][1], 114);
+    try helpers.expectEq(result.matrix[2][2], 180);
+}
+
+test "3x3 matrix transpose" {
+    const matrix = math.float3x3.fromArray(.{
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9,
+    });
+
+    const result = matrix.transpose();
+
+    try helpers.expectEq(result.matrix[0][0], 1);
+    try helpers.expectEq(result.matrix[0][1], 4);
+    try helpers.expectEq(result.matrix[0][2], 7);
+
+    try helpers.expectEq(result.matrix[1][0], 2);
+    try helpers.expectEq(result.matrix[1][1], 5);
+    try helpers.expectEq(result.matrix[1][2], 8);
+
+    try helpers.expectEq(result.matrix[2][0], 3);
+    try helpers.expectEq(result.matrix[2][1], 6);
+    try helpers.expectEq(result.matrix[2][2], 9);
 }

--- a/tests/math_test.zig
+++ b/tests/math_test.zig
@@ -36,6 +36,21 @@ test "2x2 matrix determinant" {
     try helpers.expectEq(determinant, -2);
 }
 
+test "2x2 matrix inverse" {
+    const matrix = math.float2x2.fromArray(.{
+        1, 2,
+        3, 4,
+    });
+
+    const result = matrix.inverse();
+
+    try helpers.expectApproxEqAbs(result.matrix[0][0], -2, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][1], 1, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[1][0], 1.5, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][1], -0.5, 0.1);
+}
+
 test "2x2 matrix multiply to vector" {
     const matrix = math.float2x2.fromArray(.{
         1, 2,
@@ -227,6 +242,59 @@ test "3x3 matrix transpose" {
     try helpers.expectEq(result.matrix[2][2], 9);
 }
 
+test "4x4 matrix identity" {
+    const identity_matrix = math.float4x4.identity();
+
+    try helpers.expectEq(identity_matrix.matrix[0][0], 1);
+    try helpers.expectEq(identity_matrix.matrix[0][1], 0);
+    try helpers.expectEq(identity_matrix.matrix[0][2], 0);
+    try helpers.expectEq(identity_matrix.matrix[0][3], 0);
+
+    try helpers.expectEq(identity_matrix.matrix[1][0], 0);
+    try helpers.expectEq(identity_matrix.matrix[1][1], 1);
+    try helpers.expectEq(identity_matrix.matrix[1][2], 0);
+    try helpers.expectEq(identity_matrix.matrix[1][3], 0);
+
+    try helpers.expectEq(identity_matrix.matrix[2][0], 0);
+    try helpers.expectEq(identity_matrix.matrix[2][1], 0);
+    try helpers.expectEq(identity_matrix.matrix[2][2], 1);
+    try helpers.expectEq(identity_matrix.matrix[2][3], 0);
+
+    try helpers.expectEq(identity_matrix.matrix[3][0], 0);
+    try helpers.expectEq(identity_matrix.matrix[3][1], 0);
+    try helpers.expectEq(identity_matrix.matrix[3][2], 0);
+    try helpers.expectEq(identity_matrix.matrix[3][3], 1);
+}
+
+test "load 4x4 matrix from array" {
+    const matrix = math.float4x4.fromArray(.{
+        2, 3, 4, 5,
+        4, 4, 6, 7,
+        5, 6, 6, 8,
+        6, 1, 2, 3,
+    });
+
+    try helpers.expectEq(matrix.matrix[0][0], 2);
+    try helpers.expectEq(matrix.matrix[0][1], 3);
+    try helpers.expectEq(matrix.matrix[0][2], 4);
+    try helpers.expectEq(matrix.matrix[0][3], 5);
+
+    try helpers.expectEq(matrix.matrix[1][0], 4);
+    try helpers.expectEq(matrix.matrix[1][1], 4);
+    try helpers.expectEq(matrix.matrix[1][2], 6);
+    try helpers.expectEq(matrix.matrix[1][3], 7);
+
+    try helpers.expectEq(matrix.matrix[2][0], 5);
+    try helpers.expectEq(matrix.matrix[2][1], 6);
+    try helpers.expectEq(matrix.matrix[2][2], 6);
+    try helpers.expectEq(matrix.matrix[2][3], 8);
+
+    try helpers.expectEq(matrix.matrix[3][0], 6);
+    try helpers.expectEq(matrix.matrix[3][1], 1);
+    try helpers.expectEq(matrix.matrix[3][2], 2);
+    try helpers.expectEq(matrix.matrix[3][3], 3);
+}
+
 test "4x4 matrix determinant" {
     const matrix = math.float4x4.fromArray(.{
         2, 3, 4, 5,
@@ -268,4 +336,91 @@ test "4x4 matrix inverse" {
     try helpers.expectApproxEqAbs(result.matrix[3][1], -1.8, 0.1);
     try helpers.expectApproxEqAbs(result.matrix[3][2], -0.4, 0.1);
     try helpers.expectApproxEqAbs(result.matrix[3][3], 0.5, 0.1);
+}
+
+test "4x4 matrix multiply to vector" {
+    const matrix = math.float4x4.fromArray(.{
+        2,  3,  4,  5,
+        6,  7,  8,  9,
+        10, 11, 12, 13,
+        14, 15, 16, 17,
+    });
+
+    const vector: math.float4 = .{ 2, 3, 4, 5 };
+
+    const result = matrix.mulVector(vector);
+
+    try helpers.expectEq(result[0], 54);
+    try helpers.expectEq(result[1], 110);
+    try helpers.expectEq(result[2], 166);
+    try helpers.expectEq(result[3], 222);
+}
+
+test "4x4 matrix multiply to matrix" {
+    const left_matrix = math.float4x4.fromArray(.{
+        2,  3,  4,  5,
+        6,  7,  8,  9,
+        10, 11, 12, 13,
+        14, 15, 16, 17,
+    });
+
+    const right_matrix = math.float4x4.fromArray(.{
+        1, 5, 9,  13,
+        2, 6, 10, 14,
+        3, 7, 11, 15,
+        4, 8, 12, 16,
+    });
+
+    const result = left_matrix.mul(right_matrix);
+
+    try helpers.expectApproxEqAbs(result.matrix[0][0], 40, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][1], 96, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][2], 152, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][3], 208, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[1][0], 80, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][1], 200, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][2], 320, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][3], 440, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[2][0], 120, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][1], 304, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][2], 488, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][3], 672, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[3][0], 160, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][1], 408, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][2], 656, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][3], 904, 0.1);
+}
+
+test "4x4 matrix transpose" {
+    const matrix = math.float4x4.fromArray(.{
+        2,  3,  4,  5,
+        6,  7,  8,  9,
+        10, 11, 12, 13,
+        14, 15, 16, 17,
+    });
+
+    const result = matrix.transpose();
+
+    try helpers.expectApproxEqAbs(result.matrix[0][0], 2, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][1], 6, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][2], 10, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][3], 14, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[1][0], 3, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][1], 7, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][2], 11, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][3], 15, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[2][0], 4, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][1], 8, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][2], 12, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][3], 16, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[3][0], 5, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][1], 9, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][2], 13, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][3], 17, 0.1);
 }

--- a/tests/math_test.zig
+++ b/tests/math_test.zig
@@ -119,6 +119,26 @@ test "load 3x3 matrix from array" {
     try helpers.expectEq(result.matrix[2][2], 9);
 }
 
+test "3x3 matrix determinant" {
+    const matrix = math.float3x3.fromArray(.{
+        2, 3, 4,
+        4, 4, 6,
+        5, 6, 6,
+    });
+
+    const determinant = matrix.determinant();
+    try helpers.expectEq(determinant, 10);
+
+    const non_determinant_matrix = math.float3x3.fromArray(.{
+        1, 2, 3,
+        4, 5, 6,
+        7, 8, 9,
+    });
+
+    const non_determinant = non_determinant_matrix.determinant();
+    try helpers.expectEq(non_determinant, 0);
+}
+
 test "3x3 matrix multiply to vector" {
     const matrix = math.float3x3.fromArray(.{
         1, 2, 3,
@@ -183,4 +203,16 @@ test "3x3 matrix transpose" {
     try helpers.expectEq(result.matrix[2][0], 3);
     try helpers.expectEq(result.matrix[2][1], 6);
     try helpers.expectEq(result.matrix[2][2], 9);
+}
+
+test "4x4 matrix determinant" {
+    const matrix = math.float4x4.fromArray(.{
+        2, 3, 4, 5,
+        4, 4, 6, 7,
+        5, 6, 6, 8,
+        6, 1, 2, 3,
+    });
+
+    const determinant = matrix.determinant();
+    try helpers.expectEq(determinant, 18);
 }

--- a/tests/math_test.zig
+++ b/tests/math_test.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+const testing = std.testing;
+const math = @import("../src/math.zig");
+const helpers = @import("helpers.zig");
+
+test "2x2 matrix identity" {
+    const identity_matrix = math.float2x2.identity();
+
+    try helpers.expectEq(identity_matrix.matrix[0][0], 1);
+    try helpers.expectEq(identity_matrix.matrix[0][1], 0);
+    try helpers.expectEq(identity_matrix.matrix[1][0], 0);
+    try helpers.expectEq(identity_matrix.matrix[1][1], 1);
+}
+
+test "2x2 matrix determinant" {
+    const matrix = math.float2x2.fromArray(.{
+        1, 2,
+        3, 4,
+    });
+
+    const determinant = matrix.determinant();
+
+    try helpers.expectEq(determinant, -2);
+}
+
+test "2x2 matrix multiply to vector" {
+    const matrix = math.float2x2.fromArray(.{
+        1, 2,
+        3, 4,
+    });
+
+    const vector: math.float2 = .{ 5, 6 };
+
+    const result = matrix.mulVector(vector);
+
+    try helpers.expectEq(result[0], 17);
+    try helpers.expectEq(result[1], 39);
+}
+
+test "2x2 matrix multiply to matrix" {
+    const left_matrix = math.float2x2.fromArray(.{
+        1, 2,
+        3, 4,
+    });
+
+    const right_matrix = math.float2x2.fromArray(.{
+        5, 6,
+        7, 8,
+    });
+
+    const result = left_matrix.mul(right_matrix);
+
+    try helpers.expectEq(result.matrix[0][0], 19);
+    try helpers.expectEq(result.matrix[0][1], 22);
+    try helpers.expectEq(result.matrix[1][0], 43);
+    try helpers.expectEq(result.matrix[1][1], 50);
+}

--- a/tests/math_test.zig
+++ b/tests/math_test.zig
@@ -139,6 +139,28 @@ test "3x3 matrix determinant" {
     try helpers.expectEq(non_determinant, 0);
 }
 
+test "3x3 matrix inverse" {
+    const matrix = math.float3x3.fromArray(.{
+        2, 3, 4,
+        4, 4, 6,
+        5, 6, 6,
+    });
+
+    const result = matrix.inverse();
+
+    try helpers.expectApproxEqAbs(result.matrix[0][0], -1.2, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][1], 0.6, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][2], 0.2, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[1][0], 0.6, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][1], -0.8, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][2], 0.4, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[2][0], 0.4, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][1], 0.3, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][2], -0.4, 0.1);
+}
+
 test "3x3 matrix multiply to vector" {
     const matrix = math.float3x3.fromArray(.{
         1, 2, 3,
@@ -215,4 +237,35 @@ test "4x4 matrix determinant" {
 
     const determinant = matrix.determinant();
     try helpers.expectEq(determinant, 18);
+}
+
+test "4x4 matrix inverse" {
+    const matrix = math.float4x4.fromArray(.{
+        2, 3, 4, 5,
+        4, 4, 6, 7,
+        5, 6, 6, 8,
+        6, 1, 2, 3,
+    });
+
+    const result = matrix.inverse();
+
+    try helpers.expectApproxEqAbs(result.matrix[0][0], -0.5, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][1], 0.2, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][2], 0.1, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[0][3], 0.1, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[1][0], -1.3, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][1], 0.3, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][2], 0.6, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[1][3], -0.3, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[2][0], -2.5, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][1], 2, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][2], 0, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[2][3], -0.5, 0.1);
+
+    try helpers.expectApproxEqAbs(result.matrix[3][0], 3.2, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][1], -1.8, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][2], -0.4, 0.1);
+    try helpers.expectApproxEqAbs(result.matrix[3][3], 0.5, 0.1);
 }

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -2,17 +2,18 @@ pub const AllFormats = @import("src/formats/all.zig");
 pub const bmp = @import("src/formats/bmp.zig");
 pub const color = @import("src/color.zig");
 pub const FormatInterface = @import("src/FormatInterface.zig");
-pub const Image = @import("src/Image.zig");
 pub const gif = @import("src/formats/gif.zig");
+pub const Image = @import("src/Image.zig");
+pub const jpeg = @import("src/formats/jpeg.zig");
+pub const math = @import("src/math.zig");
 pub const netpbm = @import("src/formats/netpbm.zig");
 pub const OctTreeQuantizer = @import("src/octree_quantizer.zig").OctTreeQuantizer;
+pub const pam = @import("src/formats/pam.zig");
 pub const pcx = @import("src/formats/pcx.zig");
 pub const PixelFormat = @import("src/pixel_format.zig").PixelFormat;
-pub const jpeg = @import("src/formats/jpeg.zig");
 pub const png = @import("src/formats/png.zig");
 pub const qoi = @import("src/formats/qoi.zig");
 pub const tga = @import("src/formats/tga.zig");
-pub const pam = @import("src/formats/pam.zig");
 
 test {
     const std = @import("std");
@@ -33,6 +34,7 @@ test {
         @import("tests/formats/qoi_test.zig"),
         @import("tests/formats/tga_test.zig"),
         @import("tests/image_test.zig"),
+        @import("tests/math_test.zig"),
         @import("tests/octree_quantizer_test.zig"),
         @import("tests/pixel_format_test.zig"),
     }) |source_file| std.testing.refAllDeclsRecursive(source_file);


### PR DESCRIPTION
Add Colorspace that define a RGB color using CIE xyY color coordinate for red, green, blue and white. Colorspace can convert from gamma-converted to linear and vice-versa. Also Colorspace contains lots of functions to convert to device-inpedendant color spaces 

Added predefined RGB colorspaces:
* sRGB
* Rec. 601 (NTSC,PAL)
* Rec. 709
* BT.2020 (Rec. 2020)
* Adobe RGB
* Adobe Wide Gammut
* ProPhoto RGB

Add the following color models and color spaces:
* HSL,
* HSV
* CMYK
* HSLuv
* CIE XYZ
* CIE L*a*b*
* CIE L*u*v*
* CIE LCh(ab), cylindrical version of CIE Lab
* CIE LCh(uv), cylindrical version of CIE Luv
* Oklab
* OkLCh, cylindrical version of Oklab

Closes #34 