### PR TITLE
jpeg: Undo decoding single MCUs and then writing to image

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -166,6 +166,7 @@ pub const JPEG = struct {
             }
         }
 
+        try self.frame.?.dequantizeMCUs();
         try self.frame.?.renderToPixels(&pixels_opt.*.?);
 
         return if (self.frame) |frame| frame else ImageReadError.InvalidData;

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -134,7 +134,9 @@ pub const JPEG = struct {
                 .sof13 => return ImageError.Unsupported,
                 .sof14 => return ImageError.Unsupported,
                 .sof15 => return ImageError.Unsupported,
-
+                .define_huffman_tables => {
+                    try self.frame.?.parseDefineHuffmanTables(reader);
+                },
                 .start_of_scan => {
                     try self.initializePixels(pixels_opt);
                     try self.parseScan(reader, pixels_opt);

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -72,9 +72,9 @@ pub const JPEG = struct {
         }
     }
 
-    fn parseScan(self: *JPEG, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader, pixels_opt: *?color.PixelStorage) ImageReadError!void {
+    fn parseScan(self: *JPEG, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
         if (self.frame) |frame| {
-            try Scan.performScan(&frame, reader, pixels_opt);
+            try Scan.performScan(&frame, reader);
         } else return ImageReadError.InvalidData;
     }
 
@@ -139,7 +139,7 @@ pub const JPEG = struct {
                 },
                 .start_of_scan => {
                     try self.initializePixels(pixels_opt);
-                    try self.parseScan(reader, pixels_opt);
+                    try self.parseScan(reader);
                 },
 
                 .define_quantization_tables => {
@@ -165,6 +165,8 @@ pub const JPEG = struct {
                 },
             }
         }
+
+        try self.frame.?.renderToPixels(&pixels_opt.*.?);
 
         return if (self.frame) |frame| frame else ImageReadError.InvalidData;
     }

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -38,23 +38,6 @@ pub fn read(allocator: Allocator, quantization_tables: *[4]?QuantizationTable, b
     };
     errdefer self.deinit();
 
-    var marker = try reader.readInt(u16, .big);
-    while (marker != @intFromEnum(Markers.start_of_scan)) : (marker = try reader.readInt(u16, .big)) {
-        if (JPEG_DEBUG) std.debug.print("Frame: Parsing marker value: 0x{X}\n", .{marker});
-
-        switch (@as(Markers, @enumFromInt(marker))) {
-            .define_huffman_tables => {
-                try self.parseDefineHuffmanTables(reader);
-            },
-            else => {
-                return ImageReadError.InvalidData;
-            },
-        }
-    }
-
-    // Undo the last marker read
-    try buffered_stream.seekBy(-2);
-
     return self;
 }
 
@@ -74,7 +57,7 @@ pub fn deinit(self: *Self) void {
     self.frame_header.deinit();
 }
 
-fn parseDefineHuffmanTables(self: *Self, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
+pub fn parseDefineHuffmanTables(self: *Self, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!void {
     var segment_size = try reader.readInt(u16, .big);
     if (JPEG_DEBUG) std.debug.print("DefineHuffmanTables: segment size = 0x{X}\n", .{segment_size});
     segment_size -= 2;

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -22,12 +22,28 @@ frame_header: FrameHeader,
 quantization_tables: *[4]?QuantizationTable,
 dc_huffman_tables: [2]?HuffmanTable,
 ac_huffman_tables: [2]?HuffmanTable,
+mcu_storage: [][MAX_COMPONENTS][MAX_BLOCKS]MCU,
 
 const JPEG_DEBUG = false;
+
+pub fn calculateMCUCountInFrame(frame_header: *const FrameHeader) usize {
+    // FIXME: This is very naive and probably only works for Baseline DCT.
+    // MCU of non-interleaved is just one block.
+    const horizontal_block_count = if (1 < frame_header.components.len) frame_header.getMaxHorizontalSamplingFactor() else 1;
+    const vertical_block_count = if (1 < frame_header.components.len) frame_header.getMaxVerticalSamplingFactor() else 1;
+    const mcu_width = 8 * horizontal_block_count;
+    const mcu_height = 8 * vertical_block_count;
+    const mcu_count_per_row = (frame_header.samples_per_row + mcu_width - 1) / mcu_width;
+    const mcu_count_per_column = (frame_header.row_count + mcu_height - 1) / mcu_height;
+    return mcu_count_per_row * mcu_count_per_column;
+}
 
 pub fn read(allocator: Allocator, quantization_tables: *[4]?QuantizationTable, buffered_stream: *buffered_stream_source.DefaultBufferedStreamSourceReader) ImageReadError!Self {
     const reader = buffered_stream.reader();
     const frame_header = try FrameHeader.read(allocator, reader);
+    const mcu_count: usize = calculateMCUCountInFrame(&frame_header);
+
+    const mcu_storage = try allocator.alloc([MAX_COMPONENTS][MAX_BLOCKS]MCU, mcu_count);
 
     var self = Self{
         .allocator = allocator,
@@ -35,6 +51,7 @@ pub fn read(allocator: Allocator, quantization_tables: *[4]?QuantizationTable, b
         .quantization_tables = quantization_tables,
         .dc_huffman_tables = @splat(null),
         .ac_huffman_tables = @splat(null),
+        .mcu_storage = mcu_storage,
     };
     errdefer self.deinit();
 
@@ -42,6 +59,7 @@ pub fn read(allocator: Allocator, quantization_tables: *[4]?QuantizationTable, b
 }
 
 pub fn deinit(self: *Self) void {
+    self.allocator.free(self.mcu_storage);
     for (&self.dc_huffman_tables) |*maybe_huffman_table| {
         if (maybe_huffman_table.*) |*huffman_table| {
             huffman_table.deinit();

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -106,119 +106,125 @@ pub fn parseDefineHuffmanTables(self: *Self, reader: buffered_stream_source.Defa
     }
 }
 
-pub fn renderToPixels(self: *const Self, mcu_storage: *[MAX_COMPONENTS][MAX_BLOCKS]MCU, mcu_id: usize, pixels: *color.PixelStorage) ImageReadError!void {
+pub fn renderToPixels(self: *Self, pixels: *color.PixelStorage) ImageReadError!void {
     switch (self.frame_header.components.len) {
-        1 => try self.renderToPixelsGrayscale(&mcu_storage[0][0], mcu_id, pixels.grayscale8), // Grayscale images is non-interleaved
-        3 => try self.renderToPixelsRgb(mcu_storage, mcu_id, pixels.rgb24),
+        1 => try self.renderToPixelsGrayscale(pixels.grayscale8), // Grayscale images is non-interleaved
+        3 => try self.renderToPixelsRgb(pixels.rgb24),
         else => unreachable,
     }
 }
 
-fn renderToPixelsGrayscale(self: *const Self, mcu_storage: *MCU, mcu_id: usize, pixels: []color.Grayscale8) ImageReadError!void {
+fn renderToPixelsGrayscale(self: *Self, pixels: []color.Grayscale8) ImageReadError!void {
     const mcu_width = 8;
     const mcu_height = 8;
     const width = self.frame_header.samples_per_row;
     const height = pixels.len / width;
     const mcus_per_row = (width + mcu_width - 1) / mcu_width;
-    const mcu_origin_x = (mcu_id % mcus_per_row) * mcu_width;
-    const mcu_origin_y = (mcu_id / mcus_per_row) * mcu_height;
+    var mcu_id: usize = 0;
+    while (mcu_id < self.mcu_storage.len) : (mcu_id += 1) {
+        const mcu_origin_x = (mcu_id % mcus_per_row) * mcu_width;
+        const mcu_origin_y = (mcu_id / mcus_per_row) * mcu_height;
 
-    for (0..mcu_height) |mcu_y| {
-        const y = mcu_origin_y + mcu_y;
-        if (y >= height) continue;
+        for (0..mcu_height) |mcu_y| {
+            const y = mcu_origin_y + mcu_y;
+            if (y >= height) continue;
 
-        // y coordinates in the block
-        const block_y = mcu_y % 8;
+            // y coordinates in the block
+            const block_y = mcu_y % 8;
 
-        const stride = y * width;
+            const stride = y * width;
 
-        for (0..mcu_width) |mcu_x| {
-            const x = mcu_origin_x + mcu_x;
-            if (x >= width) continue;
+            for (0..mcu_width) |mcu_x| {
+                const x = mcu_origin_x + mcu_x;
+                if (x >= width) continue;
 
-            // x coordinates in the block
-            const block_x = mcu_x % 8;
+                // x coordinates in the block
+                const block_x = mcu_x % 8;
 
-            const reconstructed_Y = idct(mcu_storage, @as(u3, @intCast(block_x)), @as(u3, @intCast(block_y)), mcu_id, 0);
-            const Y: f32 = @floatFromInt(reconstructed_Y);
-            pixels[stride + x] = .{
-                .value = @as(u8, @intFromFloat(std.math.clamp(Y + 128.0, 0.0, 255.0))),
-            };
+                const reconstructed_Y = idct(&self.mcu_storage[mcu_id][0][0], @as(u3, @intCast(block_x)), @as(u3, @intCast(block_y)), mcu_id, 0);
+                const Y: f32 = @floatFromInt(reconstructed_Y);
+                pixels[stride + x] = .{
+                    .value = @as(u8, @intFromFloat(std.math.clamp(Y + 128.0, 0.0, 255.0))),
+                };
+            }
         }
     }
 }
 
-fn renderToPixelsRgb(self: *const Self, mcu_storage: *[MAX_COMPONENTS][MAX_BLOCKS]MCU, mcu_id: usize, pixels: []color.Rgb24) ImageReadError!void {
+fn renderToPixelsRgb(self: *Self, pixels: []color.Rgb24) ImageReadError!void {
     const max_horizontal_sampling_factor = self.frame_header.getMaxHorizontalSamplingFactor();
     const max_vertical_sampling_factor = self.frame_header.getMaxVerticalSamplingFactor();
-    const mcu_width = 8 * max_horizontal_sampling_factor;
-    const mcu_height = 8 * max_vertical_sampling_factor;
+    const mcu_width = 8 * max_horizontal_sampling_factor; // in pixels
+    const mcu_height = 8 * max_vertical_sampling_factor; // in pixels
     const width = self.frame_header.samples_per_row;
     const height = pixels.len / width;
     const mcus_per_row = (width + mcu_width - 1) / mcu_width;
 
-    const mcu_origin_x = (mcu_id % mcus_per_row) * mcu_width;
-    const mcu_origin_y = (mcu_id / mcus_per_row) * mcu_height;
+    var mcu_id: usize = 0;
+    while (mcu_id < self.mcu_storage.len) : (mcu_id += 1) {
+        const mcu_origin_x = (mcu_id % mcus_per_row) * mcu_width;
+        const mcu_origin_y = (mcu_id / mcus_per_row) * mcu_height;
 
-    for (0..mcu_height) |mcu_y| {
-        const y = mcu_origin_y + mcu_y;
-        if (y >= height) continue;
+        for (0..mcu_height) |mcu_y| {
+            const y = mcu_origin_y + mcu_y;
+            if (y >= height) continue;
 
-        // y coordinates of each component applied to the sampling factor
-        const y_sampled_y = (mcu_y * self.frame_header.components[0].vertical_sampling_factor) / max_vertical_sampling_factor;
-        const cb_sampled_y = (mcu_y * self.frame_header.components[1].vertical_sampling_factor) / max_vertical_sampling_factor;
-        const cr_sampled_y = (mcu_y * self.frame_header.components[2].vertical_sampling_factor) / max_vertical_sampling_factor;
+            // y coordinates of each component applied to the sampling factor
+            const y_sampled_y = (mcu_y * self.frame_header.components[0].vertical_sampling_factor) / max_vertical_sampling_factor;
+            const cb_sampled_y = (mcu_y * self.frame_header.components[1].vertical_sampling_factor) / max_vertical_sampling_factor;
+            const cr_sampled_y = (mcu_y * self.frame_header.components[2].vertical_sampling_factor) / max_vertical_sampling_factor;
 
-        // y coordinates of each component in the block
-        const y_block_y = y_sampled_y % 8;
-        const cb_block_y = cb_sampled_y % 8;
-        const cr_block_y = cr_sampled_y % 8;
+            // y coordinates of each component in the block
+            const y_block_y = y_sampled_y % 8;
+            const cb_block_y = cb_sampled_y % 8;
+            const cr_block_y = cr_sampled_y % 8;
 
-        const stride = y * width;
+            const stride = y * width;
 
-        for (0..mcu_width) |mcu_x| {
-            const x = mcu_origin_x + mcu_x;
-            if (x >= width) continue;
+            for (0..mcu_width) |mcu_x| {
+                const x = mcu_origin_x + mcu_x;
+                if (x >= width) continue;
 
-            // x coordinates of each component applied to the sampling factor
-            const y_sampled_x = (mcu_x * self.frame_header.components[0].horizontal_sampling_factor) / max_horizontal_sampling_factor;
-            const cb_sampled_x = (mcu_x * self.frame_header.components[1].horizontal_sampling_factor) / max_horizontal_sampling_factor;
-            const cr_sampled_x = (mcu_x * self.frame_header.components[2].horizontal_sampling_factor) / max_horizontal_sampling_factor;
+                // x coordinates of each component applied to the sampling factor
+                const y_sampled_x = (mcu_x * self.frame_header.components[0].horizontal_sampling_factor) / max_horizontal_sampling_factor;
+                const cb_sampled_x = (mcu_x * self.frame_header.components[1].horizontal_sampling_factor) / max_horizontal_sampling_factor;
+                const cr_sampled_x = (mcu_x * self.frame_header.components[2].horizontal_sampling_factor) / max_horizontal_sampling_factor;
 
-            // x coordinates of each component in the block
-            const y_block_x = y_sampled_x % 8;
-            const cb_block_x = cb_sampled_x % 8;
-            const cr_block_x = cr_sampled_x % 8;
+                // x coordinates of each component in the block
+                const y_block_x = y_sampled_x % 8;
+                const cb_block_x = cb_sampled_x % 8;
+                const cr_block_x = cr_sampled_x % 8;
 
-            const y_block_ind = (y_sampled_y / 8) * self.frame_header.components[0].horizontal_sampling_factor + (y_sampled_x / 8);
-            const cb_block_ind = (cb_sampled_y / 8) * self.frame_header.components[1].horizontal_sampling_factor + (cb_sampled_x / 8);
-            const cr_block_ind = (cr_sampled_y / 8) * self.frame_header.components[2].horizontal_sampling_factor + (cr_sampled_x / 8);
+                const y_block_ind = (y_sampled_y / 8) * self.frame_header.components[0].horizontal_sampling_factor + (y_sampled_x / 8);
+                const cb_block_ind = (cb_sampled_y / 8) * self.frame_header.components[1].horizontal_sampling_factor + (cb_sampled_x / 8);
+                const cr_block_ind = (cr_sampled_y / 8) * self.frame_header.components[2].horizontal_sampling_factor + (cr_sampled_x / 8);
 
-            const mcu_Y = &mcu_storage[0][y_block_ind];
-            const mcu_Cb = &mcu_storage[1][cb_block_ind];
-            const mcu_Cr = &mcu_storage[2][cr_block_ind];
+                const mcu_Y = &self.mcu_storage[mcu_id][0][y_block_ind];
+                const mcu_Cb = &self.mcu_storage[mcu_id][1][cb_block_ind];
+                const mcu_Cr = &self.mcu_storage[mcu_id][2][cr_block_ind];
 
-            const reconstructed_Y = idct(mcu_Y, @as(u3, @intCast(y_block_x)), @as(u3, @intCast(y_block_y)), mcu_id, 0);
-            const reconstructed_Cb = idct(mcu_Cb, @as(u3, @intCast(cb_block_x)), @as(u3, @intCast(cb_block_y)), mcu_id, 1);
-            const reconstructed_Cr = idct(mcu_Cr, @as(u3, @intCast(cr_block_x)), @as(u3, @intCast(cr_block_y)), mcu_id, 2);
+                const reconstructed_Y = idct(mcu_Y, @as(u3, @intCast(y_block_x)), @as(u3, @intCast(y_block_y)), mcu_id, 0);
+                const reconstructed_Cb = idct(mcu_Cb, @as(u3, @intCast(cb_block_x)), @as(u3, @intCast(cb_block_y)), mcu_id, 1);
+                const reconstructed_Cr = idct(mcu_Cr, @as(u3, @intCast(cr_block_x)), @as(u3, @intCast(cr_block_y)), mcu_id, 2);
 
-            const Y: f32 = @floatFromInt(reconstructed_Y);
-            const Cb: f32 = @floatFromInt(reconstructed_Cb);
-            const Cr: f32 = @floatFromInt(reconstructed_Cr);
+                const Y: f32 = @floatFromInt(reconstructed_Y);
+                const Cb: f32 = @floatFromInt(reconstructed_Cb);
+                const Cr: f32 = @floatFromInt(reconstructed_Cr);
 
-            const Co_red = 0.299;
-            const Co_green = 0.587;
-            const Co_blue = 0.114;
+                const Co_red = 0.299;
+                const Co_green = 0.587;
+                const Co_blue = 0.114;
 
-            const r = Cr * (2 - 2 * Co_red) + Y;
-            const b = Cb * (2 - 2 * Co_blue) + Y;
-            const g = (Y - Co_blue * b - Co_red * r) / Co_green;
+                const r = Cr * (2 - 2 * Co_red) + Y;
+                const b = Cb * (2 - 2 * Co_blue) + Y;
+                const g = (Y - Co_blue * b - Co_red * r) / Co_green;
 
-            pixels[stride + x] = .{
-                .r = @intFromFloat(std.math.clamp(r + 128.0, 0.0, 255.0)),
-                .g = @intFromFloat(std.math.clamp(g + 128.0, 0.0, 255.0)),
-                .b = @intFromFloat(std.math.clamp(b + 128.0, 0.0, 255.0)),
-            };
+                pixels[stride + x] = .{
+                    .r = @intFromFloat(std.math.clamp(r + 128.0, 0.0, 255.0)),
+                    .g = @intFromFloat(std.math.clamp(g + 128.0, 0.0, 255.0)),
+                    .b = @intFromFloat(std.math.clamp(b + 128.0, 0.0, 255.0)),
+                };
+            }
         }
     }
 }

--- a/src/formats/jpeg/JFIFHeader.zig
+++ b/src/formats/jpeg/JFIFHeader.zig
@@ -1,6 +1,5 @@
 //! this module implements the JFIF header
-//! specified in https://www.w3.org/Graphics/JPEG/itu-t81.pdf
-//! section B.2.1 and assumes that there will be an application0 segment.
+//! specified in https://www.w3.org/Graphics/JPEG/jfif3.pdf
 
 const std = @import("std");
 

--- a/src/formats/jpeg/JFIFHeader.zig
+++ b/src/formats/jpeg/JFIFHeader.zig
@@ -28,7 +28,7 @@ pub fn read(buffered_stream: *buffered_stream_source.DefaultBufferedStreamSource
     const reader = buffered_stream.reader();
     try buffered_stream.seekTo(2);
     const maybe_app0_marker = try reader.readInt(u16, .big);
-    if (maybe_app0_marker != @intFromEnum(Markers.application0)) {
+    if (maybe_app0_marker != @intFromEnum(Markers.app0)) {
         return error.App0MarkerDoesNotExist;
     }
 
@@ -62,7 +62,7 @@ pub fn read(buffered_stream: *buffered_stream_source.DefaultBufferedStreamSource
     // TODO: Support application markers, present in versions 1.02 and above.
     // see https://www.ecma-international.org/wp-content/uploads/ECMA_TR-98_1st_edition_june_2009.pdf
     // chapt 10.1
-    if (((try reader.readInt(u16, .big)) & 0xFFF0) == @intFromEnum(Markers.application0)) {
+    if (((try reader.readInt(u16, .big)) & 0xFFF0) == @intFromEnum(Markers.app0)) {
         return error.ExtraneousApplicationMarker;
     }
 

--- a/src/formats/jpeg/Scan.zig
+++ b/src/formats/jpeg/Scan.zig
@@ -42,27 +42,6 @@ pub fn performScan(frame: *const Frame, reader: buffered_stream_source.DefaultBu
     for (0..mcu_count) |mcu_id| {
         try self.decodeMCU(mcu_id);
     }
-
-    try self.dequantizeMCUs();
-}
-
-fn dequantizeMCUs(self: *Self) !void {
-    var mcu_id: usize = 0;
-    while (mcu_id < self.frame.mcu_storage.len) : (mcu_id += 1) {
-        for (self.frame.frame_header.components, 0..) |component, component_id| {
-            const block_count = self.frame.frame_header.getBlockCount(component_id);
-            for (0..block_count) |i| {
-                const block = &self.frame.mcu_storage[mcu_id][component_id][i];
-
-                if (self.frame.quantization_tables[component.quantization_table_id]) |quantization_table| {
-                    var sample_id: usize = 0;
-                    while (sample_id < 64) : (sample_id += 1) {
-                        block[sample_id] = block[sample_id] * quantization_table.q8[sample_id];
-                    }
-                } else return ImageReadError.InvalidData;
-            }
-        }
-    }
 }
 
 fn decodeMCU(self: *Self, mcu_id: usize) ImageReadError!void {

--- a/src/formats/jpeg/Scan.zig
+++ b/src/formats/jpeg/Scan.zig
@@ -41,11 +41,14 @@ pub fn performScan(frame: *const Frame, reader: buffered_stream_source.DefaultBu
     const mcu_count = Frame.calculateMCUCountInFrame(&self.frame.frame_header);
     for (0..mcu_count) |mcu_id| {
         try self.decodeMCU(mcu_id);
-        try self.dequantize(mcu_id);
     }
+
+    try self.dequantizeMCUs();
 }
 
-fn dequantize(self: *Self, mcu_id: usize) !void {
+fn dequantizeMCUs(self: *Self) !void {
+    var mcu_id: usize = 0;
+    while (mcu_id < self.frame.mcu_storage.len) : (mcu_id += 1) {
         for (self.frame.frame_header.components, 0..) |component, component_id| {
             const block_count = self.frame.frame_header.getBlockCount(component_id);
             for (0..block_count) |i| {
@@ -57,6 +60,7 @@ fn dequantize(self: *Self, mcu_id: usize) !void {
                         block[sample_id] = block[sample_id] * quantization_table.q8[sample_id];
                     }
                 } else return ImageReadError.InvalidData;
+            }
         }
     }
 }

--- a/src/formats/jpeg/Scan.zig
+++ b/src/formats/jpeg/Scan.zig
@@ -9,8 +9,6 @@ const FrameHeader = @import("FrameHeader.zig");
 const Frame = @import("Frame.zig");
 const HuffmanReader = @import("huffman.zig").Reader;
 
-const MAX_COMPONENTS = @import("utils.zig").MAX_COMPONENTS;
-const MAX_BLOCKS = @import("utils.zig").MAX_BLOCKS;
 const MCU = @import("utils.zig").MCU;
 const ZigzagOffsets = @import("utils.zig").ZigzagOffsets;
 
@@ -22,7 +20,6 @@ const JPEG_VERY_DEBUG = false;
 frame: *const Frame,
 reader: HuffmanReader,
 scan_header: ScanHeader,
-mcu_storage: [MAX_COMPONENTS][MAX_BLOCKS]MCU,
 prediction_values: [3]i12,
 
 pub fn init(frame: *const Frame, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!Self {
@@ -31,7 +28,6 @@ pub fn init(frame: *const Frame, reader: buffered_stream_source.DefaultBufferedS
         .frame = frame,
         .reader = HuffmanReader.init(reader),
         .scan_header = scan_header,
-        .mcu_storage = undefined,
         .prediction_values = [3]i12{ 0, 0, 0 },
     };
 }
@@ -42,19 +38,19 @@ pub fn init(frame: *const Frame, reader: buffered_stream_source.DefaultBufferedS
 pub fn performScan(frame: *const Frame, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader, pixels_opt: *?color.PixelStorage) ImageReadError!void {
     var self = try Self.init(frame, reader);
 
-    const mcu_count = Self.calculateMCUCountInFrame(&frame.frame_header);
+    const mcu_count = Frame.calculateMCUCountInFrame(&self.frame.frame_header);
     for (0..mcu_count) |mcu_id| {
-        try self.decodeMCU();
-        try self.dequantize();
-        try frame.renderToPixels(&self.mcu_storage, mcu_id, &pixels_opt.*.?);
+        try self.decodeMCU(mcu_id);
+        try self.dequantize(mcu_id);
+        try frame.renderToPixels(&frame.mcu_storage[mcu_id], mcu_id, &pixels_opt.*.?);
     }
 }
 
-fn dequantize(self: *Self) !void {
+fn dequantize(self: *Self, mcu_id: usize) !void {
     for (self.frame.frame_header.components, 0..) |component, component_id| {
         const block_count = self.frame.frame_header.getBlockCount(component_id);
         for (0..block_count) |i| {
-            const block = &self.mcu_storage[component_id][i];
+            const block = &self.frame.mcu_storage[mcu_id][component_id][i];
 
             if (self.frame.quantization_tables[component.quantization_table_id]) |quantization_table| {
                 var sample_id: usize = 0;
@@ -66,29 +62,17 @@ fn dequantize(self: *Self) !void {
     }
 }
 
-fn calculateMCUCountInFrame(frame_header: *const FrameHeader) usize {
-    // FIXME: This is very naive and probably only works for Baseline DCT.
-    // MCU of non-interleaved is just one block.
-    const horizontal_block_count = if (1 < frame_header.components.len) frame_header.getMaxHorizontalSamplingFactor() else 1;
-    const vertical_block_count = if (1 < frame_header.components.len) frame_header.getMaxVerticalSamplingFactor() else 1;
-    const mcu_width = 8 * horizontal_block_count;
-    const mcu_height = 8 * vertical_block_count;
-    const mcu_count_per_row = (frame_header.samples_per_row + mcu_width - 1) / mcu_width;
-    const mcu_count_per_column = (frame_header.row_count + mcu_height - 1) / mcu_height;
-    return mcu_count_per_row * mcu_count_per_column;
-}
-
-fn decodeMCU(self: *Self) ImageReadError!void {
+fn decodeMCU(self: *Self, mcu_id: usize) ImageReadError!void {
     for (self.scan_header.components, 0..) |maybe_component, component_id| {
         _ = component_id;
         if (maybe_component == null)
             break;
 
-        try self.decodeMCUComponent(maybe_component.?);
+        try self.decodeMCUComponent(maybe_component.?, mcu_id);
     }
 }
 
-fn decodeMCUComponent(self: *Self, component: ScanComponentSpec) ImageReadError!void {
+fn decodeMCUComponent(self: *Self, component: ScanComponentSpec, mcu_id: usize) ImageReadError!void {
     // The encoder might reorder components or omit one if it decides that the
     // file size can be reduced that way. Therefore we need to select the correct
     // destination for this component.
@@ -104,7 +88,7 @@ fn decodeMCUComponent(self: *Self, component: ScanComponentSpec) ImageReadError!
 
     const block_count = self.frame.frame_header.getBlockCount(component_destination);
     for (0..block_count) |i| {
-        const mcu = &self.mcu_storage[component_destination][i];
+        const mcu = &self.frame.mcu_storage[mcu_id][component_destination][i];
 
         // Decode the DC coefficient
         if (self.frame.dc_huffman_tables[component.dc_table_selector] == null) return ImageReadError.InvalidData;

--- a/src/formats/jpeg/utils.zig
+++ b/src/formats/jpeg/utils.zig
@@ -91,7 +91,22 @@ pub const Markers = enum(u16) {
     expand_reference_components = 0xFFDF,
 
     // 0xFFE0-0xFFEF application segments markers add 0-15 as needed.
-    application0 = 0xFFE0,
+    app0 = 0xFFE0,
+    app1 = 0xFFE1,
+    app2 = 0xFFE2,
+    app3 = 0xFFE3,
+    app4 = 0xFFE4,
+    app5 = 0xFFE5,
+    app6 = 0xFFE6,
+    app7 = 0xFFE7,
+    app8 = 0xFFE8,
+    app9 = 0xFFE9,
+    app10 = 0xFFEA,
+    app11 = 0xFFEB,
+    app12 = 0xFFEC,
+    app13 = 0xFFED,
+    app14 = 0xFFEE,
+    app15 = 0xFFEF,
 
     // 0xFFF0-0xFFFD jpeg extension markers add 0-13 as needed.
     jpeg_extension0 = 0xFFF0,


### PR DESCRIPTION
In commit e18ed21, Scan was changed to decode & dequantize a single MCU, and then write the to the final pixel destination. This is then repeated for all the MCUs. This coupling is a problem for progressive JPEGs which can write to multiple MCUs at once depending on the number of components in the scan (see A.2.2 of ITU-T81).

Instead:
* place mcu_storage on Frame and have it contain all MCUs for an image (Scan only contained storage for a single MCU). This will increase the memory usage (as prior to e18ed21) but will make progressive JPEG implementation more straightforward.
* decouple dequantize and color conversion -> image writing from decoding of scan -- this makes the code clearer and will make it easier to implement progressive jpegs. 

Note: this stacks on PR https://github.com/zigimg/zigimg/pull/194