### PR TITLE
Jpeg refactor huffman jfif

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -198,13 +198,9 @@ pub const JPEG = struct {
         const maybe_start_of_image = try reader.readInt(u16, .big);
         if (maybe_start_of_image != @intFromEnum(Markers.start_of_image)) {
             return false;
+        } else {
+            return true;
         }
-
-        try buffered_stream.seekTo(6);
-        var identifier_buffer: [4]u8 = undefined;
-        _ = try buffered_stream.read(identifier_buffer[0..]);
-
-        return std.mem.eql(u8, identifier_buffer[0..], "JFIF");
     }
 
     fn readImage(allocator: Allocator, stream: *ImageUnmanaged.Stream) ImageReadError!ImageUnmanaged {

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -167,6 +167,7 @@ pub const JPEG = struct {
         }
 
         try self.frame.?.dequantizeMCUs();
+        self.frame.?.idctMCUs();
         try self.frame.?.renderToPixels(&pixels_opt.*.?);
 
         return if (self.frame) |frame| frame else ImageReadError.InvalidData;


### PR DESCRIPTION
To increase spec compliance, refactor huffman and JFIF checking code.

According to ITU-T81 section B.2.1, a frame header may be proceeded by table specifications. Previously the {ac,dc}_huffman_tables were on the Frame struct and the Frame wasn't initialized until the SOF marker was read. This prevents huffman tables that are specified before SOF from being stored.

Instead move {ac,dc}_huffman_tables to the JPEG struct so huffman tables defined before SOF can be stored. Additionally this moves parseDefineHuffmanTables to JPEG.

Not all JPEGS are JFIF, remove JFIF specific checks in formatDetect.

See 2edb358b1567b1c14213aa3c822d026c062d438f for additional context.

This stacks https://github.com/zigimg/zigimg/pull/196