### PR TITLE
ilbm: rename to ilbm to iff

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ zig build test
 | Farbfeld      | ✔️            | ✔️            |
 | GIF           | ✔️            | ❌            |
 | ICO           | ❌            | ❌            |
-| ILBM          | ✔️             | ❌            |
+| IFF           | ✔️             | ❌            |
 | JPEG          | ❌            | ❌            |
 | PAM           | ✔️            | ✔️            |
 | PBM           | ✔️            | ✔️            |
@@ -99,11 +99,12 @@ zig build test
 * Supports tiled and layered images used to achieve pseudo true color and more.
 * The plain text extension is not supported
 
-### ILBM - InterLeaved BitMap Format
+### IFF - InterchangeFileFormat
 
- * Supports 1-8 bit, 24 bit, HAM6/8, EHB files
- * Supports uncompressed, byterun 1 & 2 (Atari) compressed files
+ * Supports 1-8 bit, 24 bit, HAM6/8, EHB ILBM files
+ * Supports uncompressed, byterun 1 & 2 (Atari) compressed ILBM files
  * Supports PBM (Deluxe Paint DOS) encoded files
+ * Supports ACBM (Amiga Basic) files
  * Color cycle chunks are ignored
  * Mask is not supported (skipped)
 

--- a/src/ImageUnmanaged.zig
+++ b/src/ImageUnmanaged.zig
@@ -11,7 +11,7 @@ const SupportedFormats = struct {
     pub const bmp = formats.bmp.BMP;
     pub const farbfeld = formats.farbfeld.Farbfeld;
     pub const gif = formats.gif.GIF;
-    pub const ilbm = formats.ilbm.ILBM;
+    pub const iff = formats.iff.IFF;
     pub const jpeg = formats.jpeg.JPEG;
     pub const pam = formats.pam.PAM;
     pub const pbm = formats.netpbm.PBM;
@@ -29,7 +29,7 @@ pub const EncoderOptions = union(Format) {
     bmp: SupportedFormats.bmp.EncoderOptions,
     farbfeld: void,
     gif: void,
-    ilbm: void,
+    iff: void,
     jpeg: void,
     pam: SupportedFormats.pam.EncoderOptions,
     pbm: SupportedFormats.pbm.EncoderOptions,

--- a/src/formats.zig
+++ b/src/formats.zig
@@ -1,7 +1,7 @@
 pub const bmp = @import("formats/bmp.zig");
 pub const farbfeld = @import("formats/farbfeld.zig");
 pub const gif = @import("formats/gif.zig");
-pub const ilbm = @import("formats/ilbm.zig");
+pub const iff = @import("formats/iff.zig");
 pub const jpeg = @import("formats/jpeg.zig");
 pub const pam = @import("formats/pam.zig");
 pub const netpbm = @import("formats/netpbm.zig");

--- a/tests/formats/iff_test.zig
+++ b/tests/formats/iff_test.zig
@@ -1,6 +1,6 @@
 const PixelFormat = @import("../../src/pixel_format.zig").PixelFormat;
 const assert = std.debug.assert;
-const ilbm = @import("../../src/formats/ilbm.zig");
+const iff = @import("../../src/formats/iff.zig");
 const color = @import("../../src/color.zig");
 const ImageReadError = Image.ReadError;
 const std = @import("std");
@@ -8,11 +8,11 @@ const testing = std.testing;
 const Image = @import("../../src/Image.zig");
 const helpers = @import("../helpers.zig");
 
-test "ILBM indexed8 PBM (chunky Deluxe Paint DOS file)" {
+test "IFF-PBM indexed8 (chunky Deluxe Paint DOS file)" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-pbm.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -39,11 +39,11 @@ test "ILBM indexed8 PBM (chunky Deluxe Paint DOS file)" {
     try helpers.expectEq(palette58.b, 148);
 }
 
-test "ILBM indexed8 8 bitplanes" {
+test "IFF-ILBM indexed8 8 bitplanes" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ilbm-8bit-compressed.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -64,11 +64,11 @@ test "ILBM indexed8 8 bitplanes" {
     try helpers.expectEq(pixels.indexed8.indices[25975], 2);
 }
 
-test "ILBM indexed8 8 bitplanes uncompressed" {
+test "IFF-ILBM indexed8 8 bitplanes uncompressed" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ilbm-8bit-uncompressed.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -89,11 +89,11 @@ test "ILBM indexed8 8 bitplanes uncompressed" {
     try helpers.expectEq(pixels.indexed8.indices[25975], 2);
 }
 
-test "ILBM indexed8 6 bitplanes EHB" {
+test "IFF-ILBM indexed8 6 bitplanes EHB" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ehb.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -120,11 +120,11 @@ test "ILBM indexed8 6 bitplanes EHB" {
     try helpers.expectEq(pixels.indexed8.indices[25975], 61);
 }
 
-test "ILBM indexed8 4 bitplanes HAM" {
+test "IFF-ILBM indexed8 4 bitplanes HAM" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ham.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -148,11 +148,11 @@ test "ILBM indexed8 4 bitplanes HAM" {
     }
 }
 
-test "ILBM indexed8 6 bitplanes HAM8" {
+test "IFF-ILBM indexed8 6 bitplanes HAM8" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ham8.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -176,11 +176,11 @@ test "ILBM indexed8 6 bitplanes HAM8" {
     }
 }
 
-test "ILBM 24bit" {
+test "IFF-ILBM 24bit" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-24bit.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -204,11 +204,11 @@ test "ILBM 24bit" {
     }
 }
 
-test "ILBM indexed8 4 bitplanes Atari ST" {
+test "IFF-ILBM indexed8 4 bitplanes Atari ST" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-ilbm-4bit-compressed-atari.iff");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 
@@ -235,11 +235,11 @@ test "ILBM indexed8 4 bitplanes Atari ST" {
     try helpers.expectEq(pixels.indexed8.indices[31_207], 6);
 }
 
-test "ACBM indexed8 3 bitplanes uncompressed" {
+test "IFF-ACBM indexed8 3 bitplanes uncompressed" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "ilbm/sample-8bit.acbm");
     defer file.close();
 
-    var the_bitmap = ilbm.ILBM{};
+    var the_bitmap = iff.IFF{};
 
     var stream_source = std.io.StreamSource{ .file = file };
 

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -373,7 +373,7 @@ test "Should detect IFF/PBM properly" {
 
     for (image_tests) |image_path| {
         const format = try ImageUnmanaged.detectFormatFromFilePath(image_path);
-        try std.testing.expect(format == .ilbm);
+        try std.testing.expect(format == .iff);
 
         var test_image = try helpers.testImageFromFile(image_path);
         defer test_image.deinit();

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -19,7 +19,7 @@ test {
         @import("tests/color_test.zig"),
         @import("tests/formats/bmp_test.zig"),
         @import("tests/formats/gif_test.zig"),
-        @import("tests/formats/ilbm_test.zig"),
+        @import("tests/formats/iff_test.zig"),
         @import("tests/formats/jpeg_test.zig"),
         @import("tests/formats/netpbm_test.zig"),
         @import("tests/formats/pam_test.zig"),


### PR DESCRIPTION
Since we're already supporting ACBM in addition to ILBM IFF forms, and DEEP is also coming, let's rename ILBM to IFF.