### PR TITLE
Remove unconditional debug

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -267,6 +267,6 @@ pub const JPEG = struct {
         std.debug.assert(segment_length - 4 == 0);
 
         self.restart_interval = try reader.readInt(u16, .big);
-        std.debug.print("Restart Interval: {}", .{self.restart_interval});
+        if (JPEG_DEBUG) std.debug.print("Restart Interval: {}", .{self.restart_interval});
     }
 };


### PR DESCRIPTION
Remove unconditional use of std.debug.print(), as this doesn't work on freestanding targets.
Failed on wasm32-freestanding