### PR TITLE
Jpeg optimizations

### DIFF
--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -176,14 +176,14 @@ pub fn yCbCrToRgbBlock(self: *Self, y_block: *[3]Block, cbcr_block: *[3]Block, v
         const Y6: f32 = @floatFromInt(y_block[0][pixel_index + 6]);
         const Y7: f32 = @floatFromInt(y_block[0][pixel_index + 7]);
 
-        const cbcr_x0: usize = 0 / x_step + (8 / x_step) * h;
-        const cbcr_x1: usize = 1 / x_step + (8 / x_step) * h;
-        const cbcr_x2: usize = 2 / x_step + (8 / x_step) * h;
-        const cbcr_x3: usize = 3 / x_step + (8 / x_step) * h;
-        const cbcr_x4: usize = 4 / x_step + (8 / x_step) * h;
-        const cbcr_x5: usize = 5 / x_step + (8 / x_step) * h;
-        const cbcr_x6: usize = 6 / x_step + (8 / x_step) * h;
-        const cbcr_x7: usize = 7 / x_step + (8 / x_step) * h;
+        const cbcr_x0: usize = (0 / x_step) + (8 / x_step) * h;
+        const cbcr_x1: usize = (1 / x_step) + (8 / x_step) * h;
+        const cbcr_x2: usize = (2 / x_step) + (8 / x_step) * h;
+        const cbcr_x3: usize = (3 / x_step) + (8 / x_step) * h;
+        const cbcr_x4: usize = (4 / x_step) + (8 / x_step) * h;
+        const cbcr_x5: usize = (5 / x_step) + (8 / x_step) * h;
+        const cbcr_x6: usize = (6 / x_step) + (8 / x_step) * h;
+        const cbcr_x7: usize = (7 / x_step) + (8 / x_step) * h;
 
         const cbcr_pixel0: usize = cbcr_y * 8 + cbcr_x0;
         const cbcr_pixel1: usize = cbcr_y * 8 + cbcr_x1;

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -267,38 +267,157 @@ pub fn idctMCUs(self: *Self) void {
 }
 
 fn idctBlock(block: *Block) void {
-    var result: Block = undefined;
+    var result: [64]f32 = undefined;
+
+    const m0: f32 = 2.0 * @cos(1.0 / 16.0 * 2.0 * std.math.pi);
+    const m1: f32 = 2.0 * @cos(2.0 / 16.0 * 2.0 * std.math.pi);
+    const m3: f32 = 2.0 * @cos(2.0 / 16.0 * 2.0 * std.math.pi);
+    const m5: f32 = 2.0 * @cos(3.0 / 16.0 * 2.0 * std.math.pi);
+    const m2: f32 = m0 - m5;
+    const m4: f32 = m0 + m5;
+
+    const s0: f32 = @cos(0.0 / 16.0 * std.math.pi) / @sqrt(8.0);
+    const s1: f32 = @cos(1.0 / 16.0 * std.math.pi) / 2.0;
+    const s2: f32 = @cos(2.0 / 16.0 * std.math.pi) / 2.0;
+    const s3: f32 = @cos(3.0 / 16.0 * std.math.pi) / 2.0;
+    const s4: f32 = @cos(4.0 / 16.0 * std.math.pi) / 2.0;
+    const s5: f32 = @cos(5.0 / 16.0 * std.math.pi) / 2.0;
+    const s6: f32 = @cos(6.0 / 16.0 * std.math.pi) / 2.0;
+    const s7: f32 = @cos(7.0 / 16.0 * std.math.pi) / 2.0;
+
+    for (0..8) |x| {
+        const a0 = @as(f32, @floatFromInt(block[0 * 8 + x])) * s0;
+        const a1 = @as(f32, @floatFromInt(block[4 * 8 + x])) * s4;
+        const a2 = @as(f32, @floatFromInt(block[2 * 8 + x])) * s2;
+        const a3 = @as(f32, @floatFromInt(block[6 * 8 + x])) * s6;
+        const a4 = @as(f32, @floatFromInt(block[5 * 8 + x])) * s5;
+        const a5 = @as(f32, @floatFromInt(block[1 * 8 + x])) * s1;
+        const a6 = @as(f32, @floatFromInt(block[7 * 8 + x])) * s7;
+        const a7 = @as(f32, @floatFromInt(block[3 * 8 + x])) * s3;
+
+        const b0 = a0;
+        const b1 = a1;
+        const b2 = a2;
+        const b3 = a3;
+        const b4 = a4 - a7;
+        const b5 = a5 + a6;
+        const b6 = a5 - a6;
+        const b7 = a4 + a7;
+
+        const c0 = b0;
+        const c1 = b1;
+        const c2 = b2 - b3;
+        const c3 = b2 + b3;
+        const c4 = b4;
+        const c5 = b5 - b7;
+        const c6 = b6;
+        const c7 = b5 + b7;
+        const c8 = b4 + b6;
+
+        const d0 = c0;
+        const d1 = c1;
+        const d2 = c2 * m1;
+        const d3 = c3;
+        const d4 = c4 * m2;
+        const d5 = c5 * m3;
+        const d6 = c6 * m4;
+        const d7 = c7;
+        const d8 = c8 * m5;
+
+        const e0 = d0 + d1;
+        const e1 = d0 - d1;
+        const e2 = d2 - d3;
+        const e3 = d3;
+        const e4 = d4 + d8;
+        const e5 = d5 + d7;
+        const e6 = d6 - d8;
+        const e7 = d7;
+        const e8 = e5 - e6;
+
+        const f0 = e0 + e3;
+        const f1 = e1 + e2;
+        const f2 = e1 - e2;
+        const f3 = e0 - e3;
+        const f4 = e4 - e8;
+        const f5 = e8;
+        const f6 = e6 - e7;
+        const f7 = e7;
+
+        result[0 * 8 + x] = f0 + f7;
+        result[1 * 8 + x] = f1 + f6;
+        result[2 * 8 + x] = f2 + f5;
+        result[3 * 8 + x] = f3 + f4;
+        result[4 * 8 + x] = f3 - f4;
+        result[5 * 8 + x] = f2 - f5;
+        result[6 * 8 + x] = f1 - f6;
+        result[7 * 8 + x] = f0 - f7;
+    }
 
     for (0..8) |y| {
-        for (0..8) |x| {
-            result[y * 8 + x] = idct(block, x, y, 0, 0);
-        }
+        const a0 = result[y * 8 + 0] * s0;
+        const a1 = result[y * 8 + 4] * s4;
+        const a2 = result[y * 8 + 2] * s2;
+        const a3 = result[y * 8 + 6] * s6;
+        const a4 = result[y * 8 + 5] * s5;
+        const a5 = result[y * 8 + 1] * s1;
+        const a6 = result[y * 8 + 7] * s7;
+        const a7 = result[y * 8 + 3] * s3;
+
+        const b0 = a0;
+        const b1 = a1;
+        const b2 = a2;
+        const b3 = a3;
+        const b4 = a4 - a7;
+        const b5 = a5 + a6;
+        const b6 = a5 - a6;
+        const b7 = a4 + a7;
+
+        const c0 = b0;
+        const c1 = b1;
+        const c2 = b2 - b3;
+        const c3 = b2 + b3;
+        const c4 = b4;
+        const c5 = b5 - b7;
+        const c6 = b6;
+        const c7 = b5 + b7;
+        const c8 = b4 + b6;
+
+        const d0 = c0;
+        const d1 = c1;
+        const d2 = c2 * m1;
+        const d3 = c3;
+        const d4 = c4 * m2;
+        const d5 = c5 * m3;
+        const d6 = c6 * m4;
+        const d7 = c7;
+        const d8 = c8 * m5;
+
+        const e0 = d0 + d1;
+        const e1 = d0 - d1;
+        const e2 = d2 - d3;
+        const e3 = d3;
+        const e4 = d4 + d8;
+        const e5 = d5 + d7;
+        const e6 = d6 - d8;
+        const e7 = d7;
+        const e8 = e5 - e6;
+
+        const f0 = e0 + e3;
+        const f1 = e1 + e2;
+        const f2 = e1 - e2;
+        const f3 = e0 - e3;
+        const f4 = e4 - e8;
+        const f5 = e8;
+        const f6 = e6 - e7;
+        const f7 = e7;
+
+        block[y * 8 + 0] = @intFromFloat(std.math.clamp(f0 + f7 + 0.5, -128.0, 127.0));
+        block[y * 8 + 1] = @intFromFloat(std.math.clamp(f1 + f6 + 0.5, -128.0, 127.0));
+        block[y * 8 + 2] = @intFromFloat(std.math.clamp(f2 + f5 + 0.5, -128.0, 127.0));
+        block[y * 8 + 3] = @intFromFloat(std.math.clamp(f3 + f4 + 0.5, -128.0, 127.0));
+        block[y * 8 + 4] = @intFromFloat(std.math.clamp(f3 - f4 + 0.5, -128.0, 127.0));
+        block[y * 8 + 5] = @intFromFloat(std.math.clamp(f2 - f5 + 0.5, -128.0, 127.0));
+        block[y * 8 + 6] = @intFromFloat(std.math.clamp(f1 - f6 + 0.5, -128.0, 127.0));
+        block[y * 8 + 7] = @intFromFloat(std.math.clamp(f0 - f7 + 0.5, -128.0, 127.0));
     }
-
-    // write final result back
-    for (0..64) |idx| {
-        block[idx] = result[idx];
-    }
-}
-
-fn idct(block: *const Block, x: usize, y: usize, mcu_id: usize, component_id: usize) i8 {
-    var reconstructed_pixel: f32 = 0.0;
-
-    var u: usize = 0;
-    while (u < 8) : (u += 1) {
-        var v: usize = 0;
-        while (v < 8) : (v += 1) {
-            const block_value = block[v * 8 + u];
-            reconstructed_pixel += IDCTMultipliers[y][x][u][v] * @as(f32, @floatFromInt(block_value));
-        }
-    }
-
-    const scaled_pixel = @round(reconstructed_pixel / 4.0);
-    if (JPEG_DEBUG) {
-        if (scaled_pixel < -128.0 or scaled_pixel > 127.0) {
-            std.debug.print("Pixel at mcu={} x={} y={} component_id={} is out of bounds with DCT: {d}!\n", .{ mcu_id, x, y, component_id, scaled_pixel });
-        }
-    }
-
-    return @intFromFloat(std.math.clamp(scaled_pixel, -128.0, 127.0));
 }

--- a/tests/formats/jpeg_test.zig
+++ b/tests/formats/jpeg_test.zig
@@ -86,9 +86,9 @@ test "Read the tuba properly" {
         try testing.expect(pixels == .rgb24);
 
         // Just for fun, let's sample a few pixels. :^)
-        try helpers.expectEq(pixels.rgb24[(126 * 512 + 163)], color.Rgb24.initRgb(0xAC, 0x78, 0x54));
-        try helpers.expectEq(pixels.rgb24[(265 * 512 + 284)], color.Rgb24.initRgb(0x37, 0x30, 0x33));
-        try helpers.expectEq(pixels.rgb24[(431 * 512 + 300)], color.Rgb24.initRgb(0xFE, 0xE7, 0xC9));
+        try helpers.expectEq(pixels.rgb24[(126 * 512 + 163)], color.Rgb24.initRgb(0xAC, 0x78, 0x55));
+        try helpers.expectEq(pixels.rgb24[(265 * 512 + 284)], color.Rgb24.initRgb(0x38, 0x31, 0x34));
+        try helpers.expectEq(pixels.rgb24[(431 * 512 + 300)], color.Rgb24.initRgb(0xFE, 0xE7, 0xCB));
     }
 }
 
@@ -121,7 +121,7 @@ test "Read grayscale images" {
         try testing.expect(pixels == .grayscale8);
 
         // Just for fun, let's sample a few pixels. :^)
-        try helpers.expectEq(pixels.grayscale8[(0 * 32 + 0)], color.Grayscale8{ .value = 0x00 });
+        try helpers.expectEq(pixels.grayscale8[(0 * 32 + 0)], color.Grayscale8{ .value = 0x01 });
         try helpers.expectEq(pixels.grayscale8[(15 * 32 + 15)], color.Grayscale8{ .value = 0xaa });
         try helpers.expectEq(pixels.grayscale8[(28 * 32 + 28)], color.Grayscale8{ .value = 0xf7 });
     }


### PR DESCRIPTION
JPEG optimizations:

* Use ANN IDCT -- this should probably be changed to the LLM version since that's what's mostly commonly used in JPEG decoders. Using different IDCT methods can cause differences in final output due to rounding. It seems like there's good SIMD implementations as well for LLM https://github.com/libjpeg-turbo/ijg/blob/main/jidctint.c -- Total about >10x speed up for IDCT and 4x total.
* Unroll yCbCrToRgb loop to maximize simd loading. Not sure why this didn't unroll by itself. ~ 25% faster yCbCrToRgb, though the generated code still doesn't seem very good. I'll handroll some simd for this.
* Add acceleration structure based on stb_image. Nearly 50% of run time was huffman decoding and in particularly looking up codes in the AutoArrayHashmap. Instead use an acceleration structure for codes with length <= 9. We directly look up the associated code. Any longer codes go through the slow path. The AutoArray should probably just be eliminated in the future. To support the acceleration structure, we speculatively look forward 9 bits always. This might cause the reader to accidentally read the next segments marker. We need to put that marker back. As such, the huffman reader is now passed the actual seekable buffer.

Total speed about ~6x 

