### PR TITLE
jpeg: separate IDCT from renderToPixels{Grayscale, Rgb}

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -167,6 +167,7 @@ pub const JPEG = struct {
         }
 
         try self.frame.?.dequantizeMCUs();
+        self.frame.?.idctMCUs();
         try self.frame.?.renderToPixels(&pixels_opt.*.?);
 
         return if (self.frame) |frame| frame else ImageReadError.InvalidData;


### PR DESCRIPTION
The renderToPixels{Rgb, Grayscale} step loops through the MCUs, processes the pixels, before writing to the final image output. Previously this also included performing the IDCT step. Instead move this to a separate step that is called in the JPEG loop, after dequantizeMCU and before writing.

This is done for two reasons: it decouples performing the IDCT from rendering to the final pixel and for pictures with subsampling this reduces the amount of work done.

With subsampling a single color input pixel will be repeated over multiple final pixels. Since idct is called for every final pixel that's rendered, then for a say, 2x2 downsampled image (for Cr Cb) then we end up calling IDCT 8 times more than necessary on those channels.