### PR TITLE
tiff: fix big endian conversion + single short/long tag arrays

### DIFF
--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -55,13 +55,13 @@ pub const TIFF = struct {
             const tag: TagField = tags_map.get(key.*).?;
             switch (key.*) {
                 .image_width => {
-                    bitmap.image_width = tag.toLongOrShort();
+                    bitmap.image_width = tag.toLongOrShort(endianess);
                 },
                 .image_height => {
-                    bitmap.image_height = tag.toLongOrShort();
+                    bitmap.image_height = tag.toLongOrShort(endianess);
                 },
                 .compression => {
-                    bitmap.compression = @enumFromInt(tag.toShort());
+                    bitmap.compression = @enumFromInt(tag.toShort(endianess));
                 },
                 .color_map => {
                     // get color_map data: TIFF stores components as 16-bit values
@@ -87,16 +87,16 @@ pub const TIFF = struct {
                     bitmap.strip_offsets = try tag.readTagData(stream, allocator, endianess);
                 },
                 .rows_per_strip => {
-                    bitmap.rows_per_strip = tag.toLongOrShort();
+                    bitmap.rows_per_strip = tag.toLongOrShort(endianess);
                 },
                 .photometric_interpretation => {
-                    bitmap.photometric_interpretation = tag.toShort();
+                    bitmap.photometric_interpretation = tag.toShort(endianess);
                 },
                 .samples_per_pixel => {
-                    bitmap.samples_per_pixel = tag.toShort();
+                    bitmap.samples_per_pixel = tag.toShort(endianess);
                 },
                 .resolution_unit => {
-                    bitmap.resolution_unit = @enumFromInt(tag.toShort());
+                    bitmap.resolution_unit = @enumFromInt(tag.toShort(endianess));
                 },
                 .new_subfile_type => {
                     bitmap.new_subfile_type = tag.toLong();
@@ -105,7 +105,7 @@ pub const TIFF = struct {
                     var bits_per_sample = &bitmap.bits_per_sample;
                     bits_per_sample.resize(tag.data_count);
                     switch (tag.data_count) {
-                        1 => bits_per_sample.data[0] = tag.toShort(),
+                        1 => bits_per_sample.data[0] = tag.toShort(endianess),
                         3 => {
                             const components_bits_per_sample = try tag.readTagData(stream, allocator, endianess);
                             defer allocator.free(components_bits_per_sample);

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -111,3 +111,84 @@ test "TIFF/LE 24-bit uncompressed" {
         try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
     }
 }
+
+test "TIFF/BE rgb24 gray single strip uncompressed" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/big-endian/sample-rgb24-single-strip.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .rgb24);
+
+    const indexes = [_]usize{ 0, 12, 24 };
+    const expected_colors = [_]u32{
+        0x4c4c4c,
+        0x959595,
+        0x0,
+    };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+    }
+}
+
+test "TIFF/BE rgb24 color single strip uncompressed" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/big-endian/sample-pal8-raw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .rgb24);
+
+    const indexes = [_]usize{ 0, 12, 24 };
+    const expected_colors = [_]u32{
+        0xff021d,
+        0xff37,
+        0x0,
+    };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+    }
+}
+
+test "TIFF/BE 24-bit uncompressed" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/big-endian/sample-rgb24-raw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 664);
+    try helpers.expectEq(the_bitmap.height(), 248);
+    try testing.expect(pixels == .rgb24);
+
+    const indexes = [_]usize{ 8_754, 43_352, 42_224 };
+    const expected_colors = [_]u32{
+        0x21282e,
+        0xe4ad38,
+        0xffffff,
+    };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+    }
+}


### PR DESCRIPTION
This PR fixes a few problems found while attempting to read big-endian tiff files:
- big-endian short tags weren't decoded properly on little endian hosts
- tiff specs states that tag data that is 4 bytes or less is stored directly in the tag's offset field: this includes array of 1 short/long elements

Note: it needs this [PR](https://github.com/zigimg/test-suite/pull/32) for the tests to pass