### PR TITLE
Ilbm add indexed planar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,17 @@ zig build test
 
 * Support GIF87a and GIF89a
 * Support animated GIF with Netscape application extension for looping information
-* Supported interlaced
+* Supports interlaced
 * Supports tiled and layered images used to achieve pseudo true color and more.
 * The plain text extension is not supported
 
 ### ILBM - InterLeaved BitMap Format
 
+ * Supports Amiga <= 8-bit planar images
+ * Supports uncompressed & byterun compressed files
  * Supports PBM (Deluxe Paint DOS) encoded files
- * Amiga and Atari planar files are not supported yet
+ * HAM/HAM8/EHB/24-bit images are not supported yet
+ * Atari planar files are not supported yet
  * Most chunks are ignored
 
 ### PAM - Portable Arbitrary Map
@@ -241,7 +244,7 @@ pub fn main() !void {
 
 ## Accessing pixel data
 
-For a single image, they are two ways to get accees to the pixel data.
+For a single image, they are two ways to get access to the pixel data.
 
 ### Accessing a specific format directly
 
@@ -497,7 +500,7 @@ pub fn main() !void {
 
 ## Use image format directly
 
-In the case you want more direct access to the image format, all the image format are accessible from the `zigimg` module. However, you'll need to do a bit more manual steps in order to get the pixel data.
+In the case you want more direct access to the image format, all the image formats are accessible from the `zigimg` module. However, you'll need to do a bit more manual steps in order to retrieve the pixel data.
 
 ```zig
 const std = @import("std");

--- a/tests/formats/ilbm_test.zig
+++ b/tests/formats/ilbm_test.zig
@@ -38,3 +38,53 @@ test "ILBM indexed8 PBM (chunky Deluxe Paint DOS file)" {
     try helpers.expectEq(palette58.g, 209);
     try helpers.expectEq(palette58.b, 148);
 }
+
+test "ILBM indexed8 8 bitplanes" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ilbm-8bit-compressed.iff");
+    defer file.close();
+
+    var the_bitmap = ilbm.ILBM{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 380);
+    try helpers.expectEq(the_bitmap.height(), 200);
+    try testing.expect(pixels == .indexed8);
+
+    const palette2 = pixels.indexed8.palette[2];
+
+    try helpers.expectEq(palette2.r, 247);
+    try helpers.expectEq(palette2.g, 164);
+    try helpers.expectEq(palette2.b, 29);
+
+    try helpers.expectEq(pixels.indexed8.indices[141], 58);
+    try helpers.expectEq(pixels.indexed8.indices[25975], 2);
+}
+
+test "ILBM indexed8 8 bitplanes uncompressed" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ilbm-8bit-uncompressed.iff");
+    defer file.close();
+
+    var the_bitmap = ilbm.ILBM{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 380);
+    try helpers.expectEq(the_bitmap.height(), 200);
+    try testing.expect(pixels == .indexed8);
+
+    const palette2 = pixels.indexed8.palette[2];
+
+    try helpers.expectEq(palette2.r, 247);
+    try helpers.expectEq(palette2.g, 164);
+    try helpers.expectEq(palette2.b, 29);
+
+    try helpers.expectEq(pixels.indexed8.indices[141], 58);
+    try helpers.expectEq(pixels.indexed8.indices[25975], 2);
+}


### PR DESCRIPTION
This PR adds support for <=8-bit Amiga planar images.

HAM & 24-bit images support is planned.