### PR TITLE
tiff: add packbits compression support

### DIFF
--- a/src/formats/tiff/types.zig
+++ b/src/formats/tiff/types.zig
@@ -69,11 +69,17 @@ pub const BitmapDescriptor = struct {
     // contains extra_samples description
     extra_samples: utils.FixedStorage(u16, 8) = .{},
 
+    planar_configuration: u16 = 1,
+
     pub fn debug(self: *BitmapDescriptor) void {
         std.log.debug("{}\n", .{self});
     }
 
     pub fn guessPixelFormat(self: *BitmapDescriptor) ImageReadError!PixelFormat {
+        // only raw and packbits compression supported for now
+        if (self.compression != .uncompressed and self.compression != .packbits)
+            return ImageError.Unsupported;
+
         switch (self.photometric_interpretation) {
             // bi-level/grayscale pictures
             0, 1 => {

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -214,3 +214,119 @@ test "TIFF/LE RGBA uncompressed" {
         try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
     }
 }
+
+test "TIFF/LE monochrome black packbits" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-packbits.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 640);
+    try helpers.expectEq(the_bitmap.height(), 426);
+    try testing.expect(pixels == .grayscale1);
+
+    try helpers.expectEq(pixels.grayscale1[0].value, 1);
+    try helpers.expectEq(pixels.grayscale1[2].value, 0);
+    try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 0);
+}
+
+test "TIFF/LE grayscale8 packbits" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-grayscale8-packbits.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .grayscale8);
+
+    try helpers.expectEq(pixels.grayscale8[0].value, 76);
+    try helpers.expectEq(pixels.grayscale8[8].value, 149);
+    try helpers.expectEq(pixels.grayscale8[90].value, 0);
+    try helpers.expectEq(pixels.grayscale8[128 * 66 + 72].value, 149);
+}
+
+test "TIFF/LE 8-bit with colormap packbits" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-pal8-packbits.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .indexed8);
+
+    const palette64 = pixels.indexed8.palette[64];
+
+    try helpers.expectEq(palette64.r, 255);
+    try helpers.expectEq(palette64.g, 0);
+    try helpers.expectEq(palette64.b, 0);
+
+    try helpers.expectEq(pixels.indexed8.indices[0], 64);
+    try helpers.expectEq(pixels.indexed8.indices[12], 128);
+}
+
+test "TIFF/LE 24-bit packbits" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-rgb24-packbits.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 664);
+    try helpers.expectEq(the_bitmap.height(), 248);
+    try testing.expect(pixels == .rgb24);
+
+    const indexes = [_]usize{ 8_754, 43_352, 42_224 };
+    const expected_colors = [_]u32{
+        0x21282e,
+        0xe4ad38,
+        0xffffff,
+    };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+    }
+}
+
+test "TIFF/LE RGBA packbits" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-rgba-packbits.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 32);
+    try helpers.expectEq(the_bitmap.height(), 32);
+    try testing.expect(pixels == .rgba32);
+
+    const indexes = [_]usize{ 100, 1000, 1018 };
+    const expected_colors = [_]u32{ 0xf6ff00, 0xbe0042, 0x2900d7 };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+    }
+}


### PR DESCRIPTION
Needs this [PR](https://github.com/zigimg/test-suite/pull/34) for the tests.