### PR TITLE
jpeg: fix images with restart interval

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -123,6 +123,7 @@ pub const JPEG = struct {
                     }
 
                     self.frame = try Frame.read(self.allocator, @enumFromInt(marker), &self.quantization_tables, &self.dc_huffman_tables, &self.ac_huffman_tables, &buffered_stream);
+                    try self.initializePixels(pixels_opt);
                 },
 
                 .sof1 => return ImageError.Unsupported, // extended sequential DCT Huffman coding
@@ -140,7 +141,6 @@ pub const JPEG = struct {
                     try self.parseDefineHuffmanTables(reader);
                 },
                 .start_of_scan => {
-                    try self.initializePixels(pixels_opt);
                     try self.parseScan(&buffered_stream);
                 },
 

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -76,7 +76,7 @@ pub const JPEG = struct {
 
     fn parseScan(self: *JPEG, stream: *buffered_stream_source.DefaultBufferedStreamSourceReader) ImageReadError!void {
         if (self.frame) |frame| {
-            try Scan.performScan(&frame, stream);
+            try Scan.performScan(&frame, self.restart_interval, stream);
         } else return ImageReadError.InvalidData;
     }
 
@@ -122,7 +122,7 @@ pub const JPEG = struct {
                         return ImageError.Unsupported;
                     }
 
-                    self.frame = try Frame.read(self.allocator, @enumFromInt(marker), self.restart_interval, &self.quantization_tables, &self.dc_huffman_tables, &self.ac_huffman_tables, &buffered_stream);
+                    self.frame = try Frame.read(self.allocator, @enumFromInt(marker), &self.quantization_tables, &self.dc_huffman_tables, &self.ac_huffman_tables, &buffered_stream);
                 },
 
                 .sof1 => return ImageError.Unsupported, // extended sequential DCT Huffman coding
@@ -264,6 +264,7 @@ pub const JPEG = struct {
         std.debug.assert(segment_length - 4 == 0);
 
         self.restart_interval = try reader.readInt(u16, .big);
-        if (JPEG_DEBUG) std.debug.print("Restart Interval: {}", .{self.restart_interval});
+
+        if (JPEG_DEBUG) std.debug.print("Restart Interval: {}\n", .{self.restart_interval});
     }
 };

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -23,7 +23,6 @@ quantization_tables: *[4]?QuantizationTable,
 dc_huffman_tables: *[4]?HuffmanTable,
 ac_huffman_tables: *[4]?HuffmanTable,
 block_storage: [][MAX_COMPONENTS]Block,
-restart_interval: u16 = 0,
 frame_type: Markers = undefined,
 
 block_height: u32 = 0,
@@ -36,7 +35,7 @@ vertical_sampling_factor_max: usize = 0,
 
 const JPEG_DEBUG = false;
 
-pub fn read(allocator: Allocator, frame_type: Markers, restart_interval: u16, quantization_tables: *[4]?QuantizationTable, dc_huffman_tables: *[4]?HuffmanTable, ac_huffman_tables: *[4]?HuffmanTable, buffered_stream: *buffered_stream_source.DefaultBufferedStreamSourceReader) ImageReadError!Self {
+pub fn read(allocator: Allocator, frame_type: Markers, quantization_tables: *[4]?QuantizationTable, dc_huffman_tables: *[4]?HuffmanTable, ac_huffman_tables: *[4]?HuffmanTable, buffered_stream: *buffered_stream_source.DefaultBufferedStreamSourceReader) ImageReadError!Self {
     const reader = buffered_stream.reader();
     const frame_header = try FrameHeader.read(allocator, reader);
 
@@ -56,7 +55,6 @@ pub fn read(allocator: Allocator, frame_type: Markers, restart_interval: u16, qu
         .quantization_tables = quantization_tables,
         .dc_huffman_tables = dc_huffman_tables,
         .ac_huffman_tables = ac_huffman_tables,
-        .restart_interval = restart_interval,
         .frame_type = frame_type,
         .block_storage = block_storage,
         .block_height_actual = @intCast((height_actual + 7) / 8),

--- a/tests/formats/jpeg_test.zig
+++ b/tests/formats/jpeg_test.zig
@@ -179,3 +179,26 @@ test "Read subsampling images" {
         }
     }
 }
+
+test "Read progressive jpeg with restart intervals" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "jpeg/tuba_restart_prog.jpg");
+    defer file.close();
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    var jpeg_file = jpeg.JPEG.init(helpers.zigimg_test_allocator);
+    defer jpeg_file.deinit();
+
+    var pixels_opt: ?color.PixelStorage = null;
+    const frame = try jpeg_file.read(&stream_source, &pixels_opt);
+
+    _ = frame;
+
+    defer {
+        if (pixels_opt) |pixels| {
+            pixels.deinit(helpers.zigimg_test_allocator);
+        }
+    }
+
+    try testing.expect(pixels_opt != null);
+}


### PR DESCRIPTION
With restart intervals, when the correct number of MCUs are decoded, we're supposed to flush the remaining bits of the current byte. Previously we just emptied the bit buffer. However since we're now speculatively filling the bit buffer, there may be its that shouldn't be flushed. Instead determine if we're in the middle of a byte and flush rest of the bits in that byte.