### PR TITLE
.ICO and .CUR format support

### DIFF
--- a/src/ImageUnmanaged.zig
+++ b/src/ImageUnmanaged.zig
@@ -11,6 +11,7 @@ const SupportedFormats = struct {
     pub const bmp = formats.bmp.BMP;
     pub const farbfeld = formats.farbfeld.Farbfeld;
     pub const gif = formats.gif.GIF;
+    pub const ico = formats.ico.ICO;
     pub const iff = formats.iff.IFF;
     pub const jpeg = formats.jpeg.JPEG;
     pub const pam = formats.pam.PAM;
@@ -29,6 +30,7 @@ pub const EncoderOptions = union(Format) {
     bmp: SupportedFormats.bmp.EncoderOptions,
     farbfeld: void,
     gif: void,
+    ico: void,
     iff: void,
     jpeg: void,
     pam: SupportedFormats.pam.EncoderOptions,

--- a/src/formats.zig
+++ b/src/formats.zig
@@ -1,6 +1,7 @@
 pub const bmp = @import("formats/bmp.zig");
 pub const farbfeld = @import("formats/farbfeld.zig");
 pub const gif = @import("formats/gif.zig");
+pub const ico = @import("formats/ico.zig");
 pub const iff = @import("formats/iff.zig");
 pub const jpeg = @import("formats/jpeg.zig");
 pub const pam = @import("formats/pam.zig");

--- a/src/formats/bmp.zig
+++ b/src/formats/bmp.zig
@@ -281,6 +281,15 @@ pub const BMP = struct {
             return ImageUnmanaged.ReadError.InvalidData;
         }
 
+        try stream.seekTo(try buffered_stream.getPos());
+
+        return readInfoHeader(self, allocator, stream);
+    }
+
+    pub fn readInfoHeader(self: *BMP, allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ImageUnmanaged.ReadError!color.PixelStorage {
+        var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
+        const reader = buffered_stream.reader();
+
         const header_size = try reader.readInt(u32, .little);
         try buffered_stream.seekBy(-@sizeOf(u32));
 
@@ -296,6 +305,7 @@ pub const BMP = struct {
 
         // Read pixel data
         _ = switch (self.info_header) {
+            .windows31 => |win31Header| {},
             .v4 => |v4Header| {
                 const pixel_width = v4Header.width;
                 const pixel_height = v4Header.height;

--- a/src/formats/ico.zig
+++ b/src/formats/ico.zig
@@ -1,0 +1,162 @@
+const std = @import("std");
+
+const ImageUnmanaged = @import("../ImageUnmanaged.zig");
+const FormatInterface = @import("../FormatInterface.zig");
+const buffered_stream_source = @import("../buffered_stream_source.zig");
+const color = @import("../color.zig");
+
+const PNG = @import("./png.zig").PNG;
+const BMP = @import("./bmp.zig").BMP;
+
+const pngReader = @import("./png/reader.zig");
+
+pub const Kind = enum(u16) {
+    icon = 1, // .ico
+    cursor = 2, // .cur
+};
+
+pub const ColorPlanes = u1; // '0' or '1' are only valid options
+
+pub const IconDirEntry = struct {
+    image_width: u8, // '0' means 256
+    image_height: u8, // '0' means 256
+    color_palette_size: u8,
+    color_planes: ColorPlanes, // in .ICO format
+    bits_per_pixel: u16, // in .ICO format
+    hotspot_x: u16, // in .CUR format
+    hotspot_y: u16, // in .CUR format
+    image_data_size: u32,
+    data_offset: u32,
+};
+
+pub const IconDir = struct {
+    kind: Kind,
+    entries: []IconDirEntry,
+};
+
+pub const ICO = struct {
+    dir: IconDir = undefined,
+
+    pub fn formatInterface() FormatInterface {
+        return FormatInterface{
+            .formatDetect = formatDetect,
+            .readImage = readImage,
+            .writeImage = writeImage,
+        };
+    }
+
+    pub fn formatDetect(stream: *ImageUnmanaged.Stream) ImageUnmanaged.ReadError!bool {
+        var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
+
+        const reserved = try buffered_stream.reader().readInt(u16, .little);
+        if (reserved != 0) return false;
+
+        const image_kind_int = try buffered_stream.reader().readInt(u16, .little);
+        _ = std.meta.intToEnum(Kind, image_kind_int) catch return false;
+
+        // todo: more checks
+        return true;
+    }
+
+    pub fn readImage(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ImageUnmanaged.ReadError!ImageUnmanaged {
+        var result = ImageUnmanaged{};
+        errdefer result.deinit(allocator);
+
+        var ico = ICO{};
+
+        const pixels = try ico.read(allocator, stream);
+
+        result.width = ico.width();
+        result.height = ico.height();
+        result.pixels = pixels;
+
+        return result;
+    }
+
+    pub fn width(self: ICO) usize {
+        // todo: support more frames
+        return @intCast(self.dir.entries[0].image_width);
+    }
+
+    pub fn height(self: ICO) usize {
+        // todo: support more frames
+        return @intCast(self.dir.entries[0].image_height);
+    }
+
+    pub fn read(self: *ICO, allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) !color.PixelStorage {
+        var buffered_stream = buffered_stream_source.bufferedStreamSourceReader(stream);
+        const reader = buffered_stream.reader();
+
+        const reserved = try reader.readInt(u16, .little);
+        if (reserved != 0) return ImageUnmanaged.ReadError.InvalidData;
+
+        const image_kind_int = try reader.readInt(u16, .little);
+        self.dir.kind = std.meta.intToEnum(Kind, image_kind_int) catch return ImageUnmanaged.ReadError.InvalidData;
+
+        const num_images = try reader.readInt(u16, .little);
+        // todo: support more frames
+        if (num_images != 1) return ImageUnmanaged.ReadError.Unsupported;
+
+        var entries_list = try std.ArrayListUnmanaged(IconDirEntry).initCapacity(allocator, num_images);
+        errdefer entries_list.deinit(allocator);
+
+        for (0..num_images) |_| {
+            var entry: IconDirEntry = undefined;
+
+            entry.image_width = try reader.readInt(u8, .little);
+            entry.image_height = try reader.readInt(u8, .little);
+
+            entry.color_palette_size = try reader.readInt(u8, .little);
+            const reserved2 = try reader.readInt(u8, .little);
+            if (reserved2 != 0) return ImageUnmanaged.ReadError.InvalidData;
+
+            switch (self.dir.kind) {
+                .icon => {
+                    const color_planes_int = try reader.readInt(u16, .little);
+                    if (color_planes_int != 0 and color_planes_int != 1) return ImageUnmanaged.ReadError.InvalidData;
+                    entry.color_planes = @intCast(color_planes_int);
+                    entry.bits_per_pixel = try reader.readInt(u16, .little);
+                    entry.hotspot_x = 0;
+                    entry.hotspot_y = 0;
+                },
+                .cursor => {
+                    entry.hotspot_x = try reader.readInt(u16, .little);
+                    entry.hotspot_y = try reader.readInt(u16, .little);
+                    entry.color_planes = 0;
+                    entry.bits_per_pixel = 0;
+                },
+            }
+
+            entry.image_data_size = try reader.readInt(u32, .little);
+            entry.data_offset = try reader.readInt(u32, .little);
+
+            entries_list.appendAssumeCapacity(entry);
+        }
+
+        self.dir.entries = try entries_list.toOwnedSlice(allocator);
+        errdefer allocator.free(self.dir.entries);
+        const only_entry = self.dir.entries[0]; // todo: support more frames
+
+        try stream.seekTo(only_entry.data_offset);
+        const is_png = try PNG.formatDetect(stream);
+        try stream.seekTo(only_entry.data_offset);
+
+        if (is_png) {
+            var options = pngReader.DefaultOptions.init(.{});
+            const png_header = try pngReader.loadHeader(stream);
+            const png_pixels = try pngReader.loadWithHeader(stream, &png_header, allocator, options.get());
+
+            return png_pixels;
+        }
+
+        var bmp: BMP = .{};
+        return try bmp.readInfoHeader(allocator, stream);
+    }
+
+    pub fn writeImage(allocator: std.mem.Allocator, write_stream: *ImageUnmanaged.Stream, image: ImageUnmanaged, encoder_options: ImageUnmanaged.EncoderOptions) ImageUnmanaged.WriteError!void {
+        _ = allocator;
+        _ = write_stream;
+        _ = image;
+        _ = encoder_options;
+    }
+};

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -652,7 +652,7 @@ pub const ReaderProcessor = struct {
         const ptr_info = @typeInfo(Ptr);
 
         std.debug.assert(ptr_info == .pointer); // Must be a pointer
-        std.debug.assert(ptr_info.pointer.size == .One); // Must be a single-item pointer
+        std.debug.assert(ptr_info.pointer.size == .one); // Must be a single-item pointer
 
         const gen = struct {
             fn chunkProcessor(ptr: *anyopaque, data: *ChunkProcessData) ImageUnmanaged.ReadError!PixelFormat {
@@ -768,7 +768,7 @@ pub const TrnsProcessor = struct {
         };
         var pixel_pos: u32 = 0;
         // work around broken saturating arithmetic on wasm https://github.com/llvm/llvm-project/issues/58557
-        const isWasm = comptime @import("builtin").target.isWasm();
+        const isWasm = comptime @import("builtin").target.cpu.arch.isWasm();
         switch (self.trns_data) {
             .gray => |gray_alpha| {
                 switch (data.src_format) {
@@ -978,7 +978,7 @@ pub fn CustomReaderOptions2(Processor1: type, Processor2: type) type {
 
 const root = @import("root");
 
-pub const NoopAllocator = Allocator.VTable{ .alloc = undefined, .free = undefined, .resize = undefined };
+pub const NoopAllocator = Allocator.VTable{ .alloc = undefined, .free = undefined, .resize = undefined, .remap = undefined };
 
 /// Applications can override this by defining DefaultPngOptions struct in their root source file.
 /// We would like to use FixedBufferAllocator with memory from stack here since we should be able


### PR DESCRIPTION
This is still early days, but I thought a PR would help to track this, and since I may need some help.

#### Blockage 1
The main blockage is that .ICO and .CUR files have entries with different sizes. Normally multiple images would be fine (see .gif files), however currently there's no support in zigimg for entries of various sizes. To get around this temporarily, I've just made any files without exactly 1 entry unsupported.

I am not sure whether different entry sizes is something maintainers of zigimg want or not, but it may be the case that .ICO and .CUR files are "out of scope" and should instead store multiple ImageUnmanaged.

#### Blockage 2
The second blockage is that the .BMP file format support has no support for the windows bitmap header:
https://github.com/zigimg/zigimg/blob/b0a046be99bbe67b8a1611aff39d1dcbec89f6f9/src/formats/bmp.zig#L58
https://github.com/zigimg/zigimg/blob/b0a046be99bbe67b8a1611aff39d1dcbec89f6f9/src/formats/bmp.zig#L129
https://github.com/zigimg/zigimg/blob/b0a046be99bbe67b8a1611aff39d1dcbec89f6f9/src/formats/bmp.zig#L289

Presumably .ICO and .CUR files support other header formats for BMP, but since they're windows formats I still consider this to be a blockage.

This is a lot easier to fix than blockage 1, and I will probably just add it to this PR.

#### Notes
I've updated to Zig 0.14.0 because the Mach Nominated Zig version `2024.11.0-mach` is no longer registered for `zigup` to download. I don't suppose this PR will be finished before the next nominated version, so I don't think this is a problem. (I'll continue to work on 0.14.0)
```
PS D:\Projects\zigimg> zigup 0.14.0-dev.2577+271452d22
install directory 'C:\Users\aquila\.zigup\zigup-v2025_01_02\zig'
mkdir "C:\Users\aquila\.zigup\zigup-v2025_01_02\zig"
rd /s /q "C:\Users\aquila\.zigup\zigup-v2025_01_02\zig\0.14.0-dev.2577+271452d22.installing"
mkdir "C:\Users\aquila\.zigup\zigup-v2025_01_02\zig\0.14.0-dev.2577+271452d22.installing"
downloading 'https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.2577+271452d22.zip' to 'C:\Users\aquila\.zigup\zigup-v2025_01_02\zig\0.14.0-dev.2577+271452d22.installing\zig-windows-x86_64-0.14.0-dev.2577+271452d22.zip'
error: download 'https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.2577+271452d22.zip' failed: HTTP server replied with unsuccessful response '404 Not Found'
rd /s /q "C:\Users\aquila\.zigup\zigup-v2025_01_02\zig\0.14.0-dev.2577+271452d22.installing"
```

