### PR TITLE
jpeg: remove extern llvm instrinsic

### DIFF
--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const simd = @import("../../simd.zig");
-extern fn @"llvm.x86.avx2.permd"(v: @Vector(8, i32), mask: @Vector(8, i32)) @Vector(8, i32);
 
 const buffered_stream_source = @import("../../buffered_stream_source.zig");
 const Image = @import("../../Image.zig");


### PR DESCRIPTION
Accidentally left this in, switched to using inline asm instead.