### PR TITLE
Add support for farbfeld format https://tools.suckless.org/farbfeld/

### DIFF
--- a/src/ImageUnmanaged.zig
+++ b/src/ImageUnmanaged.zig
@@ -42,6 +42,7 @@ pub const Format = enum {
     qoi,
     tga,
     pam,
+    farbfeld,
 };
 
 pub const Stream = std.io.StreamSource;

--- a/src/formats/all.zig
+++ b/src/formats/all.zig
@@ -22,4 +22,5 @@ pub const ImageEncoderOptions = union(@import("../Image.zig").Format) {
     qoi: QOI.EncoderOptions,
     tga: TGA.EncoderOptions,
     pam: PAM.EncoderOptions,
+    farbfeld: void,
 };

--- a/src/formats/farbfeld.zig
+++ b/src/formats/farbfeld.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const mem = std.mem;
+const Allocator = std.mem.Allocator;
+const assert = std.debug.assert;
+const ImageUnmanaged = @import("../ImageUnmanaged.zig");
+const FormatInterface = @import("../FormatInterface.zig");
+const color = @import("../color.zig");
+const utils = @import("../utils.zig");
+const buffered_stream_source = @import("../buffered_stream_source.zig");
+
+pub const ReadError = ImageUnmanaged.ReadError;
+pub const WriteError = ImageUnmanaged.WriteError || error{BigDimensions};
+
+pub const Header = extern struct {
+    const width_size = 4;
+    const height_size = 4;
+    const size = 16;
+    const magic_value: [8]u8 = [8]u8{ 'f', 'a', 'r', 'b', 'f', 'e', 'l', 'd' };
+
+    width: u32 align(1),
+    height: u32 align(1),
+
+    fn encode(header: Header) [size]u8 {
+        var result: [size]u8 = undefined;
+        @memcpy(result[0..8], &magic_value);
+        std.mem.writeInt(u32, result[8..12], header.width, .big);
+        std.mem.writeInt(u32, result[12..16], header.height, .big);
+        return result;
+    }
+    comptime {
+        assert(size == 16);
+    }
+};
+
+pub fn formatInterface() FormatInterface {
+    return FormatInterface{
+        .format = format,
+        .formatDetect = formatDetect,
+        .readImage = readImage,
+        .writeImage = writeImage,
+    };
+}
+
+pub fn format() ImageUnmanaged.Format {
+    return ImageUnmanaged.format.farbfeld;
+}
+/// Taken a stream, Returns true if and only if the stream contains the magic value "fabfeld"
+pub fn formatDetect(stream: *ImageUnmanaged.Stream) ReadError!bool {
+    var magic_buffer: [Header.magic_value.len]u8 = undefined;
+    const bytes_read = try stream.read(magic_buffer[0..]);
+    return bytes_read == Header.magic_value.len and
+        mem.eql(u8, magic_buffer[0..], Header.magic_value[0..]);
+}
+/// consume stream and returns ImageUnmanaged as farbfeld format. pixelformat is rgba64 and does not have animation. Caller owns returned memory. https://tools.suckless.org/farbfeld/
+pub fn readImage(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ReadError!ImageUnmanaged {
+    var image: ImageUnmanaged = .{};
+    // read header magic value
+    var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
+    const reader = buffered_stream.reader();
+
+    const magic_match: bool = reader.isBytes(&Header.magic_value) catch return ReadError.InvalidData;
+    if (!magic_match)
+        return ReadError.InvalidData;
+
+    // read width and height
+    const header = utils.readStruct(reader, Header, .big) catch return ReadError.InvalidData;
+    image.width = header.width;
+    image.height = header.height;
+
+    image.pixels = try color.PixelStorage.init(allocator, .rgba64, @as(usize, header.width) * @as(usize, header.height));
+    const pixels: *color.PixelStorage = &image.pixels;
+    errdefer pixels.deinit(allocator);
+
+    // const pixels_size: usize = header.width * header.height;
+
+    for (pixels.rgba64) |*pixel| {
+        const pixel_color = utils.readStruct(reader, color.Rgba64, .big) catch return ReadError.InvalidData;
+        pixel.* = pixel_color;
+    }
+    return image;
+}
+/// write image into write_stream in farbfeld format. Will error if the width or the height of the image exceeds the limits. Does not deinitialize the image.
+pub fn writeImage(_: Allocator, write_stream: *ImageUnmanaged.Stream, image: ImageUnmanaged, _: ImageUnmanaged.EncoderOptions) WriteError!void {
+    // we don't need any extra memory and there are no encoding options
+    // get header width and height
+    const width = std.math.cast(u32, image.width);
+    const height = std.math.cast(u32, image.height);
+    if (width == null or height == null)
+        return WriteError.BigDimensions;
+
+    var header = Header{ .width = width.?, .height = height.? };
+
+    var buffered_stream = buffered_stream_source.bufferedStreamSourceWriter(write_stream);
+    const writer = buffered_stream.writer();
+
+    // write header
+    try writer.writeAll(&header.encode());
+    // take advantage of platform endianess if possible
+    if (builtin.cpu.arch.endian() == .big) {
+        const pixels_bytes = image.pixels.asConstBytes();
+        try writer.writeAll(pixels_bytes);
+    } else {
+        for (image.pixels.rgba64) |pixel| {
+            try writer.writeStructEndian(pixel, .big);
+        }
+    }
+    try buffered_stream.flush();
+}

--- a/src/formats/farbfeld.zig
+++ b/src/formats/farbfeld.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const assert = std.debug.assert;
 const ImageUnmanaged = @import("../ImageUnmanaged.zig");
@@ -13,13 +12,13 @@ pub const ReadError = ImageUnmanaged.ReadError;
 pub const WriteError = ImageUnmanaged.WriteError || error{BigDimensions};
 
 pub const Header = extern struct {
-    const width_size = 4;
-    const height_size = 4;
-    const size = 16;
-    const magic_value: [8]u8 = [8]u8{ 'f', 'a', 'r', 'b', 'f', 'e', 'l', 'd' };
-
     width: u32 align(1),
     height: u32 align(1),
+
+    pub const size = 16;
+    const width_size = 4;
+    const height_size = 4;
+    const magic_value: [8]u8 = "farbfeld".*;
 
     fn encode(header: Header) [size]u8 {
         var result: [size]u8 = undefined;
@@ -29,81 +28,92 @@ pub const Header = extern struct {
         return result;
     }
     comptime {
-        assert(size == 16);
+        assert(@sizeOf(Header) + @sizeOf(@TypeOf(magic_value)) == size);
     }
 };
 
-pub fn formatInterface() FormatInterface {
-    return FormatInterface{
-        .format = format,
-        .formatDetect = formatDetect,
-        .readImage = readImage,
-        .writeImage = writeImage,
-    };
-}
+pub const Farbfeld = struct {
+    header: Header,
+    pixels: []color.Rgba64,
 
-pub fn format() ImageUnmanaged.Format {
-    return ImageUnmanaged.format.farbfeld;
-}
-/// Taken a stream, Returns true if and only if the stream contains the magic value "fabfeld"
-pub fn formatDetect(stream: *ImageUnmanaged.Stream) ReadError!bool {
-    var magic_buffer: [Header.magic_value.len]u8 = undefined;
-    const bytes_read = try stream.read(magic_buffer[0..]);
-    return bytes_read == Header.magic_value.len and
-        mem.eql(u8, magic_buffer[0..], Header.magic_value[0..]);
-}
-/// consume stream and returns ImageUnmanaged as farbfeld format. pixelformat is rgba64 and does not have animation. Caller owns returned memory. https://tools.suckless.org/farbfeld/
-pub fn readImage(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ReadError!ImageUnmanaged {
-    var image: ImageUnmanaged = .{};
-    // read header magic value
-    var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
-    const reader = buffered_stream.reader();
-
-    const magic_match: bool = reader.isBytes(&Header.magic_value) catch return ReadError.InvalidData;
-    if (!magic_match)
-        return ReadError.InvalidData;
-
-    // read width and height
-    const header = utils.readStruct(reader, Header, .big) catch return ReadError.InvalidData;
-    image.width = header.width;
-    image.height = header.height;
-
-    image.pixels = try color.PixelStorage.init(allocator, .rgba64, @as(usize, header.width) * @as(usize, header.height));
-    const pixels: *color.PixelStorage = &image.pixels;
-    errdefer pixels.deinit(allocator);
-
-    // const pixels_size: usize = header.width * header.height;
-
-    for (pixels.rgba64) |*pixel| {
-        const pixel_color = utils.readStruct(reader, color.Rgba64, .big) catch return ReadError.InvalidData;
-        pixel.* = pixel_color;
+    pub fn formatInterface() FormatInterface {
+        return FormatInterface{
+            .format = format,
+            .formatDetect = formatDetect,
+            .readImage = readImage,
+            .writeImage = writeImage,
+        };
     }
-    return image;
-}
-/// write image into write_stream in farbfeld format. Will error if the width or the height of the image exceeds the limits. Does not deinitialize the image.
-pub fn writeImage(_: Allocator, write_stream: *ImageUnmanaged.Stream, image: ImageUnmanaged, _: ImageUnmanaged.EncoderOptions) WriteError!void {
-    // we don't need any extra memory and there are no encoding options
-    // get header width and height
-    const width = std.math.cast(u32, image.width);
-    const height = std.math.cast(u32, image.height);
-    if (width == null or height == null)
-        return WriteError.BigDimensions;
 
-    var header = Header{ .width = width.?, .height = height.? };
+    pub fn format() ImageUnmanaged.Format {
+        return ImageUnmanaged.format.farbfeld;
+    }
+    /// Taken a stream, Returns true if and only if the stream contains the magic value "fabfeld"
+    pub fn formatDetect(stream: *ImageUnmanaged.Stream) ReadError!bool {
+        var magic_buffer: [Header.magic_value.len]u8 = undefined;
+        const bytes_read = try stream.read(magic_buffer[0..]);
+        return bytes_read == Header.magic_value.len and
+            std.mem.eql(u8, magic_buffer[0..], Header.magic_value[0..]);
+    }
+    pub fn read(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ReadError!Farbfeld {
+        var farbfeld: Farbfeld = undefined;
+        // read header magic value
+        var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
+        const reader = buffered_stream.reader();
 
-    var buffered_stream = buffered_stream_source.bufferedStreamSourceWriter(write_stream);
-    const writer = buffered_stream.writer();
+        const magic_match: bool = reader.isBytes(&Header.magic_value) catch return ReadError.InvalidData;
+        if (!magic_match)
+            return ReadError.InvalidData;
 
-    // write header
-    try writer.writeAll(&header.encode());
-    // take advantage of platform endianess if possible
-    if (builtin.cpu.arch.endian() == .big) {
-        const pixels_bytes = image.pixels.asConstBytes();
-        try writer.writeAll(pixels_bytes);
-    } else {
-        for (image.pixels.rgba64) |pixel| {
-            try writer.writeStructEndian(pixel, .big);
+        // read width and height
+        const header = utils.readStruct(reader, Header, .big) catch return ReadError.InvalidData;
+        farbfeld.header = header;
+
+        farbfeld.pixels = try allocator.alloc(color.Rgba64, @as(usize, header.width) * @as(usize, header.height));
+        errdefer allocator.free(farbfeld.pixels);
+
+        for (farbfeld.pixels) |*pixel| {
+            const pixel_color = utils.readStruct(reader, color.Rgba64, .big) catch return ReadError.InvalidData;
+            pixel.* = pixel_color;
         }
+        return farbfeld;
     }
-    try buffered_stream.flush();
-}
+    pub fn readImage(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ReadError!ImageUnmanaged {
+        var image: ImageUnmanaged = .{};
+        const farbfeld = try read(allocator, stream);
+        image.width = farbfeld.header.width;
+        image.height = farbfeld.header.height;
+        image.pixels = .{ .rgba64 = farbfeld.pixels };
+        return image;
+    }
+    pub fn write(self: Farbfeld, write_stream: *ImageUnmanaged.Stream) WriteError!void {
+        // get header width and height
+        const width: u32 = @intCast(self.header.width);
+        const height: u32 = @intCast(self.header.height);
+
+        var header = Header{ .width = width, .height = height };
+
+        var buffered_stream = buffered_stream_source.bufferedStreamSourceWriter(write_stream);
+        const writer = buffered_stream.writer();
+
+        // write header
+        try writer.writeAll(&header.encode());
+        // take advantage of platform endianess if possible
+        if (builtin.cpu.arch.endian() == .big) {
+            const pixels_bytes = std.mem.sliceAsBytes(self.pixels);
+            try writer.writeAll(pixels_bytes);
+        } else {
+            for (self.pixels) |pixel| {
+                try writer.writeStructEndian(pixel, .big);
+            }
+        }
+        try buffered_stream.flush();
+    }
+    pub fn writeImage(_: Allocator, write_stream: *ImageUnmanaged.Stream, image: ImageUnmanaged, _: ImageUnmanaged.EncoderOptions) WriteError!void {
+        const farbfeld: Farbfeld = .{
+            .header = .{ .width = @intCast(image.width), .height = @intCast(image.height) },
+            .pixels = image.pixels.rgba64,
+        };
+        try write(farbfeld, write_stream);
+    }
+};

--- a/tests/formats/farbfeld_test.zig
+++ b/tests/formats/farbfeld_test.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+const farbfeld = @import("../../src/formats/farbfeld.zig");
+const Image = @import("../../src/Image.zig");
+const ImageUnmanaged = @import("../../src/ImageUnmanaged.zig");
+const PixelFormat = @import("../../src/pixel_format.zig").PixelFormat;
+const helpers = @import("../helpers.zig");
+
+const testing = std.testing;
+const assert = std.debug.assert;
+
+test "check dimension file" {
+    const allocator = testing.allocator;
+    const yellow_file_path = "tests/test-suite/fixtures/" ++ "farbfeld/yellow-1x1-semitransparent.png.ff";
+    var yellow_image = try getff(allocator, yellow_file_path);
+    defer yellow_image.deinit(allocator);
+    try testing.expectEqual(yellow_image.width, 1);
+    try testing.expectEqual(yellow_image.height, 1);
+
+    const dragon_path = "tests/test-suite/fixtures/" ++ "farbfeld/dragon.ff";
+    var dragon_image = try getff(allocator, dragon_path);
+    defer dragon_image.deinit(allocator);
+    try testing.expectEqual(dragon_image.width, 1680);
+    try testing.expectEqual(dragon_image.height, 1167);
+
+    // try helpers.expectEq(try farbfeld.Farbfeld.formatDetect(&stream_source));
+
+}
+
+test "invalid file format" {
+    const allocator = testing.allocator;
+    const png_file_path = "tests/test-suite/fixtures/" ++ "farbfeld/dragon.png";
+    const image = getff(allocator, png_file_path);
+
+    try testing.expectError(farbfeld.ReadError.InvalidData, image);
+}
+
+fn getff(allocator: std.mem.Allocator, file_path: []const u8) !ImageUnmanaged {
+    const file = try std.fs.cwd().openFile(file_path, .{});
+    {
+        // var reader = file.reader();
+        // // for (0..8) |_| {
+        // //     std.debug.print("{c} ", .{try reader.readByte()});
+        // // }
+        // std.debug.print("magic match {}, file {s}\n", .{ try reader.isBytes(&farbfeld.Header.magic_value), file_path });
+    }
+    defer file.close();
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const image_farb = try farbfeld.readImage(allocator, &stream_source);
+    return image_farb;
+}

--- a/tests/formats/farbfeld_test.zig
+++ b/tests/formats/farbfeld_test.zig
@@ -2,50 +2,62 @@ const std = @import("std");
 const farbfeld = @import("../../src/formats/farbfeld.zig");
 const Image = @import("../../src/Image.zig");
 const ImageUnmanaged = @import("../../src/ImageUnmanaged.zig");
-const PixelFormat = @import("../../src/pixel_format.zig").PixelFormat;
 const helpers = @import("../helpers.zig");
 
 const testing = std.testing;
 const assert = std.debug.assert;
 
 test "check dimension file" {
-    const allocator = testing.allocator;
-    const yellow_file_path = "tests/test-suite/fixtures/" ++ "farbfeld/yellow-1x1-semitransparent.png.ff";
-    var yellow_image = try getff(allocator, yellow_file_path);
-    defer yellow_image.deinit(allocator);
+    const yellow_file_path = "yellow-1x1-semitransparent.png.ff";
+    var yellow_image = try getff(helpers.zigimg_test_allocator, yellow_file_path);
+    defer yellow_image.deinit(helpers.zigimg_test_allocator);
+
     try testing.expectEqual(yellow_image.width, 1);
     try testing.expectEqual(yellow_image.height, 1);
+    try testing.expect(yellow_image.pixels == .rgba64);
 
-    const dragon_path = "tests/test-suite/fixtures/" ++ "farbfeld/dragon.ff";
-    var dragon_image = try getff(allocator, dragon_path);
-    defer dragon_image.deinit(allocator);
+    const dragon_path = "dragon.ff";
+    var dragon_image = try getff(helpers.zigimg_test_allocator, dragon_path);
+    defer dragon_image.deinit(helpers.zigimg_test_allocator);
+
     try testing.expectEqual(dragon_image.width, 1680);
     try testing.expectEqual(dragon_image.height, 1167);
-
-    // try helpers.expectEq(try farbfeld.Farbfeld.formatDetect(&stream_source));
-
+    try testing.expect(dragon_image.pixels == .rgba64);
 }
 
 test "invalid file format" {
-    const allocator = testing.allocator;
-    const png_file_path = "tests/test-suite/fixtures/" ++ "farbfeld/dragon.png";
-    const image = getff(allocator, png_file_path);
+    const png_file_path = "dragon.png";
+    const image = getff(helpers.zigimg_test_allocator, png_file_path);
 
     try testing.expectError(farbfeld.ReadError.InvalidData, image);
 }
 
-fn getff(allocator: std.mem.Allocator, file_path: []const u8) !ImageUnmanaged {
-    const file = try std.fs.cwd().openFile(file_path, .{});
-    {
-        // var reader = file.reader();
-        // // for (0..8) |_| {
-        // //     std.debug.print("{c} ", .{try reader.readByte()});
-        // // }
-        // std.debug.print("magic match {}, file {s}\n", .{ try reader.isBytes(&farbfeld.Header.magic_value), file_path });
-    }
+test "read writeImage output" {
+    const dragon_path = "yellow-1x1-semitransparent.png.ff";
+    var source_image = try getff(helpers.zigimg_test_allocator, dragon_path);
+    defer source_image.deinit(helpers.zigimg_test_allocator);
+    var buf: [farbfeld.Header.size + @sizeOf(farbfeld.color.Rgba64) * 1]u8 = undefined;
+    var stream = Image.Stream{
+        .buffer = std.io.fixedBufferStream(&buf),
+    };
+
+    try farbfeld.Farbfeld.writeImage(helpers.zigimg_test_allocator, &stream, source_image, .{ .farbfeld = {} });
+    stream.buffer = std.io.fixedBufferStream(stream.buffer.getWritten());
+
+    var decoded_image = try farbfeld.Farbfeld.readImage(helpers.zigimg_test_allocator, &stream);
+    defer decoded_image.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(decoded_image.width, source_image.width);
+    try helpers.expectEq(decoded_image.height, source_image.height);
+    try testing.expect(decoded_image.pixels == .rgba64);
+}
+
+fn getff(allocator: std.mem.Allocator, comptime file_path: []const u8) !ImageUnmanaged {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "farbfeld/" ++ file_path);
     defer file.close();
+
     var stream_source = std.io.StreamSource{ .file = file };
 
-    const image_farb = try farbfeld.readImage(allocator, &stream_source);
+    const image_farb = try farbfeld.Farbfeld.readImage(allocator, &stream_source);
     return image_farb;
 }

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -17,6 +17,7 @@ pub const PixelFormatConverter = @import("src/PixelFormatConverter.zig");
 pub const png = @import("src/formats/png.zig");
 pub const qoi = @import("src/formats/qoi.zig");
 pub const tga = @import("src/formats/tga.zig");
+pub const farbfeld = @import("src/formats/farbfeld.zig");
 
 test {
     const std = @import("std");
@@ -36,6 +37,7 @@ test {
         @import("tests/formats/png_test.zig"),
         @import("tests/formats/qoi_test.zig"),
         @import("tests/formats/tga_test.zig"),
+        @import("tests/formats/farbfeld_test.zig"),
         @import("tests/image_test.zig"),
         @import("tests/math_test.zig"),
         @import("tests/octree_quantizer_test.zig"),


### PR DESCRIPTION
tried following the conventions I found in qoi.zig and png.zig.
I also added a basic test for reading width and height and reading invalid file.
I did test writing an image but I am still not combortable with the api so I didn't commit that test.

Looking forward for your opinion