### PR TITLE
PNG: Write all supported pixel formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ zig build test
 | Farbfeld      | ✔️            | ✔️            |
 | GIF           | ✔️            | ❌            |
 | ICO           | ❌            | ❌            |
-| IFF           | ✔️             | ❌            |
+| IFF           | ✔️            | ❌            |
 | JPEG          | ✔️ (Partial)  | ❌            |
 | PAM           | ✔️            | ✔️            |
 | PBM           | ✔️            | ✔️            |
@@ -143,7 +143,7 @@ Currently, this only supports a subset of PAMs where:
 
 * Support all pixel formats supported by PNG (grayscale, grayscale+alpha, indexed, truecolor, truecolor with alpha) in 8-bit or 16-bit.
 * Support the mininal chunks in order to decode the image.
-* Not all images in Png Test Suite is covered but should be good enough for now.
+* Can write all supported pixel formats but writing interlaced images is not supported yet.
 
 ### PPM - Portable Pixmap format
 

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -116,9 +116,23 @@ pub const PNG = struct {
             return error.Unsupported;
 
         switch (image.pixels) {
-            .rgb24, .rgb48, .rgba32, .rgba64, .grayscale8, .grayscale16, .grayscale8Alpha, .grayscale16Alpha, .indexed4, .indexed8 => {},
-
-            .grayscale1, .grayscale2, .grayscale4, .indexed1, .indexed2 => return error.Unsupported, // TODO
+            .indexed4,
+            .indexed8,
+            .grayscale4,
+            .grayscale8,
+            .grayscale16,
+            .grayscale8Alpha,
+            .grayscale16Alpha,
+            .rgb24,
+            .rgb48,
+            .rgba32,
+            .rgba64,
+            => {},
+            .grayscale1,
+            .grayscale2,
+            .indexed1,
+            .indexed2,
+            => return error.Unsupported, // TODO
 
             // Should bgr be supported with swapping operations during the filtering?
 

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -1,7 +1,6 @@
 // Implement PNG image format according to W3C Portable Network Graphics (PNG) specification second edition (ISO/IEC 15948:2003 (E))
 // Last version: https://www.w3.org/TR/PNG/
 
-const Allocator = std.mem.Allocator;
 const chunk_writer = @import("png/chunk_writer.zig");
 const color = @import("../color.zig");
 const filter = @import("png/filtering.zig");
@@ -63,12 +62,12 @@ pub const PNG = struct {
         return std.mem.eql(u8, magic_buffer[0..], types.magic_header[0..]);
     }
 
-    pub fn readImage(allocator: Allocator, stream: *ImageUnmanaged.Stream) ImageReadError!ImageUnmanaged {
+    pub fn readImage(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ImageReadError!ImageUnmanaged {
         var options = DefaultOptions.init(.{});
         return load(stream, allocator, options.get());
     }
 
-    pub fn writeImage(_: Allocator, write_stream: *ImageUnmanaged.Stream, image: ImageUnmanaged, encoder_options: ImageUnmanaged.EncoderOptions) ImageWriteError!void {
+    pub fn writeImage(allocator: std.mem.Allocator, write_stream: *ImageUnmanaged.Stream, image: ImageUnmanaged, encoder_options: ImageUnmanaged.EncoderOptions) ImageWriteError!void {
         const options = encoder_options.png;
 
         try ensureWritable(image);
@@ -85,10 +84,10 @@ pub const PNG = struct {
 
         std.debug.assert(header.isValid());
 
-        try write(write_stream, image.pixels, header, options.filter_choice);
+        try write(allocator, write_stream, image.pixels, header, options.filter_choice);
     }
 
-    pub fn write(write_stream: *ImageUnmanaged.Stream, pixels: color.PixelStorage, header: HeaderData, filter_choice: filter.FilterChoice) ImageWriteError!void {
+    pub fn write(allocator: std.mem.Allocator, write_stream: *ImageUnmanaged.Stream, pixels: color.PixelStorage, header: HeaderData, filter_choice: filter.FilterChoice) ImageWriteError!void {
         // TODO: Use buffered writer
         if (header.interlace_method != .none)
             return ImageWriteError.Unsupported;
@@ -106,7 +105,7 @@ pub const PNG = struct {
         }
         // Write tRNS chunk if the pixel format can support it
         try writeTransparencyInfo(writer, pixels);
-        try writeData(writer, pixels, header, filter_choice);
+        try writeData(allocator, writer, pixels, header, filter_choice);
         try writeTrailer(writer);
     }
 
@@ -117,9 +116,9 @@ pub const PNG = struct {
             return error.Unsupported;
 
         switch (image.pixels) {
-            .rgb24, .rgb48, .rgba32, .rgba64, .grayscale8, .grayscale16, .grayscale8Alpha, .grayscale16Alpha, .indexed8 => {},
+            .rgb24, .rgb48, .rgba32, .rgba64, .grayscale8, .grayscale16, .grayscale8Alpha, .grayscale16Alpha, .indexed4, .indexed8 => {},
 
-            .grayscale1, .grayscale2, .grayscale4, .indexed1, .indexed2, .indexed4 => return error.Unsupported, // TODO
+            .grayscale1, .grayscale2, .grayscale4, .indexed1, .indexed2 => return error.Unsupported, // TODO
 
             // Should bgr be supported with swapping operations during the filtering?
 
@@ -148,7 +147,7 @@ pub const PNG = struct {
     }
 
     // IDAT (multiple maybe)
-    fn writeData(writer: anytype, pixels: color.PixelStorage, header: HeaderData, filter_choice: filter.FilterChoice) ImageWriteError!void {
+    fn writeData(allocator: std.mem.Allocator, writer: anytype, pixels: color.PixelStorage, header: HeaderData, filter_choice: filter.FilterChoice) ImageWriteError!void {
         // Note: there may be more than 1 chunk
         // TODO: provide choice of how much it buffers (how much data per idat chunk)
         var chunks = chunk_writer.chunkWriter(writer, "IDAT");
@@ -158,7 +157,7 @@ pub const PNG = struct {
         try zlib.init(chunk_wr);
 
         try zlib.begin();
-        try filter.filter(zlib.writer(), pixels, filter_choice, header);
+        try filter.filter(allocator, zlib.writer(), pixels, filter_choice, header);
         try zlib.end();
 
         try chunks.flush();

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -116,8 +116,10 @@ pub const PNG = struct {
             return error.Unsupported;
 
         switch (image.pixels) {
+            .indexed2,
             .indexed4,
             .indexed8,
+            .grayscale2,
             .grayscale4,
             .grayscale8,
             .grayscale16,
@@ -129,9 +131,8 @@ pub const PNG = struct {
             .rgba64,
             => {},
             .grayscale1,
-            .grayscale2,
+
             .indexed1,
-            .indexed2,
             => return error.Unsupported, // TODO
 
             // Should bgr be supported with swapping operations during the filtering?

--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -116,9 +116,11 @@ pub const PNG = struct {
             return error.Unsupported;
 
         switch (image.pixels) {
+            .indexed1,
             .indexed2,
             .indexed4,
             .indexed8,
+            .grayscale1,
             .grayscale2,
             .grayscale4,
             .grayscale8,
@@ -130,13 +132,7 @@ pub const PNG = struct {
             .rgba32,
             .rgba64,
             => {},
-            .grayscale1,
-
-            .indexed1,
-            => return error.Unsupported, // TODO
-
-            // Should bgr be supported with swapping operations during the filtering?
-
+            // TODO: Support other formats when the write options ask for conversion.
             else => return error.Unsupported,
         }
     }

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -82,7 +82,7 @@ fn fillScanline(pixels: color.PixelStorage, scanline_bytes: []u8, y: usize, widt
     const pixel_format: PixelFormat = std.meta.activeTag(pixels);
     const bit_depth = pixel_format.bitsPerChannel();
     switch (bit_depth) {
-        4 => {
+        2, 4 => {
             const source_row_bytes = pixels_scanline.asConstBytes();
 
             @memset(scanline_bytes, 0);
@@ -99,6 +99,9 @@ fn fillScanline(pixels: color.PixelStorage, scanline_bytes: []u8, y: usize, widt
                 shift -= bit_depth_reduced;
                 if (shift < 0) {
                     destination_index += 1;
+                    if (destination_index >= scanline_bytes.len) {
+                        break;
+                    }
                     shift = @intCast(8 - bit_depth);
                 }
             }

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -82,6 +82,27 @@ fn fillScanline(pixels: color.PixelStorage, scanline_bytes: []u8, y: usize, widt
     const pixel_format: PixelFormat = std.meta.activeTag(pixels);
     const bit_depth = pixel_format.bitsPerChannel();
     switch (bit_depth) {
+        4 => {
+            const source_row_bytes = pixels_scanline.asConstBytes();
+
+            @memset(scanline_bytes, 0);
+
+            var destination_index: usize = 0;
+
+            const bit_depth_reduced: u3 = @intCast(bit_depth);
+
+            var shift: i8 = @intCast(8 - bit_depth);
+            const mask: u8 = (@as(u8, 1) << bit_depth_reduced) - 1;
+
+            for (source_row_bytes) |source_byte| {
+                scanline_bytes[destination_index] |= (source_byte & mask) << @as(u3, @intCast(shift));
+                shift -= bit_depth_reduced;
+                if (shift < 0) {
+                    destination_index += 1;
+                    shift = @intCast(8 - bit_depth);
+                }
+            }
+        },
         8 => {
             const source_row_bytes = pixels_scanline.asConstBytes();
 

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -82,7 +82,7 @@ fn fillScanline(pixels: color.PixelStorage, scanline_bytes: []u8, y: usize, widt
     const pixel_format: PixelFormat = std.meta.activeTag(pixels);
     const bit_depth = pixel_format.bitsPerChannel();
     switch (bit_depth) {
-        2, 4 => {
+        1, 2, 4 => {
             const source_row_bytes = pixels_scanline.asConstBytes();
 
             @memset(scanline_bytes, 0);

--- a/src/formats/png/filtering.zig
+++ b/src/formats/png/filtering.zig
@@ -25,36 +25,42 @@ pub const FilterChoice = union(FilterChoiceStrategies) {
     specified: FilterType,
 };
 
-pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: FilterChoice, header: HeaderData) Image.WriteError!void {
-    var scanline: color.PixelStorage = undefined;
-    var previous_scanline: ?color.PixelStorage = null;
+pub fn filter(allocator: std.mem.Allocator, writer: anytype, pixels: color.PixelStorage, filter_choice: FilterChoice, header: HeaderData) Image.WriteError!void {
+    const line_bytes = header.lineBytes();
+    const scanline_allocation_size = 2 * line_bytes;
+
+    const scanline_buffer = try allocator.alloc(u8, scanline_allocation_size);
+    defer allocator.free(scanline_buffer);
+
+    const previous_scanline_row = scanline_buffer[0..line_bytes];
+    const current_scanline_row = scanline_buffer[line_bytes..(2 * line_bytes)];
+
+    // Fill previous scanline with 0
+    @memset(previous_scanline_row, 0);
 
     const format: PixelFormat = pixels;
-
-    if (format.bitsPerChannel() < 8)
-        return Image.WriteError.Unsupported;
 
     const pixel_len = format.pixelStride();
 
     var y: usize = 0;
     while (y < header.height) : (y += 1) {
-        scanline = pixels.slice(y * header.width, (y + 1) * header.width);
+        fillScanline(pixels, current_scanline_row, y, header.width);
 
         const filter_type: FilterType = switch (filter_choice) {
             .try_all => @panic("Unimplemented"),
-            .heuristic => filterChoiceHeuristic(scanline, previous_scanline),
+            .heuristic => filterChoiceHeuristic(current_scanline_row, previous_scanline_row),
             .specified => |f| f,
         };
 
         writer.writeByte(@intFromEnum(filter_type)) catch return Image.WriteError.InvalidData;
 
-        for (0..scanline.asBytes().len) |byte_index| {
-            const i = if (builtin.target.cpu.arch.endian() == .little) pixelByteSwappedIndex(scanline, byte_index) else byte_index;
+        for (0..current_scanline_row.len) |byte_index| {
+            const i = byte_index;
 
-            const sample = scanline.asBytes()[i];
-            const previous: u8 = if (byte_index >= pixel_len) scanline.asBytes()[i - pixel_len] else 0;
-            const above: u8 = if (previous_scanline) |b| b.asBytes()[i] else 0;
-            const above_previous = if (previous_scanline) |b| (if (byte_index >= pixel_len) b.asBytes()[i - pixel_len] else 0) else 0;
+            const sample = current_scanline_row[i];
+            const previous: u8 = if (byte_index >= pixel_len) current_scanline_row[i - pixel_len] else 0;
+            const above: u8 = previous_scanline_row[i];
+            const above_previous = if (byte_index >= pixel_len) previous_scanline_row[i - pixel_len] else 0;
 
             const byte: u8 = switch (filter_type) {
                 .none => sample,
@@ -66,43 +72,40 @@ pub fn filter(writer: anytype, pixels: color.PixelStorage, filter_choice: Filter
 
             writer.writeByte(byte) catch return Image.WriteError.InvalidData;
         }
-        previous_scanline = scanline;
+
+        @memcpy(previous_scanline_row, current_scanline_row);
     }
 }
 
-// Map the index of a byte to what it would be if each struct element was byte swapped
-fn pixelByteSwappedIndex(storage: color.PixelStorage, index: usize) usize {
-    return switch (storage) {
-        .invalid => index,
-        inline .indexed1, .indexed2, .indexed4, .indexed8, .indexed16 => |data| byteSwappedIndex(@typeInfo(@TypeOf(data.indices)).pointer.child, index),
-        inline else => |data| byteSwappedIndex(@typeInfo(@TypeOf(data)).pointer.child, index),
-    };
-}
+fn fillScanline(pixels: color.PixelStorage, scanline_bytes: []u8, y: usize, width: usize) void {
+    const pixels_scanline = pixels.slice(y * width, (y + 1) * width);
+    const pixel_format: PixelFormat = std.meta.activeTag(pixels);
+    const bit_depth = pixel_format.bitsPerChannel();
+    switch (bit_depth) {
+        8 => {
+            const source_row_bytes = pixels_scanline.asConstBytes();
 
-// Map the index of a byte to what it would be if each struct element was byte swapped
-fn byteSwappedIndex(comptime T: type, byte_index: usize) usize {
-    const element_index = byte_index / @sizeOf(T);
-    const element_offset = element_index * @sizeOf(T);
-    const index = byte_index % @sizeOf(T);
-    switch (@typeInfo(T)) {
-        .int => {
-            if (@sizeOf(T) == 1) return byte_index;
-            return element_offset + @sizeOf(T) - 1 - index;
+            @memcpy(scanline_bytes, source_row_bytes);
         },
-        .@"struct" => |info| {
-            inline for (info.fields) |field| {
-                if (index >= @offsetOf(T, field.name) or index <= @offsetOf(T, field.name) + @sizeOf(field.type)) {
-                    if (@sizeOf(field.type) == 1) return byte_index;
-                    return element_offset + @sizeOf(field.type) - 1 - index;
-                }
+        16 => {
+            const source_row_bytes = pixels_scanline.asConstBytes();
+
+            const source_row_u16 = std.mem.bytesAsSlice(u16, source_row_bytes);
+            var destination_scanline_u16 = std.mem.bytesAsSlice(u16, scanline_bytes);
+
+            const need_byteswap = builtin.target.cpu.arch.endian() == .little;
+
+            const length = scanline_bytes.len / 2;
+            for (0..length) |index| {
+                destination_scanline_u16[index] = if (need_byteswap) @byteSwap(source_row_u16[index]) else source_row_u16[index];
             }
         },
-        else => @compileError("type " ++ @typeName(T) ++ " not supported"),
+        else => {},
     }
 }
 
-fn filterChoiceHeuristic(scanline: color.PixelStorage, previous_scanline: ?color.PixelStorage) FilterType {
-    const pixel_len = @as(PixelFormat, scanline).pixelStride();
+fn filterChoiceHeuristic(scanline: []const u8, previous_scanline: []const u8) FilterType {
+    const pixel_len = scanline.len;
 
     const filter_types = [_]FilterType{ .none, .sub, .up, .average, .paeth };
 
@@ -110,10 +113,10 @@ fn filterChoiceHeuristic(scanline: color.PixelStorage, previous_scanline: ?color
     var combos: [filter_types.len]usize = @splat(0);
     var scores: [filter_types.len]usize = @splat(0);
 
-    for (scanline.asBytes(), 0..) |sample, i| {
-        const previous: u8 = if (i >= pixel_len) scanline.asBytes()[i - pixel_len] else 0;
-        const above: u8 = if (previous_scanline) |b| b.asBytes()[i] else 0;
-        const above_previous = if (previous_scanline) |b| (if (i >= pixel_len) b.asBytes()[i - pixel_len] else 0) else 0;
+    for (scanline, 0..) |sample, i| {
+        const previous: u8 = if (i >= pixel_len) scanline[i - pixel_len] else 0;
+        const above: u8 = previous_scanline[i];
+        const above_previous = if (i >= pixel_len) previous_scanline[i - pixel_len] else 0;
 
         inline for (filter_types, &previous_bytes, &combos, &scores) |filter_type, *previous_byte, *combo, *score| {
             const byte: u8 = switch (filter_type) {
@@ -181,7 +184,7 @@ test "filtering 16-bit grayscale pixels uses correct endianess" {
     defer std.testing.allocator.free(pixels);
 
     // We specify the endianess as none to simplify the test
-    try filter(output_bytes.writer(), .{ .grayscale16 = pixels }, .{ .specified = .none }, .{
+    try filter(std.testing.allocator, output_bytes.writer(), .{ .grayscale16 = pixels }, .{ .specified = .none }, .{
         .width = 4,
         .height = 2,
         .bit_depth = 16,

--- a/tests/formats/png_test.zig
+++ b/tests/formats/png_test.zig
@@ -239,6 +239,58 @@ test "png: Write tRNS chunk in indexed format only when alpha is present" {
     try std.testing.expect(check_trns_processor.present);
 }
 
+test "png: Write indexed1 format" {
+    const SOURCE_WIDTH = 477;
+    const SOURCE_HEIGHT = 512;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .indexed1);
+    defer source_image.deinit();
+
+    for (0..2) |palette_index| {
+        source_image.pixels.indexed1.palette[palette_index] = .{
+            .r = @truncate(palette_index % 2),
+            .g = @truncate(palette_index % 1),
+            .b = 1,
+            .a = 255,
+        };
+    }
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.indexed1.indices[index] = @truncate(index % 2);
+    }
+
+    const image_file_name = "zigimg_png_indexed1.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .indexed1);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..2) |palette_index| {
+        try helpers.expectEq(read_image.pixels.indexed1.palette[palette_index].r, @as(u8, @truncate(palette_index % 2)));
+        try helpers.expectEq(read_image.pixels.indexed1.palette[palette_index].g, @as(u8, @truncate(palette_index % 1)));
+        try helpers.expectEq(read_image.pixels.indexed1.palette[palette_index].b, 1);
+        try helpers.expectEq(read_image.pixels.indexed1.palette[palette_index].a, 255);
+    }
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.indexed1.indices[index], @as(u1, @truncate(index % 2)));
+    }
+}
+
 test "png: Write indexed2 format" {
     const SOURCE_WIDTH = 467;
     const SOURCE_HEIGHT = 524;
@@ -392,6 +444,42 @@ test "png: Write indexed8 format" {
 
     for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
         try helpers.expectEq(read_image.pixels.indexed8.indices[index], @as(u8, @truncate(index % 256)));
+    }
+}
+
+test "png: Write grayscale1 format" {
+    const SOURCE_WIDTH = 479;
+    const SOURCE_HEIGHT = 534;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .grayscale1);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.grayscale1[index].value = @truncate(index % 2);
+    }
+
+    const image_file_name = "zigimg_png_grayscale1.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .grayscale1);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.grayscale1[index].value, @as(u1, @truncate(index % 2)));
     }
 }
 

--- a/tests/formats/png_test.zig
+++ b/tests/formats/png_test.zig
@@ -239,6 +239,358 @@ test "png: Write tRNS chunk in indexed format only when alpha is present" {
     try std.testing.expect(check_trns_processor.present);
 }
 
+// test "png: Write indexed4 format" {
+//     const SOURCE_WIDTH = 16;
+//     const SOURCE_HEIGHT = 16;
+
+//     var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .indexed4);
+//     defer source_image.deinit();
+
+//     for (0..16) |index| {
+//         source_image.pixels.indexed4.palette[index] = .{ .r = @truncate(index * 16), .g = @truncate(index * 16), .b = @truncate(index * 16), .a = 255 };
+//     }
+
+//     for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+//         source_image.pixels.indexed4.indices[index] = @truncate(index % 16);
+//     }
+
+//     const image_file_name = "zigimg_png_indexed4.png";
+//     try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+//     defer {
+//         std.fs.cwd().deleteFile(image_file_name) catch {};
+//     }
+
+//     const read_file = try helpers.testOpenFile(image_file_name);
+//     defer read_file.close();
+
+//     var stream_source = std.io.StreamSource{ .file = read_file };
+
+//     var options = png.DefaultOptions.init(.{});
+
+//     var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+//     defer read_image.deinit(helpers.zigimg_test_allocator);
+
+//     try std.testing.expect(read_image.pixels == .indexed4);
+//     try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+//     try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+//     for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+//         try helpers.expectEq(read_image.pixels.indexed4.indices[index], @as(u4, @truncate(index % 16)));
+//     }
+// }
+
+test "png: Write grayscale8 format" {
+    const SOURCE_WIDTH = 502;
+    const SOURCE_HEIGHT = 457;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .grayscale8);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.grayscale8[index].value = @truncate(index % 256);
+    }
+
+    const image_file_name = "zigimg_png_grayscale8.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .grayscale8);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.grayscale8[index].value, @as(u8, @truncate(index % 256)));
+    }
+}
+
+test "png: Write grayscale8Alpha format" {
+    const SOURCE_WIDTH = 567;
+    const SOURCE_HEIGHT = 612;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .grayscale8Alpha);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.grayscale8Alpha[index].value = @truncate(index % 256);
+        source_image.pixels.grayscale8Alpha[index].alpha = @truncate(index % 256);
+    }
+
+    const image_file_name = "zigimg_png_grayscale8Alpha.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .grayscale8Alpha);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.grayscale8Alpha[index].value, @as(u8, @truncate(index % 256)));
+        try helpers.expectEq(read_image.pixels.grayscale8Alpha[index].alpha, @as(u8, @truncate(index % 256)));
+    }
+}
+
+test "png: Write grayscale16 format" {
+    const SOURCE_WIDTH = 534;
+    const SOURCE_HEIGHT = 567;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .grayscale16);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.grayscale16[index].value = @truncate(index % 65535);
+    }
+
+    const image_file_name = "zigimg_png_grayscale16.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .grayscale16);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.grayscale16[index].value, @as(u16, @truncate(index % 65535)));
+    }
+}
+
+test "png: Write grayscale16Alpha format" {
+    const SOURCE_WIDTH = 467;
+    const SOURCE_HEIGHT = 658;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .grayscale16Alpha);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.grayscale16Alpha[index].value = @truncate(index % 65535);
+        source_image.pixels.grayscale16Alpha[index].alpha = @truncate(index % 65535);
+    }
+
+    const image_file_name = "zigimg_png_grayscale16Alpha.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .grayscale16Alpha);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.grayscale16Alpha[index].value, @as(u16, @truncate(index % 65535)));
+        try helpers.expectEq(read_image.pixels.grayscale16Alpha[index].alpha, @as(u16, @truncate(index % 65535)));
+    }
+}
+
+test "png: Write rgb24 format" {
+    const SOURCE_WIDTH = 512;
+    const SOURCE_HEIGHT = 512;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .rgb24);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.rgb24[index].r = @truncate(index % 256);
+        source_image.pixels.rgb24[index].g = @truncate(index % 128);
+        source_image.pixels.rgb24[index].b = @truncate(index % 64);
+    }
+
+    const image_file_name = "zigimg_png_rgb24.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .rgb24);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.rgb24[index].r, @as(u8, @truncate(index % 256)));
+        try helpers.expectEq(read_image.pixels.rgb24[index].g, @as(u8, @truncate(index % 128)));
+        try helpers.expectEq(read_image.pixels.rgb24[index].b, @as(u8, @truncate(index % 64)));
+    }
+}
+
+test "png: Write rgba32 format" {
+    const SOURCE_WIDTH = 470;
+    const SOURCE_HEIGHT = 327;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .rgba32);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.rgba32[index].r = @truncate(index % 256);
+        source_image.pixels.rgba32[index].g = @truncate(index % 128);
+        source_image.pixels.rgba32[index].b = @truncate(index % 64);
+        source_image.pixels.rgba32[index].a = @truncate(index % 256);
+    }
+
+    const image_file_name = "zigimg_png_rgba32.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .rgba32);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.rgba32[index].r, @as(u8, @truncate(index % 256)));
+        try helpers.expectEq(read_image.pixels.rgba32[index].g, @as(u8, @truncate(index % 128)));
+        try helpers.expectEq(read_image.pixels.rgba32[index].b, @as(u8, @truncate(index % 64)));
+        try helpers.expectEq(read_image.pixels.rgba32[index].a, @as(u8, @truncate(index % 256)));
+    }
+}
+
+test "png: Write rgb48 format" {
+    const SOURCE_WIDTH = 453;
+    const SOURCE_HEIGHT = 217;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .rgb48);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.rgb48[index].r = @truncate(index % 65535);
+        source_image.pixels.rgb48[index].g = @truncate(index % 32767);
+        source_image.pixels.rgb48[index].b = @truncate(index % 21845);
+    }
+
+    const image_file_name = "zigimg_png_rgb48.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .rgb48);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.rgb48[index].r, @as(u16, @truncate(index % 65535)));
+        try helpers.expectEq(read_image.pixels.rgb48[index].g, @as(u16, @truncate(index % 32767)));
+        try helpers.expectEq(read_image.pixels.rgb48[index].b, @as(u16, @truncate(index % 21845)));
+    }
+}
+
+test "png: Write rgba64 format" {
+    const SOURCE_WIDTH = 556;
+    const SOURCE_HEIGHT = 464;
+
+    var source_image = try Image.create(helpers.zigimg_test_allocator, SOURCE_WIDTH, SOURCE_HEIGHT, .rgba64);
+    defer source_image.deinit();
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        source_image.pixels.rgba64[index].r = @truncate(index % 65535);
+        source_image.pixels.rgba64[index].g = @truncate(index % 32767);
+        source_image.pixels.rgba64[index].b = @truncate(index % 21845);
+        source_image.pixels.rgba64[index].a = @truncate(index % 65535);
+    }
+
+    const image_file_name = "zigimg_png_rgba64.png";
+    try source_image.writeToFilePath(image_file_name, .{ .png = .{} });
+    defer {
+        std.fs.cwd().deleteFile(image_file_name) catch {};
+    }
+
+    const read_file = try helpers.testOpenFile(image_file_name);
+    defer read_file.close();
+
+    var stream_source = std.io.StreamSource{ .file = read_file };
+
+    var options = png.DefaultOptions.init(.{});
+
+    var read_image = try png.load(&stream_source, helpers.zigimg_test_allocator, options.get());
+    defer read_image.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(read_image.pixels == .rgba64);
+    try helpers.expectEq(read_image.width, SOURCE_WIDTH);
+    try helpers.expectEq(read_image.height, SOURCE_HEIGHT);
+
+    for (0..(SOURCE_WIDTH * SOURCE_HEIGHT)) |index| {
+        try helpers.expectEq(read_image.pixels.rgba64[index].r, @as(u16, @truncate(index % 65535)));
+        try helpers.expectEq(read_image.pixels.rgba64[index].g, @as(u16, @truncate(index % 32767)));
+        try helpers.expectEq(read_image.pixels.rgba64[index].b, @as(u16, @truncate(index % 21845)));
+        try helpers.expectEq(read_image.pixels.rgba64[index].a, @as(u16, @truncate(index % 65535)));
+    }
+}
+
 test "PNG Official Test Suite" {
     try testWithDir(helpers.fixtures_path ++ "png/", true);
 }


### PR DESCRIPTION
Modified the filtering code to support all the pixel formats supported by PNG and now allocates 2 rows of bytes for filtering that require the current and previous row on a image.