### PR TITLE
tiff: fix short tags decoding, add grayscale8 support

### DIFF
--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -19,7 +19,7 @@ test "Should error on non TIFF images" {
     try helpers.expectError(invalid_file, Image.ReadError.InvalidData);
 }
 
-test "TIFF/LE monochrome black raw" {
+test "TIFF/LE monochrome black uncompressed" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-raw.tiff");
     defer file.close();
 
@@ -37,4 +37,25 @@ test "TIFF/LE monochrome black raw" {
     try helpers.expectEq(pixels.grayscale1[0].value, 1);
     try helpers.expectEq(pixels.grayscale1[2].value, 0);
     try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 0);
+}
+
+test "TIFF/LE grayscale8 uncompressed" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-grayscale8-raw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .grayscale8);
+
+    try helpers.expectEq(pixels.grayscale8[0].value, 76);
+    try helpers.expectEq(pixels.grayscale8[8].value, 149);
+    try helpers.expectEq(pixels.grayscale8[90].value, 0);
+    try helpers.expectEq(pixels.grayscale8[128 * 66 + 72].value, 149);
 }


### PR DESCRIPTION
Adds support for grayscale8 uncompressed files.

Note: this PR also fixes a bug in tag decoding: short tags had their value incorrectly shifted to the right which resulted in short tag values be zero. I thought this was ffmpeg producing wrong files but in the future I'd better trust ffmpeg than my code ;)