### PR TITLE
Tiff add lzw decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ Currently, this only supports a subset of PAMs where:
 #### What's supported:
 * bilevel, grayscale, palette and RGB(A) files
 * most _baseline_ tags
-* raw, PackBits, CCITT 1D files
+* Raw, LZW, PackBits, CCITT 1D files
 * big-endian (MM) and little-endian (II) files should both be decoded fine
 
 #### What's missing:
 * Tile-based files are not supported
 * YCbCr, CMJN and CIE Lab files are not supported
-* LZW, JPEG, CCITT Fax 3 / 4 are not supported yet
+* JPEG, CCITT Fax 3 / 4 are not supported yet
 
 #### Notes
 * Only the first IFD is decoded

--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -547,7 +547,7 @@ pub const GIF = struct {
                 return ImageUnmanaged.ReadError.InvalidData;
             }
 
-            var lzw_decoder = try lzw.Decoder(.little).init(self.allocator, lzw_minimum_code_size);
+            var lzw_decoder = try lzw.Decoder(.little).init(self.allocator, lzw_minimum_code_size, 0);
             defer lzw_decoder.deinit();
 
             var data_block_size = try context.reader.readByte();

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -349,3 +349,119 @@ test "TIFF/LE monochrome black CCITT" {
     try helpers.expectEq(pixels.grayscale1[0].value, 1);
     try helpers.expectEq(pixels.grayscale1[73 * 400 + 48].value, 0);
 }
+
+test "TIFF/LE monochrome black LZW" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-lzw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 640);
+    try helpers.expectEq(the_bitmap.height(), 426);
+    try testing.expect(pixels == .grayscale1);
+
+    try helpers.expectEq(pixels.grayscale1[0].value, 1);
+    try helpers.expectEq(pixels.grayscale1[2].value, 0);
+    try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 0);
+}
+
+test "TIFF/LE grayscale8 LZW" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-grayscale8-lzw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .grayscale8);
+
+    try helpers.expectEq(pixels.grayscale8[0].value, 76);
+    try helpers.expectEq(pixels.grayscale8[8].value, 149);
+    try helpers.expectEq(pixels.grayscale8[90].value, 0);
+    try helpers.expectEq(pixels.grayscale8[128 * 66 + 72].value, 149);
+}
+
+test "TIFF/LE 8-bit with colormap LZW" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-pal8-lzw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .indexed8);
+
+    const palette64 = pixels.indexed8.palette[64];
+
+    try helpers.expectEq(palette64.r, 255);
+    try helpers.expectEq(palette64.g, 0);
+    try helpers.expectEq(palette64.b, 0);
+
+    try helpers.expectEq(pixels.indexed8.indices[0], 64);
+    try helpers.expectEq(pixels.indexed8.indices[12], 128);
+}
+
+test "TIFF/LE 24-bit LZW" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-rgb24-lzw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 664);
+    try helpers.expectEq(the_bitmap.height(), 248);
+    try testing.expect(pixels == .rgb24);
+
+    const indexes = [_]usize{ 8_754, 43_352, 42_224 };
+    const expected_colors = [_]u32{
+        0x21282e,
+        0xe4ad38,
+        0xffffff,
+    };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+    }
+}
+
+test "TIFF/LE RGBA LZW" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-rgba-lzw.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 32);
+    try helpers.expectEq(the_bitmap.height(), 32);
+    try testing.expect(pixels == .rgba32);
+
+    const indexes = [_]usize{ 100, 1000, 1018 };
+    const expected_colors = [_]u32{ 0xf6ff00, 0xbe0042, 0x2900d7 };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+    }
+}


### PR DESCRIPTION
Adds LZW decompression support using the already written LZW decompressor that was used in GIF. It had to be slightly modified to work with TIFF.

I also added support for predictor which is often used in combination with LZW.

The tests need this [PR](https://github.com/zigimg/test-suite/pull/36) to pass.