### PR TITLE
ilbm: add support for EHB files

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ zig build test
 ### ILBM - InterLeaved BitMap Format
 
  * Supports Amiga <= 8-bit planar images
+ * Supports EHB view mode
  * Supports uncompressed & byterun compressed files
  * Supports PBM (Deluxe Paint DOS) encoded files
- * HAM/HAM8/EHB/24-bit images are not supported yet
+ * HAM/HAM8/24-bit images are not supported yet
  * Atari planar files are not supported yet
  * Most chunks are ignored
 
@@ -748,7 +749,7 @@ If the target RGB colorspace have a different white point, it will do the [chrom
 
 ### Predefined RGB color spaces
 
-Here the list of predefined RGB color spaces, all acessilbe from `zigimg.color` struct:
+Here the list of predefined RGB color spaces, all accessible from `zigimg.color` struct:
 
 * `BT601_NTSC`
 * `BT601_PAL`

--- a/tests/formats/ilbm_test.zig
+++ b/tests/formats/ilbm_test.zig
@@ -88,3 +88,34 @@ test "ILBM indexed8 8 bitplanes uncompressed" {
     try helpers.expectEq(pixels.indexed8.indices[141], 58);
     try helpers.expectEq(pixels.indexed8.indices[25975], 2);
 }
+
+test "ILBM indexed8 6 bitplanes EHB" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ehb.iff");
+    defer file.close();
+
+    var the_bitmap = ilbm.ILBM{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 320);
+    try helpers.expectEq(the_bitmap.height(), 256);
+    try testing.expect(pixels == .indexed8);
+
+    const palette2 = pixels.indexed8.palette[2];
+
+    try helpers.expectEq(palette2.r, 34);
+    try helpers.expectEq(palette2.g, 17);
+    try helpers.expectEq(palette2.b, 34);
+
+    const palette45 = pixels.indexed8.palette[45];
+
+    try helpers.expectEq(palette45.r, 153);
+    try helpers.expectEq(palette45.g, 170);
+    try helpers.expectEq(palette45.b, 153);
+
+    try helpers.expectEq(pixels.indexed8.indices[141], 21);
+    try helpers.expectEq(pixels.indexed8.indices[25975], 61);
+}


### PR DESCRIPTION
This PR adds support for EHB viewmode: it's a special Amiga feature that adds the ability to display 64 colors using only 32 color registers.