### PR TITLE
Proposal: Update installation guide to use `zig fetch --save`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,30 +28,13 @@ exe.addAnonymousModule("zigimg", .{.source_file = .{ .path = "zigimg.zig" }});
 
 #### Through the package manager
 
-1. Example build.zig.zon file
+1. Run this command in your project folder to add `zigimg` to your `build.zig.zon`
 
-```zig
-.{
-    .name = "app",
-    .version = "0.0.0",
-    .dependencies = .{
-        .zigimg = .{
-            .url = "https://github.com/zigimg/zigimg/archive/$REPLACE_WITH_WANTED_COMMIT$.tar.gz",
-        },
-    },
-}
+```sh
+zig fetch --save "https://github.com/zigimg/zigimg/archive/$REPLACE_WITH_WANTED_COMMIT.tar.gz"
 ```
 
-2. When it fails to build due to a mismatched hash, add the `hash` line to the dependency
-
-```zig
-.zigimg = .{
-    .url = "https://github.com/zigimg/zigimg/archive/$REPLACE_WITH_WANTED_COMMIT$.tar.gz",
-    .hash = "$REPLACE_WITH_HASH_FROM_BUILD_ERROR$",
-},
-```
-
-3. Get the module in your build.zig file
+2. Get the module in your `build.zig` file
 
 ```zig
 const zigimg_dependency = b.dependency("zigimg", .{


### PR DESCRIPTION
I'd like to propose updating the installation instructions to use `zig fetch` for adding `zigimg` as a dependency. This would simplify the setup process and reduce some manual steps.

Currently, users have to manually add the dependency and then copy the hash from an error message into `build.zig.zon`. Instead, using `zig fetch --save` could streamline this process by automatically adding the dependency with hash to `build.zig.zon`, making it more user-friendly.

This isn't a major change but could remove some of the hassle and confusion around getting started. Totally understand if it's not something the maintainers want to adopt, but I thought it might be worth considering!

Thanks for your time.