### PR TITLE
Add tiff format

### DIFF
--- a/src/ImageUnmanaged.zig
+++ b/src/ImageUnmanaged.zig
@@ -23,6 +23,7 @@ const SupportedFormats = struct {
     pub const ras = formats.ras.RAS;
     pub const sgi = formats.sgi.SGI;
     pub const tga = formats.tga.TGA;
+    pub const tiff = formats.tiff.TIFF;
 };
 
 pub const Format = std.meta.DeclEnum(SupportedFormats);
@@ -43,6 +44,7 @@ pub const EncoderOptions = union(Format) {
     ras: void,
     sgi: void,
     tga: SupportedFormats.tga.EncoderOptions,
+    tiff: void,
 };
 
 pub const Error = error{

--- a/src/formats.zig
+++ b/src/formats.zig
@@ -11,6 +11,7 @@ pub const qoi = @import("formats/qoi.zig");
 pub const ras = @import("formats/ras.zig");
 pub const sgi = @import("formats/sgi.zig");
 pub const tga = @import("formats/tga.zig");
+pub const tiff = @import("formats/tiff.zig");
 
 test {
     const std = @import("std");

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -205,11 +205,11 @@ pub const TIFF = struct {
             return std.builtin.Endian.big;
         }
 
-        return ImageReadError.Unsupported;
+        return ImageReadError.InvalidData;
     }
 
     pub fn formatDetect(stream: *ImageUnmanaged.Stream) !bool {
-        _ = try endianessDetect(stream);
+        _ = endianessDetect(stream) catch return false;
 
         return true;
     }

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -9,199 +9,27 @@ const utils = @import("../utils.zig");
 const std = @import("std");
 const PixelStorage = color.PixelStorage;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
+const types = @import("tiff/types.zig");
 
-const CompressionType = enum(u16) {
-    // Some encoders (eg. ffmpeg) use 0 for raw images
-    // although it's not mentionned in the TIFF specs.
-    raw = 0,
-    uncompressed = 1,
-    ccit_1d = 2,
-    gp_3_fax = 3,
-    gp_4_fax = 4,
-    lzw = 5,
-    jpeg = 6,
-    // old tag value used only in tiff v4
-    uncompressed_old = 32771,
-    packbits = 32773,
-};
-
-const ResolutionUnit = enum(u16) {
-    // Some encoders (eg. ffmpeg) use 0 for resolution_unit
-    // although it's not mentionned in the TIFF specs.
-    not_specified = 0,
-    no_unit = 1,
-    inch = 2,
-    cm = 3,
-};
-
-const TagId = enum(u16) { new_subfile_type = 254, image_width = 256, image_height = 257, bits_per_sample = 258, compression = 259, photometric_interpretation = 262, fill_order = 266, strip_offsets = 273, orientation = 274, samples_per_pixel = 277, rows_per_strip = 278, strip_byte_counts = 279, x_resolution = 282, y_resolution = 283, planar_configuration = 284, resolution_unit = 296, software = 305, extra_samples = 338, sample_format = 339, unknown_1 = 700, unknown_2 = 34665, unknown_3 = 34675 };
-
-// We'll store all tags required for
-// grayscale, color, and rgb encoded files
-const BitmapDescriptor = struct {
-    // bi-level/grayscale class type required tags
-    compression: CompressionType = .uncompressed,
-    // can be u16 or u32
-    image_width: u32 = 0,
-    // can be u16 or u32
-    image_height: u32 = 0,
-    // - b & w images: 1 is black or 0 is black
-    // rgb: 2
-    photometric_interpretation: u16 = 0,
-    // can be u16/u32: number of rows in each but the last strip
-    rows_per_strip: u32 = 0,
-    // byte offset in each strip, can be u16/u32
-    strip_offsets: ?[]u8 = null,
-    // for each strip, number of bytes (after compression)
-    strip_byte_counts: ?[]u8 = null,
-    // number of pixels per resolution unit in image_width
-    x_resolution: [2]u32 = .{ 0, 0 },
-    // number of pixels per resolution unit in image_height
-    y_resolution: [2]u32 = .{ 0, 0 },
-    resolution_unit: ResolutionUnit = .no_unit,
-    // Fields required for grayscale images
-    // - b & w:
-    // - grayscale: 4 / 8 allowed for grayscale images (16/256 shades)
-    // - rgb: 8,8,8 (count == 3)
-    // TODO: should be [samples_per_pixel]u16
-    bits_per_sample: u16 = 1,
-    // flags describing the image type
-    new_subfile_type: u32 = 0,
-    // palette class needs previous tags and:
-    // color_map: utils.FixedStorage(color.Rgba32, 0) = .{},
-    // rgb class needs previous tags and:
-    // number of components per pixel
-    samples_per_pixel: u16 = 1,
-    // Default fill_order: pixels are arranged within a byte such that
-    // pixels with lower column values are stored in the higher-order bits of the byte.
-    fill_order: u16 = 1,
-
-    pub fn debug(self: *BitmapDescriptor) void {
-        inline for (std.meta.fields(BitmapDescriptor)) |f| {
-            std.debug.print(f.name ++ "={any}\n", .{@as(f.type, @field(self, f.name))});
-        }
-        if (self.strip_byte_counts != null) {
-            const offsets: []u32 = @as(*const []u32, @ptrCast(&self.strip_byte_counts.?[0..])).*;
-            // const hex = std.fmt.bytesToHex(offsets, .upper);
-            // for (0..self.strip_byte_counts.?.len) |index| {
-            //     std.debug.print("{x} ", .{self.strip_byte_counts.?[index]});
-            // }
-            // std.debug.print("\n", .{});
-            std.debug.print("*** first byte count = {}\n", .{std.mem.toNative(u32, offsets[0], .little)});
-        }
-    }
-
-    pub fn guessPixelFormat(self: *BitmapDescriptor) ImageReadError!PixelFormat {
-        if (self.bits_per_sample == 1) {
-            return PixelFormat.grayscale1;
-        }
-
-        return ImageError.Unsupported;
-    }
-
-    pub fn deinit(self: *BitmapDescriptor, allocator: std.mem.Allocator) void {
-        if (self.strip_offsets != null) {
-            allocator.free(self.strip_offsets.?);
-        }
-
-        if (self.strip_byte_counts != null) {
-            allocator.free(self.strip_byte_counts.?);
-        }
-    }
-};
-
-const Header = extern struct {
-    const size = 6;
-
-    version: u16 align(1),
-    idf_offset: u32 align(1),
-
-    const little_endian_magic = "II";
-    const big_endian_magic = "MM";
-
-    comptime {
-        std.debug.assert(@sizeOf(Header) == Header.size);
-    }
-};
-
-// Tag as found inside the TIFF file
-const PackedTag = struct {
-    const size = 12;
-
-    tag_id: u16 align(1),
-    data_type: u16 align(1),
-    data_count: u32 align(1),
-    data_offset: u32 align(1),
-
-    comptime {
-        std.debug.assert(@sizeOf(PackedTag) == PackedTag.size);
-    }
-};
-
-const TagField = struct {
-    data_type: u16 align(1),
-    data_count: u32 align(1),
-    data_offset: u32 align(1),
-
-    pub inline fn toLong(self: *const TagField) u32 {
-        return self.data_offset;
-    }
-
-    // Some fields (eg. image_width) can be encoded as long or short:
-    // this function either returns an u16 casted to u32, or an u32
-    // based on the tag data_type
-    pub inline fn toLongOrShort(self: *const TagField) u32 {
-        return if (self.data_type == 3) self.toShort() else self.data_offset;
-    }
-
-    pub inline fn toShort(self: *const TagField) u16 {
-        // smaller than 32-bit values are left-aligned
-        return @truncate(self.data_offset >> 16);
-    }
-
-    // not sure what to do about these two values yet
-    pub fn readRational(self: *const TagField, stream: *ImageUnmanaged.Stream, endianess: std.builtin.Endian) ![2]u32 {
-        try stream.seekTo(self.data_offset);
-        const reader = stream.reader();
-
-        return [2]u32{
-            try reader.readInt(u32, endianess),
-            try reader.readInt(u32, endianess),
-        };
-    }
-
-    pub fn readU16orU32Array(self: *const TagField, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) ![]u8 {
-        const byte_size = if (self.data_type == 3) self.data_count * 2 else self.data_count * 4;
-        const data = try allocator.alloc(u8, byte_size);
-
-        std.debug.print("++ seeking to {}\n", .{self.data_offset});
-
-        try stream.seekTo(self.data_offset);
-        _ = try stream.read(data[0..]);
-
-        return data;
-    }
-};
-
-const IFD = struct {
-    num_tag_entries: u16,
-    tag_map: std.AutoHashMap(TagId, TagField),
-    next_idf_offset: u32,
-};
+pub const Header = types.Header;
+pub const IFD = types.IFD;
+pub const BitmapDescriptor = types.BitmapDescriptor;
+pub const TagField = types.TagField;
 
 pub const TIFF = struct {
     endianess: std.builtin.Endian = undefined,
     header: Header = undefined,
     // TIFF can have many images but right now
     // we handle only the first one
-    first_ifd: IFD = undefined,
+    ifd: IFD = undefined,
+    bitmap: BitmapDescriptor = undefined,
 
-    pub fn width(_: *TIFF) usize {
-        return 0;
+    pub fn width(self: *TIFF) usize {
+        return self.bitmap.image_width;
     }
 
-    pub fn height(_: *TIFF) usize {
-        return 0;
+    pub fn height(self: *TIFF) usize {
+        return self.bitmap.image_height;
     }
 
     pub fn formatInterface() FormatInterface {
@@ -212,48 +40,16 @@ pub const TIFF = struct {
         };
     }
 
-    pub fn readIFD(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) !void {
-        std.debug.print("need to seek to {} (size = {})\n", .{ self.header.idf_offset, try stream.getEndPos() });
-        var current_idf_offset = self.header.idf_offset;
-        try stream.seekTo(current_idf_offset);
-        const reader = stream.reader();
-
-        while (current_idf_offset > 0) {
-            std.debug.print("reading idf\n", .{});
-            current_idf_offset = 0;
-            const num_tag_entries = try reader.readInt(u16, self.endianess);
-            const tags_array: []u8 = try allocator.alloc(u8, @sizeOf(PackedTag) * num_tag_entries);
-            defer allocator.free(tags_array);
-            _ = try reader.readAll(tags_array);
-            const next_ifd_offset = try reader.readInt(u32, self.endianess);
-            var tags_map = std.AutoHashMap(TagId, TagField).init(allocator);
-            const tags_list = @as(*const []PackedTag, @ptrCast(&tags_array[0..])).*;
-            // We should iterate through all IFD, but since we support
-            // only one right now, we just set next offset to 0.
-            current_idf_offset = 0;
-            for (0..num_tag_entries) |index| {
-                const tag = tags_list[index];
-                std.debug.print("Adding id={}\n", .{std.mem.toNative(u16, tag.tag_id, self.endianess)});
-                try tags_map.put(@enumFromInt(std.mem.toNative(u16, tag.tag_id, self.endianess)), TagField{
-                    .data_type = std.mem.toNative(u16, tag.data_type, self.endianess),
-                    .data_count = std.mem.toNative(u32, tag.data_count, self.endianess),
-                    .data_offset = std.mem.toNative(u32, tag.data_offset, self.endianess),
-                });
-                // std.debug.print("tag id={} type={} count={x} offset={}\n", .{std.mem.toNative(u16, tag.tag_id, self.endianess)});
-                std.debug.print("[{}] = {any}\n", .{ std.mem.toNative(u16, tag.tag_id, self.endianess), tags_map.get(@enumFromInt(std.mem.toNative(u16, tag.tag_id, self.endianess))) });
-            }
-            self.first_ifd = IFD{ .num_tag_entries = num_tag_entries, .next_idf_offset = next_ifd_offset, .tag_map = tags_map };
-        }
-    }
-
-    pub fn decodeTags(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator, ifd: *IFD) !void {
+    pub fn decodeBitmap(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) !void {
         const endianess = self.endianess;
-        var bitmap = BitmapDescriptor{};
+        const ifd = self.ifd;
+        const tags_map = ifd.tags_map;
+        const bitmap = &self.bitmap;
 
-        var iterator = ifd.tag_map.keyIterator();
+        var iterator = tags_map.keyIterator();
 
         while (iterator.next()) |key| {
-            const tag: TagField = ifd.tag_map.get(key.*).?;
+            const tag: TagField = tags_map.get(key.*).?;
             switch (key.*) {
                 .image_width => {
                     bitmap.image_width = tag.toLongOrShort();
@@ -265,10 +61,10 @@ pub const TIFF = struct {
                     bitmap.compression = @enumFromInt(tag.toShort());
                 },
                 .strip_byte_counts => {
-                    bitmap.strip_byte_counts = try tag.readU16orU32Array(stream, allocator);
+                    bitmap.strip_byte_counts = try tag.readTagData(stream, allocator, endianess);
                 },
                 .strip_offsets => {
-                    bitmap.strip_offsets = try tag.readU16orU32Array(stream, allocator);
+                    bitmap.strip_offsets = try tag.readTagData(stream, allocator, endianess);
                 },
                 .rows_per_strip => {
                     bitmap.rows_per_strip = tag.toLongOrShort();
@@ -290,7 +86,6 @@ pub const TIFF = struct {
                         1 => bitmap.bits_per_sample = tag.toShort(),
                         else => return ImageError.Unsupported,
                     }
-                    std.debug.print("{}\n", .{tag});
                 },
                 .x_resolution => {
                     bitmap.x_resolution = try tag.readRational(stream, endianess);
@@ -299,14 +94,38 @@ pub const TIFF = struct {
                     bitmap.y_resolution = try tag.readRational(stream, endianess);
                 },
                 else => {
-                    std.debug.print("Skipping tag id={} {}\n", .{ key, tag });
+                    // skip optional tags
                 },
             }
         }
+    }
 
-        bitmap.debug();
+    pub fn readMono(self: *TIFF, pixels: []color.Grayscale1, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) ImageUnmanaged.ReadError!void {
+        const bitmap = &self.bitmap;
+        const total_strips = (bitmap.image_height + bitmap.rows_per_strip - 1) / bitmap.rows_per_strip;
+        const byte_counts_array = bitmap.strip_byte_counts.?;
+        const offsets_array = bitmap.strip_offsets.?;
+        const image_width = bitmap.image_width;
+        const row_per_strips = bitmap.rows_per_strip;
+        const photometric_interpretation = bitmap.photometric_interpretation;
 
-        bitmap.deinit(allocator);
+        for (0..total_strips) |index| {
+            const byte_count = byte_counts_array[index];
+            const offset = offsets_array[index];
+            const strip_buffer: []u8 = try allocator.alloc(u8, byte_count);
+            var pixel_index = index * row_per_strips * image_width;
+            defer allocator.free(strip_buffer);
+            _ = try stream.seekTo(offset);
+            _ = try stream.read(strip_buffer[0..]);
+            for (0..byte_count) |strip_index| {
+                const byte = strip_buffer[strip_index];
+                for (0..8) |bit_index| {
+                    const value: u1 = @truncate(byte >> @intCast(@as(u3, 7) - bit_index) & 1);
+                    pixels[pixel_index + bit_index].value = if (photometric_interpretation == 0) value else value ^ 1;
+                }
+                pixel_index += 8;
+            }
+        }
     }
 
     pub fn read(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) ImageUnmanaged.ReadError!color.PixelStorage {
@@ -314,30 +133,41 @@ pub const TIFF = struct {
 
         const reader = stream.reader();
 
-        std.debug.print("reading IFD, pos={}, endianess={}\n", .{ try stream.getPos(), self.endianess });
-
         self.header = Header{
             .version = try reader.readInt(u16, self.endianess),
             .idf_offset = try reader.readInt(u32, self.endianess),
         };
 
-        std.debug.print("reading IFD, pos after IFD={}\n", .{try stream.getPos()});
+        self.bitmap = BitmapDescriptor{};
+        defer self.bitmap.deinit(allocator);
 
-        try self.readIFD(stream, allocator);
+        self.ifd = try IFD.init(stream, allocator, self.header.idf_offset);
+        defer self.ifd.deinit();
 
-        try self.decodeTags(stream, allocator, &self.first_ifd);
+        try self.ifd.readTags(self.endianess);
 
-        self.first_ifd.tag_map.deinit();
+        try self.decodeBitmap(stream, allocator);
 
-        var pixels = try color.PixelStorage.init(allocator, PixelFormat.bgr24, 320 * 200);
+        self.bitmap.debug();
+
+        const pixel_format = try self.bitmap.guessPixelFormat();
+
+        var pixels = try color.PixelStorage.init(allocator, pixel_format, self.bitmap.image_width * self.bitmap.image_height);
         errdefer pixels.deinit(allocator);
 
-        std.debug.print("Read IFD: num_entries = {}\n", .{self.first_ifd.num_tag_entries});
-
-        // for (0..20) |index| {
-        //     const tag = self.first_ifd.tag_map[index];
-        //     std.debug.print("tag id={} type={} count={x} offset={}\n", .{ std.mem.toNative(u16, tag.tag_id, self.endianess), std.mem.toNative(u16, tag.data_type, self.endianess), std.mem.toNative(u32, tag.data_count, self.endianess), std.mem.toNative(u32, tag.data_offset, self.endianess) >> 16 });
-        // }
+        switch (pixels) {
+            .grayscale1 => |data| {
+                if (self.bitmap.fill_order == 1) {
+                    try self.readMono(data, stream, allocator);
+                } else {
+                    // lower column values are stored in lower-order bits
+                    return ImageUnmanaged.Error.Unsupported;
+                }
+            },
+            else => {
+                return ImageUnmanaged.Error.Unsupported;
+            },
+        }
 
         return pixels;
     }
@@ -351,6 +181,8 @@ pub const TIFF = struct {
         const pixels = try tiff.read(stream, allocator);
 
         result.pixels = pixels;
+        result.width = tiff.width();
+        result.height = tiff.height();
 
         return result;
     }

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -10,6 +10,73 @@ const std = @import("std");
 const PixelStorage = color.PixelStorage;
 const PixelFormat = @import("../pixel_format.zig").PixelFormat;
 
+const CompressionType = enum(u16) {
+    // some encoders (eg. ffmpeg) use 0 for raw images
+    // also it's not mentionned in the TIFF specs
+    raw = 0,
+    uncompressed = 1,
+    ccit_1d = 2,
+    gp_3_fax = 3,
+    gp_4_fax = 4,
+    lzw = 5,
+    jpeg = 6,
+    // old tag value used only in tiff v4
+    uncompressed_old = 32771,
+    packbits = 32773,
+};
+
+const ResolutionUnit = enum(u16) {
+    no_unit = 1,
+    inch = 2,
+    cm = 3,
+};
+
+const TagId = enum(u16) { new_subfile_type = 254, image_width = 256, image_height = 257, bits_per_sample = 258, compression = 259, photometric_interpretation = 262, fill_order = 266, strip_offsets = 273, orientation = 274, samples_per_pixel = 277, rows_per_strip = 278, stripe_byte_counts = 279, x_resolution = 282, y_resolution = 283, planar_configuration = 284, resolution_unit = 296, software = 305, extra_samples = 338, sample_format = 339, unknown_1 = 700, unknown_2 = 34665, unknown_3 = 34675 };
+
+// We'll store all tags required for
+// grayscale, color, and rgb encoded files
+const BitmapDescriptor = struct {
+    // bi-level/grayscale class type required tags
+    compression: CompressionType = .uncompressed,
+    // can be u16 or u32
+    image_width: u32 = 0,
+    // can be u16 or u32
+    image_height: u32 = 0,
+    // - b & w images: 1 is black or 0 is black
+    // rgb: 2
+    photometric_interpretation: u16 = 0,
+    // can be u16/u32: number of rows in each but the last strip
+    rows_per_strip: u32 = 0,
+    // byte offset in each stripe, can be u16/u32
+    strip_offsets: u32 = 0,
+    // for each strip, number of bytes (after compression)
+    stripe_byte_counts: u32 = 0,
+    // number of pixels per resolution unit in image_width
+    x_resolution: [2]u32 = .{ 0, 0 },
+    // number of pixels per resolution unit in image_height
+    y_resolution: [2]u32 = .{ 0, 0 },
+    resolution_unit: ResolutionUnit = .no_unit,
+    // Fields required for grayscale images
+    // - b & w:
+    // - grayscale: 4 / 8 allowed for grayscale images (16/256 shades)
+    // - rgb: 8,8,8 (count == 3)
+    bits_per_sample: u16 = 0,
+    // flags describing the image type
+    new_subfile_type: u32 = 0,
+    // palette class needs previous tags and:
+    // color_map: utils.FixedStorage(color.Rgba32, 0) = .{},
+    // rgb class needs previous tags and:
+    // number of components per pixel
+    samples_per_pixel: u16 = 0,
+    // planar_configuration: xx,
+
+    pub fn debug(self: *BitmapDescriptor) void {
+        inline for (std.meta.fields(BitmapDescriptor)) |f| {
+            std.debug.print(f.name ++ "={any}\n", .{@as(f.type, @field(self, f.name))});
+        }
+    }
+};
+
 const Header = extern struct {
     const size = 6;
 
@@ -24,7 +91,8 @@ const Header = extern struct {
     }
 };
 
-const Tag = struct {
+// Tag as found inside the TIFF file
+const PackedTag = struct {
     const size = 12;
 
     tag_id: u16 align(1),
@@ -33,19 +101,43 @@ const Tag = struct {
     data_offset: u32 align(1),
 
     comptime {
-        std.debug.assert(@sizeOf(Tag) == Tag.size);
+        std.debug.assert(@sizeOf(PackedTag) == PackedTag.size);
+    }
+};
+
+const TagField = struct {
+    data_type: u16 align(1),
+    data_count: u32 align(1),
+    data_offset: u32 align(1),
+
+    pub inline fn toLong(self: *const TagField) u32 {
+        return self.data_offset;
+    }
+
+    // Some fields (eg. image_width) can be encoded as long or short:
+    // this function either returns an u16 casted to u32, or an u32
+    // based on the tag data_type
+    pub inline fn toLongOrShort(self: *const TagField) u32 {
+        return if (self.data_type == 3) self.toShort() else self.data_offset;
+    }
+
+    pub inline fn toShort(self: *const TagField) u16 {
+        return @truncate(self.data_offset >> 16);
     }
 };
 
 const IFD = struct {
-    num_dir_entries: u16,
-    tag_list: []Tag,
+    num_tag_entries: u16,
+    tag_map: std.AutoHashMap(TagId, TagField),
     next_idf_offset: u32,
 };
 
 pub const TIFF = struct {
     endianess: std.builtin.Endian = undefined,
     header: Header = undefined,
+    // TIFF can have many images but right now
+    // we handle only the first one
+    first_ifd: IFD = undefined,
 
     pub fn width(_: *TIFF) usize {
         return 0;
@@ -63,21 +155,124 @@ pub const TIFF = struct {
         };
     }
 
-    pub fn read(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) ImageUnmanaged.ReadError!color.PixelStorage {
-        _ = allocator;
+    pub fn readIFD(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) !void {
+        std.debug.print("need to seek to {} (size = {})\n", .{ self.header.idf_offset, try stream.getEndPos() });
+        var current_idf_offset = self.header.idf_offset;
+        try stream.seekTo(current_idf_offset);
+        const reader = stream.reader();
 
+        while (current_idf_offset > 0) {
+            std.debug.print("reading idf\n", .{});
+            current_idf_offset = 0;
+            const num_tag_entries = try reader.readInt(u16, self.endianess);
+            const tags_array: []u8 = try allocator.alloc(u8, @sizeOf(PackedTag) * num_tag_entries);
+            errdefer allocator.free(tags_array);
+            _ = try reader.readAll(tags_array);
+            const next_ifd_offset = try reader.readInt(u16, self.endianess);
+            var tags_map = std.AutoHashMap(TagId, TagField).init(allocator);
+            const tags_list = @as(*const []PackedTag, @ptrCast(&tags_array[0..])).*;
+            // We should iterate through all IFD, but since we support
+            // only one right now, we just set next offset to 0.
+            current_idf_offset = 0;
+            for (0..num_tag_entries) |index| {
+                const tag = tags_list[index];
+                std.debug.print("Adding id={}\n", .{std.mem.toNative(u16, tag.tag_id, self.endianess)});
+                try tags_map.put(@enumFromInt(std.mem.toNative(u16, tag.tag_id, self.endianess)), TagField{
+                    .data_type = std.mem.toNative(u16, tag.data_type, self.endianess),
+                    .data_count = std.mem.toNative(u32, tag.data_count, self.endianess),
+                    .data_offset = std.mem.toNative(u32, tag.data_offset, self.endianess),
+                });
+                // std.debug.print("tag id={} type={} count={x} offset={}\n", .{std.mem.toNative(u16, tag.tag_id, self.endianess)});
+                std.debug.print("[{}] = {any}\n", .{ std.mem.toNative(u16, tag.tag_id, self.endianess), tags_map.get(@enumFromInt(std.mem.toNative(u16, tag.tag_id, self.endianess))) });
+            }
+            self.first_ifd = IFD{ .num_tag_entries = num_tag_entries, .next_idf_offset = next_ifd_offset, .tag_map = tags_map };
+        }
+    }
+
+    pub fn decodeTags(_: *TIFF, _: *ImageUnmanaged.Stream, _: std.mem.Allocator, ifd: *IFD) !void {
+        // const endianess = self.endianess;
+        var bitmap = BitmapDescriptor{};
+
+        var iterator = ifd.tag_map.keyIterator();
+
+        while (iterator.next()) |key| {
+            const tag: TagField = ifd.tag_map.get(key.*).?;
+            switch (key.*) {
+                .image_width => {
+                    bitmap.image_width = tag.toLongOrShort();
+                },
+                .image_height => {
+                    bitmap.image_height = tag.toLongOrShort();
+                },
+                .compression => {
+                    std.debug.print("setting bitmap compression {}\n", .{tag.toShort()});
+                    bitmap.compression = @enumFromInt(tag.toShort());
+                },
+                .photometric_interpretation => {
+                    bitmap.photometric_interpretation = tag.toShort();
+                },
+                .samples_per_pixel => {
+                    bitmap.samples_per_pixel = tag.toShort();
+                },
+                .new_subfile_type => {
+                    bitmap.new_subfile_type = tag.toLong();
+                },
+                .bits_per_sample => {
+                    switch (tag.data_count) {
+                        1 => bitmap.bits_per_sample = tag.toShort(),
+                        else => return ImageError.Unsupported,
+                    }
+                    std.debug.print("{}\n", .{tag});
+                },
+                else => {
+                    std.debug.print("Skipping tag id={} {}\n", .{ key, tag });
+                },
+            }
+        }
+
+        bitmap.debug();
+    }
+
+    pub fn read(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) ImageUnmanaged.ReadError!color.PixelStorage {
         self.endianess = try endianessDetect(stream);
 
         const reader = stream.reader();
 
-        utils.readStruct(reader, Header, self.endianess) catch return ImageReadError.InvalidData;
+        std.debug.print("reading IFD, pos={}, endianess={}\n", .{ try stream.getPos(), self.endianess });
+
+        self.header = Header{
+            .version = try reader.readInt(u16, self.endianess),
+            .idf_offset = try reader.readInt(u32, self.endianess),
+        };
+
+        std.debug.print("reading IFD, pos after IFD={}\n", .{try stream.getPos()});
+
+        try self.readIFD(stream, allocator);
+
+        try self.decodeTags(stream, allocator, &self.first_ifd);
+
+        var pixels = try color.PixelStorage.init(allocator, PixelFormat.bgr24, 320 * 200);
+        errdefer pixels.deinit(allocator);
+
+        std.debug.print("Read IFD: num_entries = {}\n", .{self.first_ifd.num_tag_entries});
+
+        // for (0..20) |index| {
+        //     const tag = self.first_ifd.tag_map[index];
+        //     std.debug.print("tag id={} type={} count={x} offset={}\n", .{ std.mem.toNative(u16, tag.tag_id, self.endianess), std.mem.toNative(u16, tag.data_type, self.endianess), std.mem.toNative(u32, tag.data_count, self.endianess), std.mem.toNative(u32, tag.data_offset, self.endianess) >> 16 });
+        // }
+
+        return pixels;
     }
 
     pub fn readImage(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ImageUnmanaged.ReadError!ImageUnmanaged {
-        _ = stream;
-
         var result = ImageUnmanaged{};
         errdefer result.deinit(allocator);
+
+        var tiff = TIFF{};
+
+        const pixels = try tiff.read(stream, allocator);
+
+        result.pixels = pixels;
 
         return result;
     }

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -1,0 +1,111 @@
+const Allocator = std.mem.Allocator;
+const buffered_stream_source = @import("../buffered_stream_source.zig");
+const color = @import("../color.zig");
+const FormatInterface = @import("../FormatInterface.zig");
+const ImageUnmanaged = @import("../ImageUnmanaged.zig");
+const ImageReadError = ImageUnmanaged.ReadError;
+const ImageError = ImageUnmanaged.Error;
+const utils = @import("../utils.zig");
+const std = @import("std");
+const PixelStorage = color.PixelStorage;
+const PixelFormat = @import("../pixel_format.zig").PixelFormat;
+
+const Header = extern struct {
+    const size = 6;
+
+    version: u16 align(1),
+    idf_offset: u32 align(1),
+
+    const little_endian_magic = "II";
+    const big_endian_magic = "MM";
+
+    comptime {
+        std.debug.assert(@sizeOf(Header) == Header.size);
+    }
+};
+
+const Tag = struct {
+    const size = 12;
+
+    tag_id: u16 align(1),
+    data_type: u16 align(1),
+    data_count: u32 align(1),
+    data_offset: u32 align(1),
+
+    comptime {
+        std.debug.assert(@sizeOf(Tag) == Tag.size);
+    }
+};
+
+const IFD = struct {
+    num_dir_entries: u16,
+    tag_list: []Tag,
+    next_idf_offset: u32,
+};
+
+pub const TIFF = struct {
+    endianess: std.builtin.Endian = undefined,
+    header: Header = undefined,
+
+    pub fn width(_: *TIFF) usize {
+        return 0;
+    }
+
+    pub fn height(_: *TIFF) usize {
+        return 0;
+    }
+
+    pub fn formatInterface() FormatInterface {
+        return FormatInterface{
+            .formatDetect = formatDetect,
+            .readImage = readImage,
+            .writeImage = writeImage,
+        };
+    }
+
+    pub fn read(self: *TIFF, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator) ImageUnmanaged.ReadError!color.PixelStorage {
+        _ = allocator;
+
+        self.endianess = try endianessDetect(stream);
+
+        const reader = stream.reader();
+
+        utils.readStruct(reader, Header, self.endianess) catch return ImageReadError.InvalidData;
+    }
+
+    pub fn readImage(allocator: std.mem.Allocator, stream: *ImageUnmanaged.Stream) ImageUnmanaged.ReadError!ImageUnmanaged {
+        _ = stream;
+
+        var result = ImageUnmanaged{};
+        errdefer result.deinit(allocator);
+
+        return result;
+    }
+
+    pub fn writeImage(allocator: std.mem.Allocator, write_stream: *ImageUnmanaged.Stream, image: ImageUnmanaged, encoder_options: ImageUnmanaged.EncoderOptions) ImageUnmanaged.Stream.WriteError!void {
+        _ = allocator;
+        _ = write_stream;
+        _ = image;
+        _ = encoder_options;
+    }
+
+    fn endianessDetect(stream: *ImageUnmanaged.Stream) !std.builtin.Endian {
+        var magic_buffer: [Header.little_endian_magic.len]u8 = undefined;
+
+        _ = try stream.read(magic_buffer[0..]);
+
+        if (std.mem.eql(u8, magic_buffer[0..], Header.little_endian_magic[0..])) {
+            return std.builtin.Endian.little;
+        } else if (std.mem.eql(u8, magic_buffer[0..], Header.big_endian_magic[0..])) {
+            return std.builtin.Endian.big;
+        }
+
+        return ImageReadError.Unsupported;
+    }
+
+    pub fn formatDetect(stream: *ImageUnmanaged.Stream) !bool {
+        _ = try endianessDetect(stream);
+
+        return true;
+    }
+};

--- a/src/formats/tiff/types.zig
+++ b/src/formats/tiff/types.zig
@@ -1,0 +1,244 @@
+const std = @import("std");
+const ImageUnmanaged = @import("../../ImageUnmanaged.zig");
+const ImageReadError = ImageUnmanaged.ReadError;
+const ImageError = ImageUnmanaged.Error;
+const PixelFormat = @import("../../pixel_format.zig").PixelFormat;
+const builtin = @import("builtin");
+const native_endian = builtin.target.cpu.arch.endian();
+
+pub const CompressionType = enum(u16) {
+    // Some encoders (eg. ffmpeg) use 0 for raw images
+    // although it's not mentionned in the TIFF specs.
+    raw = 0,
+    uncompressed = 1,
+    ccit_1d = 2,
+    gp_3_fax = 3,
+    gp_4_fax = 4,
+    lzw = 5,
+    jpeg = 6,
+    // old tag value used only in tiff v4
+    uncompressed_old = 32771,
+    packbits = 32773,
+};
+
+pub const ResolutionUnit = enum(u16) {
+    // Some encoders (eg. ffmpeg) use 0 for resolution_unit
+    // although it's not mentionned in the TIFF specs.
+    not_specified = 0,
+    no_unit = 1,
+    inch = 2,
+    cm = 3,
+};
+
+pub const TagId = enum(u16) { new_subfile_type = 254, image_width = 256, image_height = 257, bits_per_sample = 258, compression = 259, photometric_interpretation = 262, fill_order = 266, strip_offsets = 273, orientation = 274, samples_per_pixel = 277, rows_per_strip = 278, strip_byte_counts = 279, x_resolution = 282, y_resolution = 283, planar_configuration = 284, resolution_unit = 296, software = 305, extra_samples = 338, sample_format = 339, unknown_1 = 700, unknown_2 = 34665, unknown_3 = 34675 };
+
+// We'll store all tags required for
+// grayscale, color, and rgb encoded files
+pub const BitmapDescriptor = struct {
+    // bi-level/grayscale class type required tags
+    compression: CompressionType = .uncompressed,
+    // can be u16 or u32
+    image_width: u32 = 0,
+    // can be u16 or u32
+    image_height: u32 = 0,
+    // - b & w images: 1 is black or 0 is black
+    // rgb: 2
+    photometric_interpretation: u16 = 0,
+    // can be u16/u32: number of rows in each but the last strip
+    rows_per_strip: u32 = 0,
+    // byte offset in each strip, can be u16/u32
+    strip_offsets: ?[]u32 = null,
+    // for each strip, number of bytes (after compression)
+    strip_byte_counts: ?[]u32 = null,
+    // number of pixels per resolution unit in image_width
+    x_resolution: [2]u32 = .{ 0, 0 },
+    // number of pixels per resolution unit in image_height
+    y_resolution: [2]u32 = .{ 0, 0 },
+    resolution_unit: ResolutionUnit = .no_unit,
+    // Fields required for grayscale images
+    // - b & w:
+    // - grayscale: 4 / 8 allowed for grayscale images (16/256 shades)
+    // - rgb: 8,8,8 (count == 3)
+    // TODO: should be [samples_per_pixel]u16
+    bits_per_sample: u16 = 1,
+    // flags describing the image type
+    new_subfile_type: u32 = 0,
+    // palette class needs previous tags and:
+    // color_map: utils.FixedStorage(color.Rgba32, 0) = .{},
+    // rgb class needs previous tags and:
+    // number of components per pixel
+    samples_per_pixel: u16 = 1,
+    // Default fill_order: pixels are arranged within a byte such that
+    // pixels with lower column values are stored in the higher-order bits of the byte.
+    fill_order: u16 = 1,
+
+    pub fn debug(self: *BitmapDescriptor) void {
+        std.log.debug("{}\n", .{self});
+    }
+
+    pub fn guessPixelFormat(self: *BitmapDescriptor) ImageReadError!PixelFormat {
+        if (self.bits_per_sample == 0) {
+            return PixelFormat.grayscale1;
+        }
+
+        return ImageError.Unsupported;
+    }
+
+    pub fn deinit(self: *BitmapDescriptor, allocator: std.mem.Allocator) void {
+        if (self.strip_offsets != null) {
+            allocator.free(self.strip_offsets.?);
+        }
+
+        if (self.strip_byte_counts != null) {
+            allocator.free(self.strip_byte_counts.?);
+        }
+    }
+};
+
+pub const Header = extern struct {
+    const size = 6;
+
+    version: u16 align(1),
+    idf_offset: u32 align(1),
+
+    pub const little_endian_magic = "II";
+    pub const big_endian_magic = "MM";
+
+    comptime {
+        std.debug.assert(@sizeOf(Header) == Header.size);
+    }
+};
+
+pub const TagType = enum(u16) {
+    short = 3,
+    long = 4,
+};
+
+// Tag as found inside the TIFF file
+pub const PackedTag = struct {
+    const size = 12;
+
+    tag_id: u16 align(1),
+    data_type: u16 align(1),
+    data_count: u32 align(1),
+    data_offset: u32 align(1),
+
+    comptime {
+        std.debug.assert(@sizeOf(PackedTag) == PackedTag.size);
+    }
+};
+
+pub const TagField = struct {
+    data_type: u16 align(1),
+    data_count: u32 align(1),
+    data_offset: u32 align(1),
+
+    pub inline fn toLong(self: *const TagField) u32 {
+        return self.data_offset;
+    }
+
+    // Some fields (eg. image_width) can be encoded as long or short:
+    // this function either returns an u16 casted to u32, or an u32
+    // based on the tag data_type
+    pub inline fn toLongOrShort(self: *const TagField) u32 {
+        return if (self.data_type == @intFromEnum(TagType.short)) self.toShort() else self.data_offset;
+    }
+
+    pub inline fn toShort(self: *const TagField) u16 {
+        // Smaller than 32-bit values are left-aligned
+        return @truncate(self.data_offset >> 16);
+    }
+
+    pub fn readRational(self: *const TagField, stream: *ImageUnmanaged.Stream, endianess: std.builtin.Endian) ![2]u32 {
+        try stream.seekTo(self.data_offset);
+        const reader = stream.reader();
+
+        return [2]u32{
+            try reader.readInt(u32, endianess),
+            try reader.readInt(u32, endianess),
+        };
+    }
+
+    pub fn readTagData(self: *const TagField, stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator, endianess: std.builtin.Endian) ![]u32 {
+        const byte_size = if (self.data_type == @intFromEnum(TagType.short)) self.data_count * 2 else self.data_count * 4;
+        const data: []u8 = try allocator.alloc(u8, byte_size);
+        defer allocator.free(data);
+
+        const long_data: []u32 = try allocator.alloc(u32, self.data_count);
+
+        try stream.seekTo(self.data_offset);
+        _ = try stream.read(data[0..]);
+
+        if (self.data_type == @intFromEnum(TagType.long)) {
+            if (endianess == native_endian) {
+                @memcpy(std.mem.sliceAsBytes(long_data)[0..], std.mem.sliceAsBytes(data)[0..]);
+            } else {
+                const slice_to_swap = std.mem.bytesAsSlice(u32, data);
+                for (slice_to_swap, 0..self.data_count) |value, index| {
+                    long_data[index] = @byteSwap(value);
+                }
+            }
+        } else {
+            if (endianess == native_endian) {
+                @memcpy(std.mem.sliceAsBytes(long_data)[0..], std.mem.sliceAsBytes(data)[0..]);
+            } else {
+                const slice_to_swap = std.mem.bytesAsSlice(u16, data);
+                for (slice_to_swap, 0..self.data_count) |value, index| {
+                    long_data[index] = @byteSwap(value);
+                }
+            }
+        }
+
+        return long_data;
+    }
+};
+
+pub const IFD = struct {
+    ifd_offset: u32 = 0,
+    num_tag_entries: u16 = 0,
+    tags_map: std.AutoHashMap(TagId, TagField),
+    next_ifd_offset: u32 = 0,
+    stream: *ImageUnmanaged.Stream,
+    allocator: std.mem.Allocator,
+
+    pub fn init(stream: *ImageUnmanaged.Stream, allocator: std.mem.Allocator, ifd_offset: u32) !IFD {
+        return .{
+            .stream = stream,
+            .allocator = allocator,
+            .ifd_offset = ifd_offset,
+            .tags_map = std.AutoHashMap(TagId, TagField).init(allocator),
+        };
+    }
+
+    pub fn readTags(self: *IFD, endianess: std.builtin.Endian) !void {
+        const stream = self.stream;
+
+        try stream.seekTo(self.ifd_offset);
+        const reader = stream.reader();
+
+        const num_tag_entries = try reader.readInt(u16, endianess);
+        const tags_array: []u8 = try self.allocator.alloc(u8, @sizeOf(PackedTag) * num_tag_entries);
+        defer self.allocator.free(tags_array);
+        _ = try reader.readAll(tags_array);
+        const next_ifd_offset = try reader.readInt(u32, endianess);
+        const tags_list = @as(*const []PackedTag, @ptrCast(&tags_array[0..])).*;
+        // We should iterate through all IFD, but since we support
+        // only one right now, we just set next offset to 0.
+
+        for (0..num_tag_entries) |index| {
+            const tag = tags_list[index];
+            try self.tags_map.put(@enumFromInt(std.mem.toNative(u16, tag.tag_id, endianess)), TagField{
+                .data_type = std.mem.toNative(u16, tag.data_type, endianess),
+                .data_count = std.mem.toNative(u32, tag.data_count, endianess),
+                .data_offset = std.mem.toNative(u32, tag.data_offset, endianess),
+            });
+        }
+
+        self.num_tag_entries = num_tag_entries;
+        self.next_ifd_offset = next_ifd_offset;
+    }
+
+    pub fn deinit(self: *IFD) void {
+        self.tags_map.deinit();
+    }
+};

--- a/src/formats/tiff/types.zig
+++ b/src/formats/tiff/types.zig
@@ -115,7 +115,7 @@ pub const TagType = enum(u16) {
 };
 
 // Tag as found inside the TIFF file
-pub const PackedTag = struct {
+pub const PackedTag = extern struct {
     const size = 12;
 
     tag_id: u16 align(1),
@@ -128,7 +128,7 @@ pub const PackedTag = struct {
     }
 };
 
-pub const TagField = struct {
+pub const TagField = extern struct {
     data_type: u16 align(1),
     data_count: u32 align(1),
     data_offset: u32 align(1),

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -1,0 +1,40 @@
+const PixelFormat = zigimg.PixelFormat;
+const tiff = zigimg.formats.tiff;
+const color = zigimg.color;
+const zigimg = @import("../../zigimg.zig");
+const Image = zigimg.Image;
+const std = @import("std");
+const testing = std.testing;
+const helpers = @import("../helpers.zig");
+
+test "Should error on non TIFF images" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "bmp/simple_v4.bmp");
+    defer file.close();
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    var sgi_file = tiff.TIFF{};
+
+    const invalid_file = sgi_file.read(&stream_source, helpers.zigimg_test_allocator);
+    try helpers.expectError(invalid_file, Image.ReadError.InvalidData);
+}
+
+test "TIFF/LE monochrome black raw" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-raw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 640);
+    try helpers.expectEq(the_bitmap.height(), 426);
+    try testing.expect(pixels == .grayscale1);
+
+    try helpers.expectEq(pixels.grayscale1[0].value, 1);
+    try helpers.expectEq(pixels.grayscale1[2].value, 0);
+    try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 0);
+}

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -408,6 +408,20 @@ test "Should detect SGI properly" {
     }
 }
 
+test "Should detect TIFF properly" {
+    const image_tests = &[_][]const u8{
+        helpers.fixtures_path ++ "tiff/sample-uncompressed.tiff",
+    };
+
+    for (image_tests) |image_path| {
+        const format = try ImageUnmanaged.detectFormatFromFilePath(image_path);
+        try std.testing.expect(format == .tiff);
+
+        var test_image = try helpers.testImageFromFile(image_path);
+        defer test_image.deinit();
+    }
+}
+
 test "Should error on invalid file" {
     const invalidFile = helpers.testImageFromFile("tests/helpers.zig");
     try helpers.expectError(invalidFile, ImageError.Unsupported);

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -410,7 +410,8 @@ test "Should detect SGI properly" {
 
 test "Should detect TIFF properly" {
     const image_tests = &[_][]const u8{
-        helpers.fixtures_path ++ "tiff/sample-uncompressed.tiff",
+        // helpers.fixtures_path ++ "tiff/sample-uncompressed.tiff",
+        helpers.fixtures_path ++ "tiff/sample-monob-raw.tiff",
     };
 
     for (image_tests) |image_path| {

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -29,6 +29,7 @@ test {
         @import("tests/formats/ras_test.zig"),
         @import("tests/formats/sgi_test.zig"),
         @import("tests/formats/tga_test.zig"),
+        @import("tests/formats/tiff_test.zig"),
         @import("tests/formats/farbfeld_test.zig"),
         @import("tests/image_test.zig"),
         @import("tests/math_test.zig"),


### PR DESCRIPTION
This PR adds preliminary support for decoding [TIFF](https://en.wikipedia.org/wiki/TIFF) files.

- most _baseline_ tags are decoded
- both _little endian_ and _big endian_ files are supported
- only very basic monochrome uncompressed TIFF files can be decoded
- only the first image is decoded (TIFF can contain many)

Note: tests require the sample file added in this [PR](https://github.com/zigimg/test-suite/pull/28) to pass