### PR TITLE
jpeg: set values to 0 outside of image boundary

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -24,9 +24,6 @@ const HuffmanTable = @import("./jpeg/huffman.zig").Table;
 const Frame = @import("./jpeg/Frame.zig");
 const Scan = @import("./jpeg/Scan.zig");
 
-// TODO: Chroma subsampling
-// TODO: Progressive scans
-// TODO: Non-baseline sequential DCT
 // TODO: Precisions other than 8-bit
 
 // TODO: Hierarchical mode of JPEG compression.
@@ -175,8 +172,8 @@ pub const JPEG = struct {
             }
         }
 
-        try self.frame.?.dequantizeMCUs();
-        self.frame.?.idctMCUs();
+        try self.frame.?.dequantizeBlocks();
+        self.frame.?.idctBlocks();
         try self.frame.?.renderToPixels(&pixels_opt.*.?);
 
         return if (self.frame) |frame| frame else ImageReadError.InvalidData;

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -290,6 +290,8 @@ pub fn yCbCrToRgb(self: *Self) ImageReadError!void {
                 var h: usize = h_max;
                 while (h > 0) {
                     h -= 1;
+                    if (y + v >= self.block_height or x + h >= self.block_width) continue;
+
                     const y_block = &self.block_storage[(y + v) * self.block_width_actual + (x + h)];
                     yCbCrToRgbBlock(self, y_block, cbcr_block, v, h);
                 }
@@ -321,8 +323,12 @@ pub fn dequantizeMCUs(self: *Self) ImageReadError!void {
                     for (0..h_max) |h| {
                         const block_id = (y + v) * self.block_width_actual + (x + h);
                         const block = &self.block_storage[block_id][component_id];
-                        for (0..64) |sample_id| {
-                            block[sample_id] = block[sample_id] * quantization_table.q8[sample_id];
+                        if (y + v >= self.block_height) {
+                            @memset(block, 0);
+                        } else {
+                            for (0..64) |sample_id| {
+                                block[sample_id] = block[sample_id] * quantization_table.q8[sample_id];
+                            }
                         }
                     }
                 }

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -300,7 +300,7 @@ pub fn yCbCrToRgb(self: *Self) ImageReadError!void {
     }
 }
 
-pub fn dequantizeMCUs(self: *Self) ImageReadError!void {
+pub fn dequantizeBlocks(self: *Self) ImageReadError!void {
     for (self.frame_header.components) |component| {
         if (self.quantization_tables[component.quantization_table_id] == null) {
             return ImageReadError.InvalidData;
@@ -337,7 +337,7 @@ pub fn dequantizeMCUs(self: *Self) ImageReadError!void {
     }
 }
 
-pub fn idctMCUs(self: *Self) void {
+pub fn idctBlocks(self: *Self) void {
     const y_step = self.vertical_sampling_factor_max;
     const x_step = self.horizontal_sampling_factor_max;
 

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -162,112 +162,28 @@ pub fn yCbCrToRgbBlock(self: *Self, y_block: *[3]Block, cbcr_block: *[3]Block, v
     var y: usize = 8;
     while (y > 0) {
         y -= 1;
-        const cbcr_y: usize = y / y_step + (8 / y_step) * v;
-
         const pixel_index: usize = y * 8;
-        const Y0: f32 = @floatFromInt(y_block[0][pixel_index + 0]);
-        const Y1: f32 = @floatFromInt(y_block[0][pixel_index + 1]);
-        const Y2: f32 = @floatFromInt(y_block[0][pixel_index + 2]);
-        const Y3: f32 = @floatFromInt(y_block[0][pixel_index + 3]);
-        const Y4: f32 = @floatFromInt(y_block[0][pixel_index + 4]);
-        const Y5: f32 = @floatFromInt(y_block[0][pixel_index + 5]);
-        const Y6: f32 = @floatFromInt(y_block[0][pixel_index + 6]);
-        const Y7: f32 = @floatFromInt(y_block[0][pixel_index + 7]);
+        comptime var x: usize = 8;
+        inline while (x > 0) {
+            x -= 1;
+            const Y: f32 = @floatFromInt(y_block[0][pixel_index + x]);
 
-        const cbcr_x0: usize = (0 / x_step) + (8 / x_step) * h;
-        const cbcr_x1: usize = (1 / x_step) + (8 / x_step) * h;
-        const cbcr_x2: usize = (2 / x_step) + (8 / x_step) * h;
-        const cbcr_x3: usize = (3 / x_step) + (8 / x_step) * h;
-        const cbcr_x4: usize = (4 / x_step) + (8 / x_step) * h;
-        const cbcr_x5: usize = (5 / x_step) + (8 / x_step) * h;
-        const cbcr_x6: usize = (6 / x_step) + (8 / x_step) * h;
-        const cbcr_x7: usize = (7 / x_step) + (8 / x_step) * h;
+            const cbcr_y: usize = y / y_step + (8 / y_step) * v;
+            const cbcr_x: usize = x / x_step + (8 / x_step) * h;
 
-        const cbcr_pixel0: usize = cbcr_y * 8 + cbcr_x0;
-        const cbcr_pixel1: usize = cbcr_y * 8 + cbcr_x1;
-        const cbcr_pixel2: usize = cbcr_y * 8 + cbcr_x2;
-        const cbcr_pixel3: usize = cbcr_y * 8 + cbcr_x3;
-        const cbcr_pixel4: usize = cbcr_y * 8 + cbcr_x4;
-        const cbcr_pixel5: usize = cbcr_y * 8 + cbcr_x5;
-        const cbcr_pixel6: usize = cbcr_y * 8 + cbcr_x6;
-        const cbcr_pixel7: usize = cbcr_y * 8 + cbcr_x7;
+            const cbcr_pixel: usize = cbcr_y * 8 + cbcr_x;
 
-        const Cb0: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel0]);
-        const Cb1: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel1]);
-        const Cb2: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel2]);
-        const Cb3: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel3]);
-        const Cb4: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel4]);
-        const Cb5: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel5]);
-        const Cb6: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel6]);
-        const Cb7: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel7]);
+            const Cb: f32 = @floatFromInt(cbcr_block[1][cbcr_pixel]);
+            const Cr: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel]);
 
-        const Cr0: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel0]);
-        const Cr1: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel1]);
-        const Cr2: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel2]);
-        const Cr3: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel3]);
-        const Cr4: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel4]);
-        const Cr5: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel5]);
-        const Cr6: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel6]);
-        const Cr7: f32 = @floatFromInt(cbcr_block[2][cbcr_pixel7]);
+            const r = Cr * (2 - 2 * 0.299) + Y;
+            const b = Cb * (2 - 2 * 0.114) + Y;
+            const g = (Y - 0.114 * b - 0.299 * r) / 0.587;
 
-        const r0 = Cr0 * (2 - 2 * 0.299) + Y0;
-        const r1 = Cr1 * (2 - 2 * 0.299) + Y1;
-        const r2 = Cr2 * (2 - 2 * 0.299) + Y2;
-        const r3 = Cr3 * (2 - 2 * 0.299) + Y3;
-        const r4 = Cr4 * (2 - 2 * 0.299) + Y4;
-        const r5 = Cr5 * (2 - 2 * 0.299) + Y5;
-        const r6 = Cr6 * (2 - 2 * 0.299) + Y6;
-        const r7 = Cr7 * (2 - 2 * 0.299) + Y7;
-
-        const b0 = Cb0 * (2 - 2 * 0.114) + Y0;
-        const b1 = Cb1 * (2 - 2 * 0.114) + Y1;
-        const b2 = Cb2 * (2 - 2 * 0.114) + Y2;
-        const b3 = Cb3 * (2 - 2 * 0.114) + Y3;
-        const b4 = Cb4 * (2 - 2 * 0.114) + Y4;
-        const b5 = Cb5 * (2 - 2 * 0.114) + Y5;
-        const b6 = Cb6 * (2 - 2 * 0.114) + Y6;
-        const b7 = Cb7 * (2 - 2 * 0.114) + Y7;
-
-        const g0 = (Y0 - 0.114 * b0 - 0.299 * r0) / 0.587;
-        const g1 = (Y1 - 0.114 * b1 - 0.299 * r1) / 0.587;
-        const g2 = (Y2 - 0.114 * b2 - 0.299 * r2) / 0.587;
-        const g3 = (Y3 - 0.114 * b3 - 0.299 * r3) / 0.587;
-        const g4 = (Y4 - 0.114 * b4 - 0.299 * r4) / 0.587;
-        const g5 = (Y5 - 0.114 * b5 - 0.299 * r5) / 0.587;
-        const g6 = (Y6 - 0.114 * b6 - 0.299 * r6) / 0.587;
-        const g7 = (Y7 - 0.114 * b7 - 0.299 * r7) / 0.587;
-
-        y_block[0][pixel_index + 0] = @intFromFloat(std.math.clamp(r0 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 0] = @intFromFloat(std.math.clamp(g0 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 0] = @intFromFloat(std.math.clamp(b0 + 128.0, 0.0, 255.0));
-
-        y_block[0][pixel_index + 1] = @intFromFloat(std.math.clamp(r1 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 1] = @intFromFloat(std.math.clamp(g1 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 1] = @intFromFloat(std.math.clamp(b1 + 128.0, 0.0, 255.0));
-
-        y_block[0][pixel_index + 2] = @intFromFloat(std.math.clamp(r2 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 2] = @intFromFloat(std.math.clamp(g2 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 2] = @intFromFloat(std.math.clamp(b2 + 128.0, 0.0, 255.0));
-
-        y_block[0][pixel_index + 3] = @intFromFloat(std.math.clamp(r3 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 3] = @intFromFloat(std.math.clamp(g3 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 3] = @intFromFloat(std.math.clamp(b3 + 128.0, 0.0, 255.0));
-
-        y_block[0][pixel_index + 4] = @intFromFloat(std.math.clamp(r4 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 4] = @intFromFloat(std.math.clamp(g4 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 4] = @intFromFloat(std.math.clamp(b4 + 128.0, 0.0, 255.0));
-
-        y_block[0][pixel_index + 5] = @intFromFloat(std.math.clamp(r5 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 5] = @intFromFloat(std.math.clamp(g5 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 5] = @intFromFloat(std.math.clamp(b5 + 128.0, 0.0, 255.0));
-
-        y_block[0][pixel_index + 6] = @intFromFloat(std.math.clamp(r6 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 6] = @intFromFloat(std.math.clamp(g6 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 6] = @intFromFloat(std.math.clamp(b6 + 128.0, 0.0, 255.0));
-
-        y_block[0][pixel_index + 7] = @intFromFloat(std.math.clamp(r7 + 128.0, 0.0, 255.0));
-        y_block[1][pixel_index + 7] = @intFromFloat(std.math.clamp(g7 + 128.0, 0.0, 255.0));
-        y_block[2][pixel_index + 7] = @intFromFloat(std.math.clamp(b7 + 128.0, 0.0, 255.0));
+            y_block[0][pixel_index + x] = @intFromFloat(std.math.clamp(r + 128.0, 0.0, 255.0));
+            y_block[1][pixel_index + x] = @intFromFloat(std.math.clamp(g + 128.0, 0.0, 255.0));
+            y_block[2][pixel_index + x] = @intFromFloat(std.math.clamp(b + 128.0, 0.0, 255.0));
+        }
     }
 }
 

--- a/src/formats/jpeg/utils.zig
+++ b/src/formats/jpeg/utils.zig
@@ -1,6 +1,10 @@
 //! general utilizies and constants
 const std = @import("std");
 
+pub const MAX_COMPONENTS = 3;
+pub const MAX_BLOCKS = 8;
+pub const Block = [64]i32;
+
 // See figure A.6 in T.81.
 // zig fmt: off
 pub const ZigzagOffsets: [64]usize  = .{
@@ -14,36 +18,6 @@ pub const ZigzagOffsets: [64]usize  = .{
     53, 60, 61, 54, 47, 55, 62, 63
 };
 // zig fmt: on
-
-/// The precalculated IDCT multipliers. This is possible because the only part of
-/// the IDCT calculation that changes between runs is the coefficients.
-/// see A.3.3 of t.81 1992
-pub const IDCTMultipliers = blk: {
-    var multipliers: [8][8][8][8]f32 = undefined;
-    @setEvalBranchQuota(4700);
-
-    var y: usize = 0;
-    while (y < 8) : (y += 1) {
-        var x: usize = 0;
-        while (x < 8) : (x += 1) {
-            var u: usize = 0;
-            while (u < 8) : (u += 1) {
-                var v: usize = 0;
-                while (v < 8) : (v += 1) {
-                    const C_u: f32 = if (u == 0) 1.0 / @sqrt(2.0) else 1.0;
-                    const C_v: f32 = if (v == 0) 1.0 / @sqrt(2.0) else 1.0;
-
-                    const x_cosine = @cos(((2 * @as(f32, @floatFromInt(x)) + 1) * @as(f32, @floatFromInt(u)) * std.math.pi) / 16.0);
-                    const y_cosine = @cos(((2 * @as(f32, @floatFromInt(y)) + 1) * @as(f32, @floatFromInt(v)) * std.math.pi) / 16.0);
-                    const uv_value = C_u * C_v * x_cosine * y_cosine;
-                    multipliers[y][x][u][v] = uv_value;
-                }
-            }
-        }
-    }
-
-    break :blk multipliers;
-};
 
 /// Marker codes, see t-81 section B.1.1.3
 pub const Markers = enum(u16) {
@@ -114,7 +88,3 @@ pub const Markers = enum(u16) {
 
     // reserved markers from 0xFF01-0xFFBF, add as needed
 };
-
-pub const MAX_COMPONENTS = 3;
-pub const MAX_BLOCKS = 8;
-pub const Block = [64]i32;


### PR DESCRIPTION
JPEGs always are arrays that are multiples of 8x8, for subsampled images, they're also a multiple of the MCU block size, and included in some operations. As such we need to 0 out the non-filled pixels (that is the scan ends before filling the remainder of the frame with 0s.