### PR TITLE
JPEG: implements spectral selection for progressive jpegs

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -37,8 +37,8 @@ pub const JPEG = struct {
     frame: ?Frame = null,
     allocator: Allocator,
     quantization_tables: [4]?QuantizationTable = @splat(null),
-    dc_huffman_tables: [2]?HuffmanTable = @splat(null),
-    ac_huffman_tables: [2]?HuffmanTable = @splat(null),
+    dc_huffman_tables: [4]?HuffmanTable = @splat(null),
+    ac_huffman_tables: [4]?HuffmanTable = @splat(null),
     restart_interval: u16 = 0,
 
     pub fn init(allocator: Allocator) JPEG {
@@ -239,7 +239,7 @@ pub const JPEG = struct {
         while (segment_size > 0) {
             const class_and_destination = try reader.readByte();
             const table_class = class_and_destination >> 4;
-            const table_destination = class_and_destination & 0b1;
+            const table_destination = class_and_destination & 0x0F;
 
             const huffman_table = try HuffmanTable.read(self.allocator, table_class, reader);
 

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -20,9 +20,9 @@ const Self = @This();
 allocator: Allocator,
 frame_header: FrameHeader,
 quantization_tables: *[4]?QuantizationTable,
-dc_huffman_tables: *[2]?HuffmanTable,
-ac_huffman_tables: *[2]?HuffmanTable,
-mcu_storage: [][MAX_COMPONENTS][MAX_BLOCKS]MCU,
+dc_huffman_tables: *[4]?HuffmanTable,
+ac_huffman_tables: *[4]?HuffmanTable,
+mcu_storage: [][MAX_COMPONENTS][MAX_BLOCKS]Block,
 restart_interval: u16 = 0,
 frame_type: Markers = undefined,
 
@@ -40,7 +40,7 @@ pub fn calculateMCUCountInFrame(frame_header: *const FrameHeader) usize {
     return mcu_count_per_row * mcu_count_per_column;
 }
 
-pub fn read(allocator: Allocator, frame_type: Markers, restart_interval: u16, quantization_tables: *[4]?QuantizationTable, dc_huffman_tables: *[2]?HuffmanTable, ac_huffman_tables: *[2]?HuffmanTable, buffered_stream: *buffered_stream_source.DefaultBufferedStreamSourceReader) ImageReadError!Self {
+pub fn read(allocator: Allocator, frame_type: Markers, restart_interval: u16, quantization_tables: *[4]?QuantizationTable, dc_huffman_tables: *[4]?HuffmanTable, ac_huffman_tables: *[4]?HuffmanTable, buffered_stream: *buffered_stream_source.DefaultBufferedStreamSourceReader) ImageReadError!Self {
     const reader = buffered_stream.reader();
     const frame_header = try FrameHeader.read(allocator, reader);
     const mcu_count: usize = calculateMCUCountInFrame(&frame_header);

--- a/src/formats/jpeg/utils.zig
+++ b/src/formats/jpeg/utils.zig
@@ -117,4 +117,4 @@ pub const Markers = enum(u16) {
 
 pub const MAX_COMPONENTS = 3;
 pub const MAX_BLOCKS = 8;
-pub const MCU = [64]i32;
+pub const Block = [64]i32;


### PR DESCRIPTION
JPEG: implements spectral selection for progressive jpegs

Implements Spectral Selection for progressive jpegs only (Section G.1.1.1.1) that is, successive approximation (Section G.1.1.1.2) is not implemented.

Other major change was to rename MCU to Block. According to ITU-T81, 3.1.11 the 8x8 array of values is a Block, and MCUs can consist of 1 or more blocks. Rename for clarity.