### PR TITLE
indexed PNG: use pixel format defined by header

### DIFF
--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -845,24 +845,8 @@ pub const PlteProcessor = struct {
 
     pub fn processChunk(self: *Self, data: *ChunkProcessData) ImageUnmanaged.ReadError!PixelFormat {
         // This is critical chunk so it is already read and there is no need to read it here
-        var result_format = data.current_format;
-        if (self.processed or !result_format.isIndexed()) {
-            self.processed = true;
-            return result_format;
-        }
-
-        const palette_size = data.chunk_length / 3;
-        if (palette_size <= 2) {
-            return .indexed1;
-        } else if (palette_size <= 4) {
-            return .indexed2;
-        } else if (palette_size <= 16) {
-            return .indexed4;
-        } else if (palette_size <= 256) {
-            return .indexed8;
-        } else {
-            return .indexed16;
-        }
+        _ = self;
+        return data.current_format;
     }
 
     pub fn processPalette(self: *Self, data: *PaletteProcessData) ImageUnmanaged.ReadError!void {


### PR DESCRIPTION
Trying to load the following PNG results in an `InvalidData` error:

![solitaire-cards](https://github.com/user-attachments/assets/2a55e6f6-ee87-45f6-86b3-3dc18f8b2edd)

Stack trace from project where I was using it:

```
InvalidData
/home/geemili/.cache/zig/p/zigimg-0.1.0-lly-O4heEADSRxoTwJwrD3TBfUob9052sIgb9SL8Iz-A/src/formats/png/reader.zig:372:47: 0x147fd41 in readAllData (seizer-solitaire)
            if (result_format != dest_format) return ImageUnmanaged.ReadError.InvalidData;
                                              ^
/home/geemili/.cache/zig/p/zigimg-0.1.0-lly-O4heEADSRxoTwJwrD3TBfUob9052sIgb9SL8Iz-A/src/formats/png/reader.zig:242:26: 0x13a6354 in loadWithHeader (seizer-solitaire)
                result = try readAllData(&buffered_stream, header, palette, allocator, &options, &chunk_process_data);
                         ^
/home/geemili/.cache/zig/p/zigimg-0.1.0-lly-O4heEADSRxoTwJwrD3TBfUob9052sIgb9SL8Iz-A/src/formats/png/reader.zig:182:21: 0x1330a5e in load (seizer-solitaire)
    result.pixels = try loadWithHeader(stream, &header, allocator, options);
                    ^
/home/geemili/.cache/zig/p/zigimg-0.1.0-lly-O4heEADSRxoTwJwrD3TBfUob9052sIgb9SL8Iz-A/src/formats/png.zig:67:9: 0x12d2880 in readImage (seizer-solitaire)
        return load(stream, allocator, default_options.get());
        ^
/home/geemili/.cache/zig/p/zigimg-0.1.0-lly-O4heEADSRxoTwJwrD3TBfUob9052sIgb9SL8Iz-A/src/ImageUnmanaged.zig:330:12: 0x12cf2ba in internalRead (seizer-solitaire)
    return try format_interface.readImage(allocator, stream);
           ^
/home/geemili/.cache/zig/p/zigimg-0.1.0-lly-O4heEADSRxoTwJwrD3TBfUob9052sIgb9SL8Iz-A/src/ImageUnmanaged.zig:173:5: 0x12cf430 in fromMemory (seizer-solitaire)
    return internalRead(allocator, &stream_source);
    ^
/home/geemili/.cache/zig/p/zigimg-0.1.0-lly-O4heEADSRxoTwJwrD3TBfUob9052sIgb9SL8Iz-A/src/Image.zig:74:13: 0x12cf4f6 in fromMemory (seizer-solitaire)
    return (try ImageUnmanaged.fromMemory(allocator, buffer)).toManaged(allocator);
            ^
/home/geemili/.cache/zig/p/seizer-0.4.0-Px_Ng-EtHgAvPJTKfoAT6DCE3ffbDIpthxAZ6CENZUcN/src/image/linear.zig:22:23: 0x12cf68c in fromMemory (seizer-solitaire)
            var img = try zigimg.Image.fromMemory(allocator, file_contents);
                      ^
/home/geemili/code/seizer-solitaire/src/assets.zig:18:25: 0x12d0c91 in init (seizer-solitaire)
        const texture = try seizer.image.Linear(seizer.color.argbf32_premultiplied).fromMemory(
                        ^
/home/geemili/code/seizer-solitaire/src/assets.zig:275:21: 0x12d0dec in loadSolitaireCards (seizer-solitaire)
    var tilesheet = try TileSheet.init(.{
                    ^
/home/geemili/code/seizer-solitaire/src/main.zig:117:20: 0x12dad75 in init (seizer-solitaire)
    card_tilemap = try assets.loadSolitaireCards(gpa.allocator());
                   ^
```

The core of the issue is that the PNG encoder (aseprite's, in this case) does not use the smallest possible bit depth for the image. If you inspect the headers, you can see that the bit depth is `8`, while the palette only contains 5 colors.

```
magic 89504e470d0a1a0a
IHDR (13 bytes, flags = critical, public, 0, unsafe_to_copy)
    width = 448
    height = 160
    bit depth = 8
    color type = root.Chunk.IHDR.ColorType.indexed
    compression method = root.Chunk.IHDR.CompressionMethod.deflate
    filter method = root.Chunk.IHDR.FilterMethod.adaptive
    interlace method = root.Chunk.IHDR.InterlaceMethod.none
crc ac784caf

sRGB (1 bytes, flags = ancillary, public, 0, unsafe_to_copy)
crc aece1ce9

PLTE (15 bytes, flags = critical, public, 0, unsafe_to_copy)
    entry[0] = .{ .red = 0x00, .green = 0x00, .blue = 0x00 }
    entry[1] = .{ .red = 0xcb, .green = 0xdb, .blue = 0xfc }
    entry[2] = .{ .red = 0xff, .green = 0xff, .blue = 0xff }
    entry[3] = .{ .red = 0xd9, .green = 0x57, .blue = 0x63 }
    entry[4] = .{ .red = 0x00, .green = 0x00, .blue = 0x00 }
crc 2395de37

tRNS (5 bytes, flags = ancillary, public, 0, unsafe_to_copy)
    entry[0] = .{ .alpha = 0x00 }
    entry[1] = .{ .alpha = 0xff }
    entry[2] = .{ .alpha = 0xff }
    entry[3] = .{ .alpha = 0xff }
    entry[4] = .{ .alpha = 0xff }
    All indices greater than 4 in palette are opaque (alpha = 255)
crc 1cd02652

IDAT (2387 bytes, flags = critical, public, 0, unsafe_to_copy)
crc 6305a77c

IEND (0 bytes, flags = critical, public, 0, unsafe_to_copy)
crc ae426082
```

That interacts badly with the code introduced in 4c7da3a01f780040547831e224b7a3e0ce5e20c2, which always chooses the minimum required bit depth for the palette:

https://github.com/zigimg/zigimg/blob/4c7da3a01f780040547831e224b7a3e0ce5e20c2/src/formats/png/reader.zig#L845-L856

This patch removes format selection from `processChunk`, and makes it always return the current format. I'm not sure if this is how the problem should be solved, but it does make zigimg work for this file.