### PR TITLE
Jpeg rework marker reading

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -134,7 +134,9 @@ pub const JPEG = struct {
                 .sof13 => return ImageError.Unsupported,
                 .sof14 => return ImageError.Unsupported,
                 .sof15 => return ImageError.Unsupported,
-
+                .define_huffman_tables => {
+                    try self.frame.?.parseDefineHuffmanTables(reader);
+                },
                 .start_of_scan => {
                     try self.initializePixels(pixels_opt);
                     try self.parseScan(reader, pixels_opt);

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -38,23 +38,6 @@ pub fn read(allocator: Allocator, quantization_tables: *[4]?QuantizationTable, b
     };
     errdefer self.deinit();
 
-    var marker = try reader.readInt(u16, .big);
-    while (marker != @intFromEnum(Markers.start_of_scan)) : (marker = try reader.readInt(u16, .big)) {
-        if (JPEG_DEBUG) std.debug.print("Frame: Parsing marker value: 0x{X}\n", .{marker});
-
-        switch (@as(Markers, @enumFromInt(marker))) {
-            .define_huffman_tables => {
-                try self.parseDefineHuffmanTables(reader);
-            },
-            else => {
-                return ImageReadError.InvalidData;
-            },
-        }
-    }
-
-    // Undo the last marker read
-    try buffered_stream.seekBy(-2);
-
     return self;
 }
 
@@ -74,7 +57,7 @@ pub fn deinit(self: *Self) void {
     self.frame_header.deinit();
 }
 
-fn parseDefineHuffmanTables(self: *Self, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
+pub fn parseDefineHuffmanTables(self: *Self, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var segment_size = try reader.readInt(u16, .big);
     if (JPEG_DEBUG) std.debug.print("DefineHuffmanTables: segment size = 0x{X}\n", .{segment_size});
     segment_size -= 2;

--- a/src/formats/jpeg/JFIFHeader.zig
+++ b/src/formats/jpeg/JFIFHeader.zig
@@ -1,6 +1,5 @@
 //! this module implements the JFIF header
-//! specified in https://www.w3.org/Graphics/JPEG/itu-t81.pdf
-//! section B.2.1 and assumes that there will be an application0 segment.
+//! specified in https://www.w3.org/Graphics/JPEG/jfif3.pdf
 
 const std = @import("std");
 

--- a/src/formats/jpeg/JFIFHeader.zig
+++ b/src/formats/jpeg/JFIFHeader.zig
@@ -28,7 +28,7 @@ pub fn read(buffered_stream: *buffered_stream_source.DefaultBufferedStreamSource
     const reader = buffered_stream.reader();
     try buffered_stream.seekTo(2);
     const maybe_app0_marker = try reader.readInt(u16, .big);
-    if (maybe_app0_marker != @intFromEnum(Markers.application0)) {
+    if (maybe_app0_marker != @intFromEnum(Markers.app0)) {
         return error.App0MarkerDoesNotExist;
     }
 
@@ -62,7 +62,7 @@ pub fn read(buffered_stream: *buffered_stream_source.DefaultBufferedStreamSource
     // TODO: Support application markers, present in versions 1.02 and above.
     // see https://www.ecma-international.org/wp-content/uploads/ECMA_TR-98_1st_edition_june_2009.pdf
     // chapt 10.1
-    if (((try reader.readInt(u16, .big)) & 0xFFF0) == @intFromEnum(Markers.application0)) {
+    if (((try reader.readInt(u16, .big)) & 0xFFF0) == @intFromEnum(Markers.app0)) {
         return error.ExtraneousApplicationMarker;
     }
 

--- a/src/formats/jpeg/utils.zig
+++ b/src/formats/jpeg/utils.zig
@@ -91,7 +91,22 @@ pub const Markers = enum(u16) {
     expand_reference_components = 0xFFDF,
 
     // 0xFFE0-0xFFEF application segments markers add 0-15 as needed.
-    application0 = 0xFFE0,
+    app0 = 0xFFE0,
+    app1 = 0xFFE1,
+    app2 = 0xFFE2,
+    app3 = 0xFFE3,
+    app4 = 0xFFE4,
+    app5 = 0xFFE5,
+    app6 = 0xFFE6,
+    app7 = 0xFFE7,
+    app8 = 0xFFE8,
+    app9 = 0xFFE9,
+    app10 = 0xFFEA,
+    app11 = 0xFFEB,
+    app12 = 0xFFEC,
+    app13 = 0xFFED,
+    app14 = 0xFFEE,
+    app15 = 0xFFEF,
 
     // 0xFFF0-0xFFFD jpeg extension markers add 0-13 as needed.
     jpeg_extension0 = 0xFFF0,


### PR DESCRIPTION
The primary change is removing the check for JFIF specification since not all JPEGs are JFIFs (JPEG spec is ITU-T87 and JFIF is ITU-T871) https://www.itu.int/rec/T-REC-T.871-201105-I/en.

This can be added in later to parse additional meta data but it shouldn't prevent parsing of non-JFIF spec images.

Additionally this hoists the huffman table parsing to the main marker loop. The Huffman Table definitions can occur in any order between the SOF and SOS header(s). See B.2.4 and Figure B.16 of ITU-T81. This will be needed to support multiple scans (progressive)
