### PR TITLE
fix: Update to Zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "zigimg",
+    .name = .zigimg,
     .version = "0.1.0",
+    .fingerprint = 0x6d2b443c3bbe5c96,
     .paths = .{""},
 }

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -652,7 +652,7 @@ pub const ReaderProcessor = struct {
         const ptr_info = @typeInfo(Ptr);
 
         std.debug.assert(ptr_info == .pointer); // Must be a pointer
-        std.debug.assert(ptr_info.pointer.size == .One); // Must be a single-item pointer
+        std.debug.assert(ptr_info.pointer.size == .one); // Must be a single-item pointer
 
         const gen = struct {
             fn chunkProcessor(ptr: *anyopaque, data: *ChunkProcessData) ImageUnmanaged.ReadError!PixelFormat {
@@ -773,7 +773,7 @@ pub const TrnsProcessor = struct {
         };
         var pixel_pos: u32 = 0;
         // work around broken saturating arithmetic on wasm https://github.com/llvm/llvm-project/issues/58557
-        const isWasm = comptime @import("builtin").target.isWasm();
+        const isWasm = comptime @import("builtin").target.cpu.arch.isWasm();
         switch (self.trns_data) {
             .gray => |gray_alpha| {
                 switch (data.src_format) {
@@ -983,7 +983,7 @@ pub fn CustomReaderOptions2(Processor1: type, Processor2: type) type {
 
 const root = @import("root");
 
-pub const NoopAllocator = Allocator.VTable{ .alloc = undefined, .free = undefined, .resize = undefined };
+pub const NoopAllocator = Allocator.VTable{ .alloc = undefined, .free = undefined, .resize = undefined, .remap = undefined };
 
 /// Applications can override this by defining DefaultPngOptions struct in their root source file.
 /// We would like to use FixedBufferAllocator with memory from stack here since we should be able


### PR DESCRIPTION
0.14.0 should be releasing this Monday, and I needed zigimg for a thing, so I just patched it up so it should work with the new release. As far as I can tell, all tests still pass.

Submitting it as a draft, because I know the project tracks Mach's nominated version, but this would still be useful for anyone tracking official releases, I feel.

edit: I'll be regularly rebasing, which results in orphaned commits if you track this branch. If you're a downstream user wanting to use zigimg with Zig 0.14.0, you should track my [0.14.0 branch](https://github.com/TUSF/zigimg/tree/0.14.0).