### PR TITLE
tiff: add zlib deflate compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Currently, this only supports a subset of PAMs where:
 #### What's supported:
 * bilevel, grayscale, palette and RGB(A) files
 * most _baseline_ tags
-* Raw, LZW, PackBits, CCITT 1D files
+* Raw, LZW, Deflate, PackBits, CCITT 1D files
 * big-endian (MM) and little-endian (II) files should both be decoded fine
 
 #### What's missing:

--- a/src/formats/tiff/types.zig
+++ b/src/formats/tiff/types.zig
@@ -15,9 +15,11 @@ pub const CompressionType = enum(u16) {
     gp_4_fax = 4,
     lzw = 5,
     jpeg = 6,
+    deflate = 8,
     // old tag value used only in tiff v4
     uncompressed_old = 32771,
     packbits = 32773,
+    pixar_deflate = 32946,
 };
 
 pub const ResolutionUnit = enum(u16) {
@@ -113,8 +115,16 @@ pub const BitmapDescriptor = struct {
 
     pub fn guessPixelFormat(self: *BitmapDescriptor) ImageReadError!PixelFormat {
         // only raw, packbits, lzw and ccitt_rle compression supported for now
-        if (self.compression != .uncompressed and self.compression != .packbits and self.compression != .ccitt_rle and self.compression != .lzw)
-            return ImageError.Unsupported;
+        switch (self.compression) {
+            .uncompressed,
+            .packbits,
+            .ccitt_rle,
+            .lzw,
+            .deflate,
+            .pixar_deflate,
+            => {},
+            else => return ImageError.Unsupported,
+        }
 
         switch (self.photometric_interpretation) {
             // bi-level/grayscale pictures

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -465,3 +465,119 @@ test "TIFF/LE RGBA LZW" {
         try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
     }
 }
+
+test "TIFF/LE monochrome black Deflate" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-deflate.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 640);
+    try helpers.expectEq(the_bitmap.height(), 426);
+    try testing.expect(pixels == .grayscale1);
+
+    try helpers.expectEq(pixels.grayscale1[0].value, 1);
+    try helpers.expectEq(pixels.grayscale1[2].value, 0);
+    try helpers.expectEq(pixels.grayscale1[15 * 8 + 7].value, 0);
+}
+
+test "TIFF/LE grayscale8 Deflate" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-grayscale8-deflate.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .grayscale8);
+
+    try helpers.expectEq(pixels.grayscale8[0].value, 76);
+    try helpers.expectEq(pixels.grayscale8[8].value, 149);
+    try helpers.expectEq(pixels.grayscale8[90].value, 0);
+    try helpers.expectEq(pixels.grayscale8[128 * 66 + 72].value, 149);
+}
+
+test "TIFF/LE 8-bit with colormap Deflate" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-pal8-deflate.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 128);
+    try helpers.expectEq(the_bitmap.height(), 128);
+    try testing.expect(pixels == .indexed8);
+
+    const palette64 = pixels.indexed8.palette[64];
+
+    try helpers.expectEq(palette64.r, 255);
+    try helpers.expectEq(palette64.g, 0);
+    try helpers.expectEq(palette64.b, 0);
+
+    try helpers.expectEq(pixels.indexed8.indices[0], 64);
+    try helpers.expectEq(pixels.indexed8.indices[12], 128);
+}
+
+test "TIFF/LE 24-bit Deflate" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-rgb24-deflate.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 664);
+    try helpers.expectEq(the_bitmap.height(), 248);
+    try testing.expect(pixels == .rgb24);
+
+    const indexes = [_]usize{ 8_754, 43_352, 42_224 };
+    const expected_colors = [_]u32{
+        0x21282e,
+        0xe4ad38,
+        0xffffff,
+    };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+    }
+}
+
+test "TIFF/LE RGBA Deflate" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-rgba-deflate.tiff");
+    defer file.close();
+
+    var the_bitmap = tiff.TIFF{};
+
+    var stream_source = std.io.StreamSource{ .file = file };
+
+    const pixels = try the_bitmap.read(&stream_source, helpers.zigimg_test_allocator);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_bitmap.width(), 32);
+    try helpers.expectEq(the_bitmap.height(), 32);
+    try testing.expect(pixels == .rgba32);
+
+    const indexes = [_]usize{ 100, 1000, 1018 };
+    const expected_colors = [_]u32{ 0xf6ff00, 0xbe0042, 0x2900d7 };
+
+    for (expected_colors, indexes) |hex_color, index| {
+        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+    }
+}


### PR DESCRIPTION
This PR adds support for zlib/deflate-compressed tiff files. This is an Adobe extension to TIFF and is apparently common.

Needs this [PR](https://github.com/zigimg/test-suite/pull/37) for the tests.