### PR TITLE
jpeg refactor storage

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -89,7 +89,7 @@ pub const JPEG = struct {
                 else => unreachable,
             }
 
-            const pixel_count = @as(usize, @intCast(frame.frame_header.samples_per_row)) * @as(usize, @intCast(frame.frame_header.row_count));
+            const pixel_count = @as(usize, @intCast(frame.frame_header.width)) * @as(usize, @intCast(frame.frame_header.height));
             pixels_opt.* = try color.PixelStorage.init(self.allocator, pixel_format, pixel_count);
         } else return ImageReadError.InvalidData;
     }
@@ -212,8 +212,8 @@ pub const JPEG = struct {
 
         const frame = try jpeg.read(stream, &pixels_opt);
 
-        result.width = frame.frame_header.samples_per_row;
-        result.height = frame.frame_header.row_count;
+        result.width = frame.frame_header.width;
+        result.height = frame.frame_header.height;
 
         if (pixels_opt) |pixels| {
             result.pixels = pixels;

--- a/src/formats/jpeg/FrameHeader.zig
+++ b/src/formats/jpeg/FrameHeader.zig
@@ -121,14 +121,3 @@ pub fn getMaxVerticalSamplingFactor(self: Self) usize {
 
     return ret;
 }
-
-pub fn getBlockCount(self: Self, component_id: usize) usize {
-    // MCU of non-interleaved is just one block.
-    if (self.components.len == 1) {
-        return 1;
-    }
-
-    const horizontal_block_count = self.components[component_id].horizontal_sampling_factor;
-    const vertical_block_count = self.components[component_id].vertical_sampling_factor;
-    return horizontal_block_count * vertical_block_count;
-}

--- a/src/formats/jpeg/FrameHeader.zig
+++ b/src/formats/jpeg/FrameHeader.zig
@@ -55,8 +55,8 @@ const Self = @This();
 
 allocator: Allocator,
 sample_precision: u8,
-row_count: u16,
-samples_per_row: u16,
+height: u16,
+width: u16,
 components: []Component,
 
 pub fn read(allocator: Allocator, reader: buffered_stream_source.DefaultBufferedStreamSourceReader.Reader) ImageReadError!Self {
@@ -64,8 +64,8 @@ pub fn read(allocator: Allocator, reader: buffered_stream_source.DefaultBuffered
     if (JPEG_DEBUG) std.debug.print("StartOfFrame: frame size = 0x{X}\n", .{segment_size});
 
     const sample_precision = try reader.readByte();
-    const row_count = try reader.readInt(u16, .big);
-    const samples_per_row = try reader.readInt(u16, .big);
+    const height = try reader.readInt(u16, .big);
+    const width = try reader.readInt(u16, .big);
 
     const component_count = try reader.readByte();
 
@@ -74,7 +74,7 @@ pub fn read(allocator: Allocator, reader: buffered_stream_source.DefaultBuffered
         return ImageReadError.InvalidData;
     }
 
-    if (JPEG_DEBUG) std.debug.print("  {}x{}, precision={}, {} components\n", .{ samples_per_row, row_count, sample_precision, component_count });
+    if (JPEG_DEBUG) std.debug.print("  {}x{}, precision={}, {} components\n", .{ height, width, sample_precision, component_count });
 
     var components = try allocator.alloc(Component, component_count);
     errdefer allocator.free(components);
@@ -82,12 +82,6 @@ pub fn read(allocator: Allocator, reader: buffered_stream_source.DefaultBuffered
     var i: usize = 0;
     while (i < component_count) : (i += 1) {
         components[i] = try Component.read(reader);
-        // TODO(angelo): remove this
-        // if (JPEG_VERY_DEBUG) {
-        //     std.debug.print("    ID={}, Vfactor={}, Hfactor={} QtableID={}\n", .{
-        //         components[i].id, components[i].vertical_sampling_factor, components[i].horizontal_sampling_factor, components[i].quantization_table_id,
-        //     });
-        // }
     }
 
     // see B 8.2 table for the meaning of this check.
@@ -96,8 +90,8 @@ pub fn read(allocator: Allocator, reader: buffered_stream_source.DefaultBuffered
     return Self{
         .allocator = allocator,
         .sample_precision = sample_precision,
-        .row_count = row_count,
-        .samples_per_row = samples_per_row,
+        .height = height,
+        .width = width,
         .components = components,
     };
 }

--- a/tests/formats/jpeg_test.zig
+++ b/tests/formats/jpeg_test.zig
@@ -45,8 +45,8 @@ test "Read JFIF header properly and decode simple Huffman stream" {
         }
     }
 
-    try helpers.expectEq(frame.frame_header.row_count, 8);
-    try helpers.expectEq(frame.frame_header.samples_per_row, 16);
+    try helpers.expectEq(frame.frame_header.height, 8);
+    try helpers.expectEq(frame.frame_header.width, 16);
     try helpers.expectEq(frame.frame_header.sample_precision, 8);
     try helpers.expectEq(frame.frame_header.components.len, 3);
 
@@ -75,8 +75,8 @@ test "Read the tuba properly" {
         }
     }
 
-    try helpers.expectEq(frame.frame_header.row_count, 512);
-    try helpers.expectEq(frame.frame_header.samples_per_row, 512);
+    try helpers.expectEq(frame.frame_header.height, 512);
+    try helpers.expectEq(frame.frame_header.width, 512);
     try helpers.expectEq(frame.frame_header.sample_precision, 8);
     try helpers.expectEq(frame.frame_header.components.len, 3);
 
@@ -110,8 +110,8 @@ test "Read grayscale images" {
         }
     }
 
-    try helpers.expectEq(frame.frame_header.row_count, 32);
-    try helpers.expectEq(frame.frame_header.samples_per_row, 32);
+    try helpers.expectEq(frame.frame_header.height, 32);
+    try helpers.expectEq(frame.frame_header.width, 32);
     try helpers.expectEq(frame.frame_header.sample_precision, 8);
     try helpers.expectEq(frame.frame_header.components.len, 1);
 


### PR DESCRIPTION
Previously jpeg used `mcu_storage: [][MAX_COMPONENTS][MAX_BLOCKS]Block` where each element contained 1 MCU. When dealing with subsampling (say 2x2) then 1 MCU will contain 4 Luma blocks and 1 of each Cb Cr.

This becomes problematic when dealing progressive jpegs with multiple scans. When each scan contains all components, then performScan can fully fill the MCU before moving to the next MCU. This occurs in the interleaved (ITU-T81, A.2.3) ordering.

However if a scan only contains a single component, then instead of filling a single MCU interleaved order, the scan contains elements per block  (ITU-T81, A.2.2). This results in a difficult fill order where perform scan would need to loop through MCUs multiple times and fill the internal block buffers in an order dictated by the sampling factor. For example with 2x2 subsampling, we'd have to loop through each MCU twice, filling the first two blocks of the MCU on the first loop and then the second two blocks on the same MCU on the second pass.

This conflation of the logical MCU structure and the physical image layout also causes problems in other locations such as renderToPixelsRgb. There's lots of extra code dealing with the fact that there's no easy way to access the underlying physical data structure.

Instead introduce block_storage `[][MAX_COMPONENTS]Block` which is flat array of blocks. Then to loop through MCUs, we just loop based on the sampling factor, see the new YCbCrToRgb for an example where the first two loops iterate across logical MCUs and the internal two loops iterate through blocks inside the logical MCU.

This also refactors renderToPixelsRgb which did both the YCbCr to RGB conversion as well as copied the colors to the final pixel storage. Instead we have YcbCrToRgb and renderToPixelsRgb copies the internal buffer to the external pixels.

Additionally we skip performing idct and dequant on blocks that aren't filled in during subsampling.

Other benefits: mcu_storage requires per MCU, storage for the maximum possible blocks for each component. This is wasteful in subsampling. With the block_storage method, we could conceivable store a separate array for each component, and those arrays are different sizes depending on the subsampling. This would require component number of allocations, whereas we'd have num_mcu*num_components allocations in the other way.
