### PR TITLE
#178 - fix for 0.14 TypeInfo changes

### DIFF
--- a/src/ImageUnmanaged.zig
+++ b/src/ImageUnmanaged.zig
@@ -93,8 +93,8 @@ const all_interface_funcs = blk: {
         const entry_type = @TypeOf(decl_value);
         if (entry_type == type) {
             const entryTypeInfo = @typeInfo(decl_value);
-            if (entryTypeInfo == .Struct) {
-                for (entryTypeInfo.Struct.decls) |structEntry| {
+            if (entryTypeInfo == .@"struct") {
+                for (entryTypeInfo.@"struct".decls) |structEntry| {
                     if (std.mem.eql(u8, structEntry.name, "formatInterface")) {
                         result = result ++ [_]FormatInteraceFnType{
                             @field(decl_value, structEntry.name),

--- a/src/color.zig
+++ b/src/color.zig
@@ -13,7 +13,7 @@ pub inline fn scaleToIntColor(comptime T: type, value: anytype) T {
     const ValueT = @TypeOf(value);
     if (ValueT == comptime_int) return @as(T, value);
     const ValueTypeInfo = @typeInfo(ValueT);
-    if (ValueTypeInfo != .Int or ValueTypeInfo.Int.signedness != .unsigned) {
+    if (ValueTypeInfo != .int or ValueTypeInfo.int.signedness != .unsigned) {
         @compileError("scaleToInColor only accepts unsigned integers as values. Got " ++ @typeName(ValueT) ++ ".");
     }
     const cur_value_bits = @bitSizeOf(ValueT);

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -376,7 +376,7 @@ pub const BMP = struct {
     }
 
     fn readPixelsInternal(pixels: anytype, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader, pixel_width: i32, pixel_height: i32) ImageUnmanaged.ReadError!void {
-        const ColorBufferType = @typeInfo(@TypeOf(pixels)).Pointer.child;
+        const ColorBufferType = @typeInfo(@TypeOf(pixels)).pointer.child;
 
         var x: i32 = 0;
         var y: i32 = pixel_height - 1;

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -74,8 +74,8 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
 fn pixelByteSwappedIndex(storage: color.PixelStorage, index: usize) usize {
     return switch (storage) {
         .invalid => index,
-        inline .indexed1, .indexed2, .indexed4, .indexed8, .indexed16 => |data| byteSwappedIndex(@typeInfo(@TypeOf(data.indices)).Pointer.child, index),
-        inline else => |data| byteSwappedIndex(@typeInfo(@TypeOf(data)).Pointer.child, index),
+        inline .indexed1, .indexed2, .indexed4, .indexed8, .indexed16 => |data| byteSwappedIndex(@typeInfo(@TypeOf(data.indices)).pointer.child, index),
+        inline else => |data| byteSwappedIndex(@typeInfo(@TypeOf(data)).pointer.child, index),
     };
 }
 
@@ -85,11 +85,11 @@ fn byteSwappedIndex(comptime T: type, byte_index: usize) usize {
     const element_offset = element_index * @sizeOf(T);
     const index = byte_index % @sizeOf(T);
     switch (@typeInfo(T)) {
-        .Int => {
+        .int => {
             if (@sizeOf(T) == 1) return byte_index;
             return element_offset + @sizeOf(T) - 1 - index;
         },
-        .Struct => |info| {
+        .@"struct" => |info| {
             inline for (info.fields) |field| {
                 if (index >= @offsetOf(T, field.name) or index <= @offsetOf(T, field.name) + @sizeOf(field.type)) {
                     if (@sizeOf(field.type) == 1) return byte_index;

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -639,8 +639,8 @@ pub const ReaderProcessor = struct {
         const Ptr = @TypeOf(context);
         const ptr_info = @typeInfo(Ptr);
 
-        std.debug.assert(ptr_info == .Pointer); // Must be a pointer
-        std.debug.assert(ptr_info.Pointer.size == .One); // Must be a single-item pointer
+        std.debug.assert(ptr_info == .pointer); // Must be a pointer
+        std.debug.assert(ptr_info.pointer.size == .One); // Must be a single-item pointer
 
         const gen = struct {
             fn chunkProcessor(ptr: *anyopaque, data: *ChunkProcessData) ImageUnmanaged.ReadError!PixelFormat {

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -335,12 +335,12 @@ fn RunLengthSIMDEncoder(comptime IntType: type) type {
     return struct {
         const VectorLength = std.simd.suggestVectorLength(IntType) orelse 4;
         const VectorType = @Vector(VectorLength, IntType);
-        const BytesPerPixels = (@typeInfo(IntType).Int.bits + 7) / 8;
+        const BytesPerPixels = (@typeInfo(IntType).int.bits + 7) / 8;
         const IndexStep = VectorLength * BytesPerPixels;
         const MaskType = std.meta.Int(.unsigned, VectorLength);
 
         comptime {
-            if (!std.math.isPowerOfTwo(@typeInfo(IntType).Int.bits)) {
+            if (!std.math.isPowerOfTwo(@typeInfo(IntType).int.bits)) {
                 @compileError("Only power of two integers are supported by the run-length SIMD encoder");
             }
         }

--- a/src/simd.zig
+++ b/src/simd.zig
@@ -54,16 +54,16 @@ pub fn floatToInt(comptime DestinationType: type, source: anytype, comptime leng
 
 fn vectorLength(comptime VectorType: type) comptime_int {
     return switch (@typeInfo(VectorType)) {
-        .Vector => |info| info.len,
-        .Array => |info| info.len,
+        .vector => |info| info.len,
+        .array => |info| info.len,
         else => @compileError("Invalid type " ++ @typeName(VectorType)),
     };
 }
 
 fn vectorInnerType(comptime VectorType: type) type {
     return switch (@typeInfo(VectorType)) {
-        .Vector => |info| info.child,
-        .Array => |info| info.child,
+        .vector => |info| info.child,
+        .array => |info| info.child,
         else => @compileError("Invalid type " ++ @typeName(VectorType)),
     };
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -53,14 +53,14 @@ pub inline fn toMagicNumber(magic: []const u8, comptime wanted_endian: std.built
 }
 
 fn checkEnumFields(data: anytype) StructReadError!void {
-    const T = @typeInfo(@TypeOf(data)).Pointer.child;
+    const T = @typeInfo(@TypeOf(data)).pointer.child;
     inline for (std.meta.fields(T)) |entry| {
         switch (@typeInfo(entry.type)) {
-            .Enum => {
+            .@"enum" => {
                 const value = @intFromEnum(@field(data, entry.name));
                 _ = std.meta.intToEnum(entry.type, value) catch return StructReadError.InvalidData;
             },
-            .Struct => {
+            .@"struct" => {
                 try checkEnumFields(&@field(data, entry.name));
             },
             else => {},
@@ -104,18 +104,18 @@ pub fn writeStructForeign(writer: anytype, value: anytype) StructWriteError!void
 
 // Extend std.mem.byteSwapAllFields to support enums
 fn swapFieldBytes(data: anytype) StructReadError!void {
-    const T = @typeInfo(@TypeOf(data)).Pointer.child;
+    const T = @typeInfo(@TypeOf(data)).pointer.child;
     inline for (std.meta.fields(T)) |entry| {
         switch (@typeInfo(entry.type)) {
-            .Int => |int| {
+            .int => |int| {
                 if (int.bits > 8) {
                     @field(data, entry.name) = @byteSwap(@field(data, entry.name));
                 }
             },
-            .Struct => {
+            .@"struct" => {
                 try swapFieldBytes(&@field(data, entry.name));
             },
-            .Enum => {
+            .@"enum" => {
                 const value = @intFromEnum(@field(data, entry.name));
                 if (@bitSizeOf(@TypeOf(value)) > 8) {
                     @field(data, entry.name) = try std.meta.intToEnum(entry.type, @byteSwap(value));
@@ -123,12 +123,12 @@ fn swapFieldBytes(data: anytype) StructReadError!void {
                     _ = std.meta.intToEnum(entry.type, value) catch return StructReadError.InvalidData;
                 }
             },
-            .Array => |array| {
+            .array => |array| {
                 if (array.child != u8) {
                     @compileError("Add support for type " ++ @typeName(T) ++ "." ++ @typeName(entry.type) ++ " in swapFieldBytes");
                 }
             },
-            .Bool => {},
+            .bool => {},
             else => {
                 @compileError("Add support for type " ++ @typeName(T) ++ "." ++ @typeName(entry.type) ++ " in swapFieldBytes");
             },


### PR DESCRIPTION
Zig 0.14 renames a bunch of fields in TypeInfo. This PR addresses that.

I would not merge this until 0.14 is out, since who knows what else gets renamed, but maybe you want to introduce a 0.14 branch or something. Anyway, hope it saves someone else 10 minutes of work.