### PR TITLE
Remove use of `usingnamespace` in `color.zig`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ pub fn example(allocator: std.mem.Allocator) !void {
     var palette_storage: [256]zigimg.color.Rgba32 = undefined;
     const palette = quantizer.makePalette(255, palette_storage[0..]);
 
-    const palette_index = try quantizer.getPaletteIndex(zigimg.color.Rgba32.initRgba(110, 0, 0, 255));
+    const palette_index = try quantizer.getPaletteIndex(zigimg.color.Rgba32.from.rgba(110, 0, 0, 255));
 }
 ```
 
@@ -623,11 +623,11 @@ You can get a color from a HTML hex string. The alpha component is always last. 
 
 ```zig
 pub fn example() !void {
-    const rgb24 = try zigimg.color.Rgb24.fromHtmlHex("#123499");
-    const rgba32 = try zigimg.color.Rgba32.fromHtmlHex("FF000045");
+    const rgb24 = try zigimg.color.Rgb24.from.htmlHex("#123499");
+    const rgba32 = try zigimg.color.Rgba32.from.htmlHex("FF000045");
 
-    const red_rgb24 = try zigimg.color.Rgb24.fromHtmlHex("#F00");
-    const blue_rgba32 = try zigimg.clor.Rgba32.fromHtmlHex("#00FA");
+    const red_rgb24 = try zigimg.color.Rgb24.from.htmlHex("#F00");
+    const blue_rgba32 = try zigimg.color.Rgba32.from.htmlHex("#00FA");
 }
 ```
 

--- a/src/OctTreeQuantizer.zig
+++ b/src/OctTreeQuantizer.zig
@@ -76,11 +76,11 @@ fn anyColorToRgb24(color_value: anytype) color.Rgb24 {
 
     const has_alpha_type = @hasField(T, "a");
     if (has_alpha_type) {
-        const premultiplied_alpha = color_value.toPremultipliedAlpha();
+        const premultiplied_alpha = color_value.to.premultipliedAlpha();
 
-        return color.Rgb24.fromU32Rgba(premultiplied_alpha.toU32Rgba());
+        return color.Rgb24.from.u32Rgba(premultiplied_alpha.to.u32Rgba());
     } else {
-        return color.Rgb24.fromU32Rgb(color_value.toU32Rgb());
+        return color.Rgb24.from.u32Rgb(color_value.to.u32Rgb());
     }
 }
 
@@ -112,7 +112,7 @@ const Node = struct {
     }
 
     pub fn getColor(self: Node) color.Rgba32 {
-        return color.Rgba32.initRgb(@intCast(self.red / self.reference_count), @intCast(self.green / self.reference_count), @intCast(self.blue / self.reference_count));
+        return color.Rgba32.from.rgb(@intCast(self.red / self.reference_count), @intCast(self.green / self.reference_count), @intCast(self.blue / self.reference_count));
     }
 
     pub fn addColor(self: *Node, source_color: anytype, level: i32, parent: *OctTreeQuantizer) Error!void {

--- a/src/PixelFormatConverter.zig
+++ b/src/PixelFormatConverter.zig
@@ -200,10 +200,10 @@ pub fn convert(allocator: std.mem.Allocator, source: *const color.PixelStorage, 
 
         conversionId(.grayscale16, .grayscale16Alpha) => GrayscaleToGrayscale(.grayscale16, .grayscale16Alpha).convert(source, &destination),
 
-        conversionId(.grayscale8Alpha, .grayscale16Alpha) => GreyscaleAlphaToGrayscaleAlpha(.grayscale8Alpha, .grayscale16Alpha).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .grayscale16Alpha) => GrayscaleAlphaToGrayscaleAlpha(.grayscale8Alpha, .grayscale16Alpha).convert(source, &destination),
 
-        // Greyscale large -> small
-        conversionId(.grayscale16Alpha, .grayscale8Alpha) => GreyscaleAlphaToGrayscaleAlpha(.grayscale16Alpha, .grayscale8Alpha).convert(source, &destination),
+        // Grayscale large -> small
+        conversionId(.grayscale16Alpha, .grayscale8Alpha) => GrayscaleAlphaToGrayscaleAlpha(.grayscale16Alpha, .grayscale8Alpha).convert(source, &destination),
         conversionId(.grayscale16Alpha, .grayscale16) => GrayscaleAlphaToGrayscale(.grayscale16Alpha, .grayscale16).convert(source, &destination),
         conversionId(.grayscale16Alpha, .grayscale8) => GrayscaleAlphaToGrayscale(.grayscale16Alpha, .grayscale8).convert(source, &destination),
         conversionId(.grayscale16Alpha, .grayscale4) => GrayscaleAlphaToGrayscale(.grayscale16Alpha, .grayscale4).convert(source, &destination),
@@ -232,94 +232,94 @@ pub fn convert(allocator: std.mem.Allocator, source: *const color.PixelStorage, 
         conversionId(.grayscale2, .grayscale1) => GrayscaleToGrayscale(.grayscale2, .grayscale1).convert(source, &destination),
 
         // Grayscale -> RGB332
-        conversionId(.grayscale1, .rgb332) => GreyscaleToRgbColor(.grayscale1, .rgb332).convert(source, &destination),
-        conversionId(.grayscale2, .rgb332) => GreyscaleToRgbColor(.grayscale2, .rgb332).convert(source, &destination),
-        conversionId(.grayscale4, .rgb332) => GreyscaleToRgbColor(.grayscale4, .rgb332).convert(source, &destination),
-        conversionId(.grayscale8, .rgb332) => GreyscaleToRgbColor(.grayscale8, .rgb332).convert(source, &destination),
-        conversionId(.grayscale16, .rgb332) => GreyscaleToRgbColor(.grayscale16, .rgb332).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .rgb332) => GreyscaleAlphaToRgbColor(.grayscale8Alpha, .rgb332).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .rgb332) => GreyscaleAlphaToRgbColor(.grayscale16Alpha, .rgb332).convert(source, &destination),
+        conversionId(.grayscale1, .rgb332) => GrayscaleToRgbColor(.grayscale1, .rgb332).convert(source, &destination),
+        conversionId(.grayscale2, .rgb332) => GrayscaleToRgbColor(.grayscale2, .rgb332).convert(source, &destination),
+        conversionId(.grayscale4, .rgb332) => GrayscaleToRgbColor(.grayscale4, .rgb332).convert(source, &destination),
+        conversionId(.grayscale8, .rgb332) => GrayscaleToRgbColor(.grayscale8, .rgb332).convert(source, &destination),
+        conversionId(.grayscale16, .rgb332) => GrayscaleToRgbColor(.grayscale16, .rgb332).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .rgb332) => GrayscaleAlphaToRgbColor(.grayscale8Alpha, .rgb332).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .rgb332) => GrayscaleAlphaToRgbColor(.grayscale16Alpha, .rgb332).convert(source, &destination),
 
         // Grayscale -> RGB555
-        conversionId(.grayscale1, .rgb555) => GreyscaleToRgbColor(.grayscale1, .rgb555).convert(source, &destination),
-        conversionId(.grayscale2, .rgb555) => GreyscaleToRgbColor(.grayscale2, .rgb555).convert(source, &destination),
-        conversionId(.grayscale4, .rgb555) => GreyscaleToRgbColor(.grayscale4, .rgb555).convert(source, &destination),
-        conversionId(.grayscale8, .rgb555) => GreyscaleToRgbColor(.grayscale8, .rgb555).convert(source, &destination),
-        conversionId(.grayscale16, .rgb555) => GreyscaleToRgbColor(.grayscale16, .rgb555).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .rgb555) => GreyscaleAlphaToRgbColor(.grayscale8Alpha, .rgb555).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .rgb555) => GreyscaleAlphaToRgbColor(.grayscale16Alpha, .rgb555).convert(source, &destination),
+        conversionId(.grayscale1, .rgb555) => GrayscaleToRgbColor(.grayscale1, .rgb555).convert(source, &destination),
+        conversionId(.grayscale2, .rgb555) => GrayscaleToRgbColor(.grayscale2, .rgb555).convert(source, &destination),
+        conversionId(.grayscale4, .rgb555) => GrayscaleToRgbColor(.grayscale4, .rgb555).convert(source, &destination),
+        conversionId(.grayscale8, .rgb555) => GrayscaleToRgbColor(.grayscale8, .rgb555).convert(source, &destination),
+        conversionId(.grayscale16, .rgb555) => GrayscaleToRgbColor(.grayscale16, .rgb555).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .rgb555) => GrayscaleAlphaToRgbColor(.grayscale8Alpha, .rgb555).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .rgb555) => GrayscaleAlphaToRgbColor(.grayscale16Alpha, .rgb555).convert(source, &destination),
 
         // Grayscale -> RGB565
-        conversionId(.grayscale1, .rgb565) => GreyscaleToRgbColor(.grayscale1, .rgb565).convert(source, &destination),
-        conversionId(.grayscale2, .rgb565) => GreyscaleToRgbColor(.grayscale2, .rgb565).convert(source, &destination),
-        conversionId(.grayscale4, .rgb565) => GreyscaleToRgbColor(.grayscale4, .rgb565).convert(source, &destination),
-        conversionId(.grayscale8, .rgb565) => GreyscaleToRgbColor(.grayscale8, .rgb565).convert(source, &destination),
-        conversionId(.grayscale16, .rgb565) => GreyscaleToRgbColor(.grayscale16, .rgb565).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .rgb565) => GreyscaleAlphaToRgbColor(.grayscale8Alpha, .rgb565).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .rgb565) => GreyscaleAlphaToRgbColor(.grayscale16Alpha, .rgb565).convert(source, &destination),
+        conversionId(.grayscale1, .rgb565) => GrayscaleToRgbColor(.grayscale1, .rgb565).convert(source, &destination),
+        conversionId(.grayscale2, .rgb565) => GrayscaleToRgbColor(.grayscale2, .rgb565).convert(source, &destination),
+        conversionId(.grayscale4, .rgb565) => GrayscaleToRgbColor(.grayscale4, .rgb565).convert(source, &destination),
+        conversionId(.grayscale8, .rgb565) => GrayscaleToRgbColor(.grayscale8, .rgb565).convert(source, &destination),
+        conversionId(.grayscale16, .rgb565) => GrayscaleToRgbColor(.grayscale16, .rgb565).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .rgb565) => GrayscaleAlphaToRgbColor(.grayscale8Alpha, .rgb565).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .rgb565) => GrayscaleAlphaToRgbColor(.grayscale16Alpha, .rgb565).convert(source, &destination),
 
         // Grayscale -> RGB24
-        conversionId(.grayscale1, .rgb24) => GreyscaleToRgbColor(.grayscale1, .rgb24).convert(source, &destination),
-        conversionId(.grayscale2, .rgb24) => GreyscaleToRgbColor(.grayscale2, .rgb24).convert(source, &destination),
-        conversionId(.grayscale4, .rgb24) => GreyscaleToRgbColor(.grayscale4, .rgb24).convert(source, &destination),
-        conversionId(.grayscale8, .rgb24) => GreyscaleToRgbColor(.grayscale8, .rgb24).convert(source, &destination),
-        conversionId(.grayscale16, .rgb24) => GreyscaleToRgbColor(.grayscale16, .rgb24).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .rgb24) => GreyscaleAlphaToRgbColor(.grayscale8Alpha, .rgb24).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .rgb24) => GreyscaleAlphaToRgbColor(.grayscale16Alpha, .rgb24).convert(source, &destination),
+        conversionId(.grayscale1, .rgb24) => GrayscaleToRgbColor(.grayscale1, .rgb24).convert(source, &destination),
+        conversionId(.grayscale2, .rgb24) => GrayscaleToRgbColor(.grayscale2, .rgb24).convert(source, &destination),
+        conversionId(.grayscale4, .rgb24) => GrayscaleToRgbColor(.grayscale4, .rgb24).convert(source, &destination),
+        conversionId(.grayscale8, .rgb24) => GrayscaleToRgbColor(.grayscale8, .rgb24).convert(source, &destination),
+        conversionId(.grayscale16, .rgb24) => GrayscaleToRgbColor(.grayscale16, .rgb24).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .rgb24) => GrayscaleAlphaToRgbColor(.grayscale8Alpha, .rgb24).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .rgb24) => GrayscaleAlphaToRgbColor(.grayscale16Alpha, .rgb24).convert(source, &destination),
 
         // Grayscale -> RGBA32
-        conversionId(.grayscale1, .rgba32) => GreyscaleToRgbaColor(.grayscale1, .rgba32).convert(source, &destination),
-        conversionId(.grayscale2, .rgba32) => GreyscaleToRgbaColor(.grayscale2, .rgba32).convert(source, &destination),
-        conversionId(.grayscale4, .rgba32) => GreyscaleToRgbaColor(.grayscale4, .rgba32).convert(source, &destination),
-        conversionId(.grayscale8, .rgba32) => GreyscaleToRgbaColor(.grayscale8, .rgba32).convert(source, &destination),
-        conversionId(.grayscale16, .rgba32) => GreyscaleToRgbaColor(.grayscale16, .rgba32).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .rgba32) => GreyscaleAlphaToRgbaColor(.grayscale8Alpha, .rgba32).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .rgba32) => GreyscaleAlphaToRgbaColor(.grayscale16Alpha, .rgba32).convert(source, &destination),
+        conversionId(.grayscale1, .rgba32) => GrayscaleToRgbaColor(.grayscale1, .rgba32).convert(source, &destination),
+        conversionId(.grayscale2, .rgba32) => GrayscaleToRgbaColor(.grayscale2, .rgba32).convert(source, &destination),
+        conversionId(.grayscale4, .rgba32) => GrayscaleToRgbaColor(.grayscale4, .rgba32).convert(source, &destination),
+        conversionId(.grayscale8, .rgba32) => GrayscaleToRgbaColor(.grayscale8, .rgba32).convert(source, &destination),
+        conversionId(.grayscale16, .rgba32) => GrayscaleToRgbaColor(.grayscale16, .rgba32).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .rgba32) => GrayscaleAlphaToRgbaColor(.grayscale8Alpha, .rgba32).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .rgba32) => GrayscaleAlphaToRgbaColor(.grayscale16Alpha, .rgba32).convert(source, &destination),
 
         // Grayscale -> BGR555
-        conversionId(.grayscale1, .bgr555) => GreyscaleToRgbColor(.grayscale1, .bgr555).convert(source, &destination),
-        conversionId(.grayscale2, .bgr555) => GreyscaleToRgbColor(.grayscale2, .bgr555).convert(source, &destination),
-        conversionId(.grayscale4, .bgr555) => GreyscaleToRgbColor(.grayscale4, .bgr555).convert(source, &destination),
-        conversionId(.grayscale8, .bgr555) => GreyscaleToRgbColor(.grayscale8, .bgr555).convert(source, &destination),
-        conversionId(.grayscale16, .bgr555) => GreyscaleToRgbColor(.grayscale16, .bgr555).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .bgr555) => GreyscaleAlphaToRgbColor(.grayscale8Alpha, .bgr555).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .bgr555) => GreyscaleAlphaToRgbColor(.grayscale16Alpha, .bgr555).convert(source, &destination),
+        conversionId(.grayscale1, .bgr555) => GrayscaleToRgbColor(.grayscale1, .bgr555).convert(source, &destination),
+        conversionId(.grayscale2, .bgr555) => GrayscaleToRgbColor(.grayscale2, .bgr555).convert(source, &destination),
+        conversionId(.grayscale4, .bgr555) => GrayscaleToRgbColor(.grayscale4, .bgr555).convert(source, &destination),
+        conversionId(.grayscale8, .bgr555) => GrayscaleToRgbColor(.grayscale8, .bgr555).convert(source, &destination),
+        conversionId(.grayscale16, .bgr555) => GrayscaleToRgbColor(.grayscale16, .bgr555).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .bgr555) => GrayscaleAlphaToRgbColor(.grayscale8Alpha, .bgr555).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .bgr555) => GrayscaleAlphaToRgbColor(.grayscale16Alpha, .bgr555).convert(source, &destination),
 
         // Grayscale -> BGR24
-        conversionId(.grayscale1, .bgr24) => GreyscaleToRgbColor(.grayscale1, .bgr24).convert(source, &destination),
-        conversionId(.grayscale2, .bgr24) => GreyscaleToRgbColor(.grayscale2, .bgr24).convert(source, &destination),
-        conversionId(.grayscale4, .bgr24) => GreyscaleToRgbColor(.grayscale4, .bgr24).convert(source, &destination),
-        conversionId(.grayscale8, .bgr24) => GreyscaleToRgbColor(.grayscale8, .bgr24).convert(source, &destination),
-        conversionId(.grayscale16, .bgr24) => GreyscaleToRgbColor(.grayscale16, .bgr24).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .bgr24) => GreyscaleAlphaToRgbColor(.grayscale8Alpha, .bgr24).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .bgr24) => GreyscaleAlphaToRgbColor(.grayscale16Alpha, .bgr24).convert(source, &destination),
+        conversionId(.grayscale1, .bgr24) => GrayscaleToRgbColor(.grayscale1, .bgr24).convert(source, &destination),
+        conversionId(.grayscale2, .bgr24) => GrayscaleToRgbColor(.grayscale2, .bgr24).convert(source, &destination),
+        conversionId(.grayscale4, .bgr24) => GrayscaleToRgbColor(.grayscale4, .bgr24).convert(source, &destination),
+        conversionId(.grayscale8, .bgr24) => GrayscaleToRgbColor(.grayscale8, .bgr24).convert(source, &destination),
+        conversionId(.grayscale16, .bgr24) => GrayscaleToRgbColor(.grayscale16, .bgr24).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .bgr24) => GrayscaleAlphaToRgbColor(.grayscale8Alpha, .bgr24).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .bgr24) => GrayscaleAlphaToRgbColor(.grayscale16Alpha, .bgr24).convert(source, &destination),
 
         // Grayscale -> BGRA32
-        conversionId(.grayscale1, .bgra32) => GreyscaleToRgbaColor(.grayscale1, .bgra32).convert(source, &destination),
-        conversionId(.grayscale2, .bgra32) => GreyscaleToRgbaColor(.grayscale2, .bgra32).convert(source, &destination),
-        conversionId(.grayscale4, .bgra32) => GreyscaleToRgbaColor(.grayscale4, .bgra32).convert(source, &destination),
-        conversionId(.grayscale8, .bgra32) => GreyscaleToRgbaColor(.grayscale8, .bgra32).convert(source, &destination),
-        conversionId(.grayscale16, .bgra32) => GreyscaleToRgbaColor(.grayscale16, .bgra32).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .bgra32) => GreyscaleAlphaToRgbaColor(.grayscale8Alpha, .bgra32).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .bgra32) => GreyscaleAlphaToRgbaColor(.grayscale16Alpha, .bgra32).convert(source, &destination),
+        conversionId(.grayscale1, .bgra32) => GrayscaleToRgbaColor(.grayscale1, .bgra32).convert(source, &destination),
+        conversionId(.grayscale2, .bgra32) => GrayscaleToRgbaColor(.grayscale2, .bgra32).convert(source, &destination),
+        conversionId(.grayscale4, .bgra32) => GrayscaleToRgbaColor(.grayscale4, .bgra32).convert(source, &destination),
+        conversionId(.grayscale8, .bgra32) => GrayscaleToRgbaColor(.grayscale8, .bgra32).convert(source, &destination),
+        conversionId(.grayscale16, .bgra32) => GrayscaleToRgbaColor(.grayscale16, .bgra32).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .bgra32) => GrayscaleAlphaToRgbaColor(.grayscale8Alpha, .bgra32).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .bgra32) => GrayscaleAlphaToRgbaColor(.grayscale16Alpha, .bgra32).convert(source, &destination),
 
         // Grayscale -> RGB48
-        conversionId(.grayscale1, .rgb48) => GreyscaleToRgbColor(.grayscale1, .rgb48).convert(source, &destination),
-        conversionId(.grayscale2, .rgb48) => GreyscaleToRgbColor(.grayscale2, .rgb48).convert(source, &destination),
-        conversionId(.grayscale4, .rgb48) => GreyscaleToRgbColor(.grayscale4, .rgb48).convert(source, &destination),
-        conversionId(.grayscale8, .rgb48) => GreyscaleToRgbColor(.grayscale8, .rgb48).convert(source, &destination),
-        conversionId(.grayscale16, .rgb48) => GreyscaleToRgbColor(.grayscale16, .rgb48).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .rgb48) => GreyscaleAlphaToRgbColor(.grayscale8Alpha, .rgb48).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .rgb48) => GreyscaleAlphaToRgbColor(.grayscale16Alpha, .rgb48).convert(source, &destination),
+        conversionId(.grayscale1, .rgb48) => GrayscaleToRgbColor(.grayscale1, .rgb48).convert(source, &destination),
+        conversionId(.grayscale2, .rgb48) => GrayscaleToRgbColor(.grayscale2, .rgb48).convert(source, &destination),
+        conversionId(.grayscale4, .rgb48) => GrayscaleToRgbColor(.grayscale4, .rgb48).convert(source, &destination),
+        conversionId(.grayscale8, .rgb48) => GrayscaleToRgbColor(.grayscale8, .rgb48).convert(source, &destination),
+        conversionId(.grayscale16, .rgb48) => GrayscaleToRgbColor(.grayscale16, .rgb48).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .rgb48) => GrayscaleAlphaToRgbColor(.grayscale8Alpha, .rgb48).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .rgb48) => GrayscaleAlphaToRgbColor(.grayscale16Alpha, .rgb48).convert(source, &destination),
 
         // Grayscale -> RGBA64
-        conversionId(.grayscale1, .rgba64) => GreyscaleToRgbaColor(.grayscale1, .rgba64).convert(source, &destination),
-        conversionId(.grayscale2, .rgba64) => GreyscaleToRgbaColor(.grayscale2, .rgba64).convert(source, &destination),
-        conversionId(.grayscale4, .rgba64) => GreyscaleToRgbaColor(.grayscale4, .rgba64).convert(source, &destination),
-        conversionId(.grayscale8, .rgba64) => GreyscaleToRgbaColor(.grayscale8, .rgba64).convert(source, &destination),
-        conversionId(.grayscale16, .rgba64) => GreyscaleToRgbaColor(.grayscale16, .rgba64).convert(source, &destination),
-        conversionId(.grayscale8Alpha, .rgba64) => GreyscaleAlphaToRgbaColor(.grayscale8Alpha, .rgba64).convert(source, &destination),
-        conversionId(.grayscale16Alpha, .rgba64) => GreyscaleAlphaToRgbaColor(.grayscale16Alpha, .rgba64).convert(source, &destination),
+        conversionId(.grayscale1, .rgba64) => GrayscaleToRgbaColor(.grayscale1, .rgba64).convert(source, &destination),
+        conversionId(.grayscale2, .rgba64) => GrayscaleToRgbaColor(.grayscale2, .rgba64).convert(source, &destination),
+        conversionId(.grayscale4, .rgba64) => GrayscaleToRgbaColor(.grayscale4, .rgba64).convert(source, &destination),
+        conversionId(.grayscale8, .rgba64) => GrayscaleToRgbaColor(.grayscale8, .rgba64).convert(source, &destination),
+        conversionId(.grayscale16, .rgba64) => GrayscaleToRgbaColor(.grayscale16, .rgba64).convert(source, &destination),
+        conversionId(.grayscale8Alpha, .rgba64) => GrayscaleAlphaToRgbaColor(.grayscale8Alpha, .rgba64).convert(source, &destination),
+        conversionId(.grayscale16Alpha, .rgba64) => GrayscaleAlphaToRgbaColor(.grayscale16Alpha, .rgba64).convert(source, &destination),
 
         // Grayscale -> Colorf32
         conversionId(.grayscale1, .float32) => grayscaleToColorf32(.grayscale1, source, &destination),
@@ -805,12 +805,12 @@ fn indexedToColorf32(comptime source_format: PixelFormat, source: *const color.P
 fn GrayscaleToGrayscale(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
     return struct {
         pub fn convert(source: *const color.PixelStorage, destination: *color.PixelStorage) void {
-            const source_greyscale = @field(source, getFieldNameFromPixelFormat(source_format));
+            const source_grayscale = @field(source, getFieldNameFromPixelFormat(source_format));
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const destination_type = @TypeOf(destination_pixels[0]);
 
-            for (0..source_greyscale.len) |index| {
-                destination_pixels[index] = grayscaleToGrayscale(destination_type, source_greyscale[index]);
+            for (0..source_grayscale.len) |index| {
+                destination_pixels[index] = grayscaleToGrayscale(destination_type, source_grayscale[index]);
             }
         }
     };
@@ -819,82 +819,82 @@ fn GrayscaleToGrayscale(comptime source_format: PixelFormat, comptime destinatio
 fn GrayscaleAlphaToGrayscale(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
     return struct {
         pub fn convert(source: *const color.PixelStorage, destination: *color.PixelStorage) void {
-            const source_greyscale = @field(source, getFieldNameFromPixelFormat(source_format));
+            const source_grayscale = @field(source, getFieldNameFromPixelFormat(source_format));
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const destination_type = @TypeOf(destination_pixels[0]);
 
-            for (0..source_greyscale.len) |index| {
-                destination_pixels[index] = grayscaleAlphaToGrayscale(destination_type, source_greyscale[index]);
+            for (0..source_grayscale.len) |index| {
+                destination_pixels[index] = grayscaleAlphaToGrayscale(destination_type, source_grayscale[index]);
             }
         }
     };
 }
 
-fn GreyscaleAlphaToGrayscaleAlpha(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
+fn GrayscaleAlphaToGrayscaleAlpha(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
     return struct {
         pub fn convert(source: *const color.PixelStorage, destination: *color.PixelStorage) void {
-            const source_greyscale = @field(source, getFieldNameFromPixelFormat(source_format));
+            const source_grayscale = @field(source, getFieldNameFromPixelFormat(source_format));
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const destination_type = @TypeOf(destination_pixels[0]);
 
-            for (0..source_greyscale.len) |index| {
-                destination_pixels[index] = grayscaleAlphaToGrayscaleAlpha(destination_type, source_greyscale[index]);
+            for (0..source_grayscale.len) |index| {
+                destination_pixels[index] = grayscaleAlphaToGrayscaleAlpha(destination_type, source_grayscale[index]);
             }
         }
     };
 }
 
-fn GreyscaleToRgbColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
+fn GrayscaleToRgbColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
     return struct {
         pub fn convert(source: *const color.PixelStorage, destination: *color.PixelStorage) void {
-            const source_greyscale = @field(source, getFieldNameFromPixelFormat(source_format));
+            const source_grayscale = @field(source, getFieldNameFromPixelFormat(source_format));
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const destination_type = @TypeOf(destination_pixels[0]);
 
-            for (0..source_greyscale.len) |index| {
-                destination_pixels[index] = grayscaleToRgb(destination_type, source_greyscale[index]);
+            for (0..source_grayscale.len) |index| {
+                destination_pixels[index] = grayscaleToRgb(destination_type, source_grayscale[index]);
             }
         }
     };
 }
 
-fn GreyscaleToRgbaColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
+fn GrayscaleToRgbaColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
     return struct {
         pub fn convert(source: *const color.PixelStorage, destination: *color.PixelStorage) void {
-            const source_greyscale = @field(source, getFieldNameFromPixelFormat(source_format));
+            const source_grayscale = @field(source, getFieldNameFromPixelFormat(source_format));
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const destination_type = @TypeOf(destination_pixels[0]);
 
-            for (0..source_greyscale.len) |index| {
-                destination_pixels[index] = grayscaleToRgba(destination_type, source_greyscale[index]);
+            for (0..source_grayscale.len) |index| {
+                destination_pixels[index] = grayscaleToRgba(destination_type, source_grayscale[index]);
             }
         }
     };
 }
 
-fn GreyscaleAlphaToRgbColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
+fn GrayscaleAlphaToRgbColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
     return struct {
         pub fn convert(source: *const color.PixelStorage, destination: *color.PixelStorage) void {
-            const source_greyscale = @field(source, getFieldNameFromPixelFormat(source_format));
+            const source_grayscale = @field(source, getFieldNameFromPixelFormat(source_format));
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const destination_type = @TypeOf(destination_pixels[0]);
 
-            for (0..source_greyscale.len) |index| {
-                destination_pixels[index] = grayscaleAlphaToRgb(destination_type, source_greyscale[index]);
+            for (0..source_grayscale.len) |index| {
+                destination_pixels[index] = grayscaleAlphaToRgb(destination_type, source_grayscale[index]);
             }
         }
     };
 }
 
-fn GreyscaleAlphaToRgbaColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
+fn GrayscaleAlphaToRgbaColor(comptime source_format: PixelFormat, comptime destination_format: PixelFormat) type {
     return struct {
         pub fn convert(source: *const color.PixelStorage, destination: *color.PixelStorage) void {
-            const source_greyscale = @field(source, getFieldNameFromPixelFormat(source_format));
+            const source_grayscale = @field(source, getFieldNameFromPixelFormat(source_format));
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const destination_type = @TypeOf(destination_pixels[0]);
 
-            for (0..source_greyscale.len) |index| {
-                destination_pixels[index] = grayscaleAlphaToRgba(destination_type, source_greyscale[index]);
+            for (0..source_grayscale.len) |index| {
+                destination_pixels[index] = grayscaleAlphaToRgba(destination_type, source_grayscale[index]);
             }
         }
     };

--- a/src/PixelFormatConverter.zig
+++ b/src/PixelFormatConverter.zig
@@ -653,102 +653,55 @@ fn getFieldNameFromPixelFormat(comptime source_format: PixelFormat) []const u8 {
 // Single color conversions
 // ========================
 fn rgbToRgb(comptime T: type, rgb: anytype) T {
-    return T{
-        .r = color.scaleToIntColor(std.meta.fieldInfo(T, .r).type, rgb.r),
-        .g = color.scaleToIntColor(std.meta.fieldInfo(T, .g).type, rgb.g),
-        .b = color.scaleToIntColor(std.meta.fieldInfo(T, .b).type, rgb.b),
-    };
+    return T.from.color(rgb);
 }
 
 fn rgbToRgba(comptime T: type, rgb: anytype) T {
-    return T{
-        .r = color.scaleToIntColor(std.meta.fieldInfo(T, .r).type, rgb.r),
-        .g = color.scaleToIntColor(std.meta.fieldInfo(T, .g).type, rgb.g),
-        .b = color.scaleToIntColor(std.meta.fieldInfo(T, .b).type, rgb.b),
-        .a = 255,
-    };
+    return T.from.color(rgb);
 }
 
 fn rgbaToRgb(comptime T: type, rgba: anytype) T {
-    const alpha = color.toF32Color(rgba.a);
-
-    return T{
-        .r = color.toIntColor(std.meta.fieldInfo(T, .r).type, color.toF32Color(rgba.r) * alpha),
-        .g = color.toIntColor(std.meta.fieldInfo(T, .g).type, color.toF32Color(rgba.g) * alpha),
-        .b = color.toIntColor(std.meta.fieldInfo(T, .b).type, color.toF32Color(rgba.b) * alpha),
-    };
+    return T.from.color(rgba.to.premultipliedAlpha());
 }
 
 fn rgbaToRgba(comptime T: type, rgba: anytype) T {
-    return T{
-        .r = color.scaleToIntColor(std.meta.fieldInfo(T, .r).type, rgba.r),
-        .g = color.scaleToIntColor(std.meta.fieldInfo(T, .g).type, rgba.g),
-        .b = color.scaleToIntColor(std.meta.fieldInfo(T, .b).type, rgba.b),
-        .a = color.scaleToIntColor(std.meta.fieldInfo(T, .a).type, rgba.a),
+    return T.from.color(rgba);
+}
+
+fn grayscaleToGrayscale(comptime T: type, gray: anytype) T {
+    const scaleValue = color.ScaleValue(std.meta.fieldInfo(T, .value).type);
+    return .{ .value = scaleValue(gray.value) };
+}
+
+fn grayscaleAlphaToGrayscale(comptime T: type, gray: anytype) T {
+    const toF32 = color.ScaleValue(f32);
+    const scaleValue = color.ScaleValue(std.meta.fieldInfo(T, .value).type);
+    return .{ .value = scaleValue(toF32(gray.value) * toF32(gray.alpha)) };
+}
+
+fn grayscaleAlphaToGrayscaleAlpha(comptime T: type, gray: anytype) T {
+    const scaleValue = color.ScaleValue(std.meta.fieldInfo(T, .value).type);
+    const scaleAlpha = color.ScaleValue(std.meta.fieldInfo(T, .alpha).type);
+    return .{
+        .value = scaleValue(gray.value),
+        .alpha = scaleAlpha(gray.alpha),
     };
 }
 
-fn grayscaleToGrayscale(comptime T: type, grey: anytype) T {
-    return T{
-        .value = color.scaleToIntColor(std.meta.fieldInfo(T, .value).type, grey.value),
-    };
+fn grayscaleToRgb(comptime T: type, gray: anytype) T {
+    return T.from.grayscale(gray);
 }
 
-fn grayscaleAlphaToGrayscale(comptime T: type, grey: anytype) T {
-    const alpha = color.toF32Color(grey.alpha);
-    return T{
-        .value = color.toIntColor(std.meta.fieldInfo(T, .value).type, color.toF32Color(grey.value) * alpha),
-    };
+fn grayscaleToRgba(comptime T: type, gray: anytype) T {
+    return T.from.grayscale(gray);
 }
 
-fn grayscaleAlphaToGrayscaleAlpha(comptime T: type, grey: anytype) T {
-    return T{
-        .value = color.scaleToIntColor(std.meta.fieldInfo(T, .value).type, grey.value),
-        .alpha = color.scaleToIntColor(std.meta.fieldInfo(T, .alpha).type, grey.alpha),
-    };
+fn grayscaleAlphaToRgb(comptime T: type, gray: anytype) T {
+    return T.from.grayscale(grayscaleAlphaToGrayscale(color.Grayscalef32, gray));
 }
 
-fn grayscaleToRgb(comptime T: type, grey: anytype) T {
-    const grey_value = grey.value;
-
-    return T{
-        .r = color.scaleToIntColor(std.meta.fieldInfo(T, .r).type, grey_value),
-        .g = color.scaleToIntColor(std.meta.fieldInfo(T, .g).type, grey_value),
-        .b = color.scaleToIntColor(std.meta.fieldInfo(T, .b).type, grey_value),
-    };
-}
-
-fn grayscaleToRgba(comptime T: type, grey: anytype) T {
-    const grey_value = grey.value;
-
-    return T{
-        .r = color.scaleToIntColor(std.meta.fieldInfo(T, .r).type, grey_value),
-        .g = color.scaleToIntColor(std.meta.fieldInfo(T, .g).type, grey_value),
-        .b = color.scaleToIntColor(std.meta.fieldInfo(T, .b).type, grey_value),
-        .a = 255,
-    };
-}
-
-fn grayscaleAlphaToRgb(comptime T: type, grey: anytype) T {
-    const alpha = color.toF32Color(grey.alpha);
-    const grey_f32 = color.toF32Color(grey.value);
-
-    return T{
-        .r = color.toIntColor(std.meta.fieldInfo(T, .r).type, grey_f32 * alpha),
-        .g = color.toIntColor(std.meta.fieldInfo(T, .g).type, grey_f32 * alpha),
-        .b = color.toIntColor(std.meta.fieldInfo(T, .b).type, grey_f32 * alpha),
-    };
-}
-
-fn grayscaleAlphaToRgba(comptime T: type, grey: anytype) T {
-    const grey_value = grey.value;
-
-    return T{
-        .r = color.scaleToIntColor(std.meta.fieldInfo(T, .r).type, grey_value),
-        .g = color.scaleToIntColor(std.meta.fieldInfo(T, .g).type, grey_value),
-        .b = color.scaleToIntColor(std.meta.fieldInfo(T, .b).type, grey_value),
-        .a = color.scaleToIntColor(std.meta.fieldInfo(T, .a).type, grey.alpha),
-    };
+fn grayscaleAlphaToRgba(comptime T: type, gray: anytype) T {
+    return T.from.grayscale(gray);
 }
 
 // ===================
@@ -842,7 +795,7 @@ fn indexedToColorf32(comptime source_format: PixelFormat, source: *const color.P
     const source_indexed = @field(source, getFieldNameFromPixelFormat(source_format));
 
     for (0..source_indexed.indices.len) |index| {
-        destination.float32[index] = source_indexed.palette[source_indexed.indices[index]].toColorf32();
+        destination.float32[index] = source_indexed.palette[source_indexed.indices[index]].to.color(color.Colorf32);
     }
 }
 
@@ -1035,17 +988,18 @@ fn RgbColorToGrayscale(comptime source_format: PixelFormat, comptime destination
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const DestinationType = @TypeOf(destination_pixels[0]);
 
+            const scaleValue = color.ScaleValue(std.meta.fieldInfo(DestinationType, .value).type);
+
             for (0..source_rgb.len) |index| {
-                const source_float4 = source_rgb[index].toColorf32().toFloat4();
+                const source_float4 = source_rgb[index].to.float4();
 
                 const converted_float4 = GrayscaleFactors * source_float4;
 
-                const grayscale = color.toIntColor(
-                    std.meta.fieldInfo(DestinationType, .value).type,
+                const grayscale = scaleValue(
                     (converted_float4[0] + converted_float4[1] + converted_float4[2]) * converted_float4[3],
                 );
 
-                destination_pixels[index] = DestinationType{ .value = grayscale };
+                destination_pixels[index] = .{ .value = grayscale };
             }
         }
     };
@@ -1058,16 +1012,19 @@ fn RgbColorToGrayscaleAlpha(comptime source_format: PixelFormat, comptime destin
             var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
             const DestinationType = @TypeOf(destination_pixels[0]);
 
+            const scaleValue = color.ScaleValue(std.meta.fieldInfo(DestinationType, .value).type);
+            const scaleAlpha = color.ScaleValue(std.meta.fieldInfo(DestinationType, .alpha).type);
+
             for (0..source_rgb.len) |index| {
-                const source_float4 = source_rgb[index].toColorf32().toFloat4();
+                const source_float4 = source_rgb[index].to.float4();
 
                 const converted_float4 = GrayscaleFactors * source_float4;
 
-                const grayscale = color.toIntColor(std.meta.fieldInfo(DestinationType, .value).type, converted_float4[0] + converted_float4[1] + converted_float4[2]);
+                const grayscale = scaleValue(converted_float4[0] + converted_float4[1] + converted_float4[2]);
 
                 destination_pixels[index] = DestinationType{
                     .value = grayscale,
-                    .alpha = color.toIntColor(std.meta.fieldInfo(DestinationType, .alpha).type, converted_float4[3]),
+                    .alpha = scaleAlpha(converted_float4[3]),
                 };
             }
         }
@@ -1134,7 +1091,7 @@ fn rgbColorToColorf32(comptime source_format: PixelFormat, source: *const color.
     const source_rgb = @field(source, getFieldNameFromPixelFormat(source_format));
 
     for (0..source_rgb.len) |index| {
-        destination.float32[index] = source_rgb[index].toColorf32();
+        destination.float32[index] = source_rgb[index].to.color(color.Colorf32);
     }
 }
 
@@ -1211,7 +1168,7 @@ fn rgba32ToColorf32(comptime source_format: PixelFormat, source: *const color.Pi
 
     // Process the rest sequentially
     while (index < source_pixels.len) : (index += 1) {
-        destination_pixels[index] = source_pixels[index].toColorf32();
+        destination_pixels[index] = source_pixels[index].to.color(color.Colorf32);
     }
 }
 
@@ -1258,7 +1215,7 @@ fn bgra32ToColorf32(comptime source_format: PixelFormat, source: *const color.Pi
 
     // Process the rest sequentially
     while (index < source_pixels.len) : (index += 1) {
-        destination_pixels[index] = source_pixels[index].toColorf32();
+        destination_pixels[index] = source_pixels[index].to.color(color.Colorf32);
     }
 }
 
@@ -1297,20 +1254,11 @@ fn RgbColorToIndexed(comptime source_format: PixelFormat, comptime destination_f
 // Colorf32 (float32) color conversions
 // ====================================
 fn colorf32ToRgb(comptime T: type, source: color.Colorf32) T {
-    return T{
-        .r = color.toIntColor(std.meta.fieldInfo(T, .r).type, source.r),
-        .g = color.toIntColor(std.meta.fieldInfo(T, .g).type, source.g),
-        .b = color.toIntColor(std.meta.fieldInfo(T, .b).type, source.b),
-    };
+    return T.from.color(source);
 }
 
 fn colorf32ToRgba(comptime T: type, source: color.Colorf32) T {
-    return T{
-        .r = color.toIntColor(std.meta.fieldInfo(T, .r).type, source.r),
-        .g = color.toIntColor(std.meta.fieldInfo(T, .g).type, source.g),
-        .b = color.toIntColor(std.meta.fieldInfo(T, .b).type, source.b),
-        .a = color.toIntColor(std.meta.fieldInfo(T, .a).type, source.a),
-    };
+    return T.from.color(source);
 }
 
 fn colorf32ToRgbColor(comptime destination_format: PixelFormat, source: *const color.PixelStorage, destination: *color.PixelStorage) void {
@@ -1421,13 +1369,14 @@ fn colorf32ToGrayscale(comptime destination_format: PixelFormat, source: *const 
     var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
     const DestinationType = @TypeOf(destination_pixels[0]);
 
+    const scaleValue = color.ScaleValue(std.meta.fieldInfo(DestinationType, .value).type);
+
     for (0..source_pixels.len) |index| {
-        const source_float4 = source_pixels[index].toFloat4();
+        const source_float4 = source_pixels[index].to.float4();
 
         const converted_float4 = GrayscaleFactors * source_float4;
 
-        const grayscale = color.toIntColor(
-            std.meta.fieldInfo(DestinationType, .value).type,
+        const grayscale = scaleValue(
             (converted_float4[0] + converted_float4[1] + converted_float4[2]) * converted_float4[3],
         );
 
@@ -1441,16 +1390,19 @@ fn colorf32ToGrayscaleAlpha(comptime destination_format: PixelFormat, source: *c
     var destination_pixels = @field(destination, getFieldNameFromPixelFormat(destination_format));
     const DestinationType = @TypeOf(destination_pixels[0]);
 
+    const scaleValue = color.ScaleValue(std.meta.fieldInfo(DestinationType, .value).type);
+    const scaleAlpha = color.ScaleValue(std.meta.fieldInfo(DestinationType, .alpha).type);
+
     for (0..source_pixels.len) |index| {
-        const source_float4 = source_pixels[index].toFloat4();
+        const source_float4 = source_pixels[index].to.float4();
 
         const converted_float4 = GrayscaleFactors * source_float4;
 
-        const grayscale = color.toIntColor(std.meta.fieldInfo(DestinationType, .value).type, converted_float4[0] + converted_float4[1] + converted_float4[2]);
+        const grayscale = scaleValue(converted_float4[0] + converted_float4[1] + converted_float4[2]);
 
         destination_pixels[index] = DestinationType{
             .value = grayscale,
-            .alpha = color.toIntColor(std.meta.fieldInfo(DestinationType, .alpha).type, converted_float4[3]),
+            .alpha = scaleAlpha(converted_float4[3]),
         };
     }
 }

--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -674,22 +674,22 @@ pub const GIF = struct {
         switch (current_frame.pixels) {
             .indexed1 => |pixels| {
                 for (0..@min(effective_color_table.len, pixels.palette.len)) |index| {
-                    pixels.palette[index] = color.Rgba32.fromU32Rgb(effective_color_table[index].toU32Rgb());
+                    pixels.palette[index] = color.Rgba32.from.u32Rgb(effective_color_table[index].to.u32Rgb());
                 }
             },
             .indexed2 => |pixels| {
                 for (0..@min(effective_color_table.len, pixels.palette.len)) |index| {
-                    pixels.palette[index] = color.Rgba32.fromU32Rgb(effective_color_table[index].toU32Rgb());
+                    pixels.palette[index] = color.Rgba32.from.u32Rgb(effective_color_table[index].to.u32Rgb());
                 }
             },
             .indexed4 => |pixels| {
                 for (0..@min(effective_color_table.len, pixels.palette.len)) |index| {
-                    pixels.palette[index] = color.Rgba32.fromU32Rgb(effective_color_table[index].toU32Rgb());
+                    pixels.palette[index] = color.Rgba32.from.u32Rgb(effective_color_table[index].to.u32Rgb());
                 }
             },
             .indexed8 => |pixels| {
                 for (0..@min(effective_color_table.len, pixels.palette.len)) |index| {
-                    pixels.palette[index] = color.Rgba32.fromU32Rgb(effective_color_table[index].toU32Rgb());
+                    pixels.palette[index] = color.Rgba32.from.u32Rgb(effective_color_table[index].to.u32Rgb());
                 }
             },
             else => {},
@@ -707,7 +707,7 @@ pub const GIF = struct {
             .indexed4 => |pixels| @memset(pixels.indices, @intCast(background_color_index)),
             .indexed8 => |pixels| @memset(pixels.indices, background_color_index),
             .rgb24 => |pixels| @memset(pixels, effective_color_table[background_color_index]),
-            .rgba32 => |pixels| @memset(pixels, color.Rgba32.fromU32Rgba(effective_color_table[background_color_index].toU32Rgb())),
+            .rgba32 => |pixels| @memset(pixels, color.Rgba32.from.u32Rgba(effective_color_table[background_color_index].to.u32Rgb())),
             else => std.debug.panic("Pixel format {s} not supported", .{@tagName(current_frame.pixels)}),
         }
     }
@@ -787,7 +787,7 @@ pub const GIF = struct {
                         }
 
                         if (background_color_index < effective_color_table.len) {
-                            pixels[target_index] = color.Rgba32.fromU32Rgba(effective_color_table[background_color_index].toU32Rgba());
+                            pixels[target_index] = color.Rgba32.from.u32Rgba(effective_color_table[background_color_index].to.u32Rgba());
                         }
                     },
                     else => {
@@ -928,7 +928,7 @@ pub const GIF = struct {
 
                 const pixel_index = sub_image.pixels[source_index];
                 if (pixel_index < effective_color_table.len) {
-                    pixels[target_index] = color.Rgba32.fromU32Rgba(effective_color_table[pixel_index].toU32Rgba());
+                    pixels[target_index] = color.Rgba32.from.u32Rgba(effective_color_table[pixel_index].to.u32Rgba());
                 }
             },
             else => {
@@ -955,8 +955,8 @@ pub const GIF = struct {
             .indexed2 => |pixels| @memset(pixels.indices, 0),
             .indexed4 => |pixels| @memset(pixels.indices, 0),
             .indexed8 => |pixels| @memset(pixels.indices, 0),
-            .rgb24 => |pixels| @memset(pixels, color.Rgb24.fromU32Rgb(0)),
-            .rgba32 => |pixels| @memset(pixels, color.Rgba32.fromU32Rgba(0)),
+            .rgb24 => |pixels| @memset(pixels, color.Rgb24.from.u32Rgb(0)),
+            .rgba32 => |pixels| @memset(pixels, color.Rgba32.from.u32Rgba(0)),
             else => std.debug.panic("Pixel format {} not supported", .{pixel_format}),
         }
 

--- a/src/formats/iff.zig
+++ b/src/formats/iff.zig
@@ -217,7 +217,7 @@ pub fn extendEhbPalette(palette: *utils.FixedStorage(color.Rgba32, 256)) void {
     for (0..32) |i| {
         const c = data[i];
         // EHB mode extends the palette to 64 colors by adding 32 darker colors
-        data[i + 32] = color.Rgba32.initRgb(c.r >> 1, c.g >> 1, c.b >> 1);
+        data[i + 32] = color.Rgba32.from.rgb(c.r >> 1, c.g >> 1, c.b >> 1);
     }
 }
 
@@ -459,7 +459,7 @@ pub const IFF = struct {
 
         for (0..num_colors) |i| {
             const c = try utils.readStruct(reader, color.Rgb24, .little);
-            palette[i] = color.Rgba32.fromU32Rgb(c.toU32Rgb());
+            palette[i] = color.Rgba32.from.u32Rgb(c.to.u32Rgb());
         }
         self.cmap_bits = std.math.log2_int_ceil(usize, palette.len);
     }
@@ -544,13 +544,13 @@ pub const IFF = struct {
                     // Keep color: in HAM mode, current color
                     // may be based on previous color instead of coming from
                     // the palette.
-                    var previous_color = color.Rgb24.initRgb(0, 0, 0);
+                    var previous_color = color.Rgb24.from.rgb(0, 0, 0);
                     for (0..self.width()) |col| {
                         const index = (self.width() * row * pixel_size) + (col * pixel_size);
                         if (planes == 24) {
-                            previous_color = color.Rgb24.initRgb(chunky_buffer[index], chunky_buffer[index + 1], chunky_buffer[index + 2]);
+                            previous_color = color.Rgb24.from.rgb(chunky_buffer[index], chunky_buffer[index + 1], chunky_buffer[index + 2]);
                         } else if (chunky_buffer[index] < palette.len) {
-                            previous_color = color.Rgb24.fromU32Rgba(palette[chunky_buffer[index]].toU32Rgba());
+                            previous_color = color.Rgb24.from.u32Rgba(palette[chunky_buffer[index]].to.u32Rgba());
                         } else if (is_ham) {
                             // Get the control bit which will tell use how current pixel should be calculated
                             const control: u8 = (chunky_buffer[index] >> cmap_bits) & 0x3;

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -583,7 +583,7 @@ pub const PCX = struct {
                 // Write VGA palette
                 try writer.writeByte(VGAPaletteIdentifier);
                 for (pixels.indexed8.palette) |current_entry| {
-                    const rgb24_color = color.Rgb24.fromU32Rgba(current_entry.toU32Rgba());
+                    const rgb24_color = color.Rgb24.from.u32Rgba(current_entry.to.u32Rgba());
                     try utils.writeStruct(writer, rgb24_color, .little);
                 }
             },

--- a/src/formats/png/reader.zig
+++ b/src/formats/png/reader.zig
@@ -308,7 +308,7 @@ fn readAllData(
         };
 
         for (palette, 0..) |entry, n| {
-            destination_palette[n] = color.Rgba32.initRgb(entry.r, entry.g, entry.b);
+            destination_palette[n] = color.Rgba32.from.rgb(entry.r, entry.g, entry.b);
         }
 
         try callPaletteProcessors(options, destination_palette);

--- a/src/formats/ras.zig
+++ b/src/formats/ras.zig
@@ -157,7 +157,7 @@ pub const RAS = struct {
 
                 for (0..colors) |index| {
                     // palette components are stored in a separate plane
-                    palette[index] = color.Rgba32.initRgb(buffer[index], buffer[index + colors], buffer[index + 2 * colors]);
+                    palette[index] = color.Rgba32.from.rgb(buffer[index], buffer[index + colors], buffer[index + 2 * colors]);
                 }
             },
             else => return ImageError.Unsupported,
@@ -234,14 +234,14 @@ pub const RAS = struct {
                     for (0..image_height) |y| {
                         for (0..image_width) |x| {
                             const offset = y * image_width + x;
-                            storage.*[offset] = color.Rgba32.initRgb(buffer[offset * pixel_size + 1], buffer[offset * pixel_size + 2], buffer[offset * pixel_size + 3]);
+                            storage.*[offset] = color.Rgba32.from.rgb(buffer[offset * pixel_size + 1], buffer[offset * pixel_size + 2], buffer[offset * pixel_size + 3]);
                         }
                     }
                 } else {
                     for (0..image_height) |y| {
                         for (0..image_width) |x| {
                             const offset = y * image_width + x;
-                            storage.*[offset] = color.Rgba32.initRgb(buffer[offset * pixel_size + 3], buffer[offset * pixel_size + 2], buffer[offset * pixel_size + 1]);
+                            storage.*[offset] = color.Rgba32.from.rgb(buffer[offset * pixel_size + 3], buffer[offset * pixel_size + 2], buffer[offset * pixel_size + 1]);
                         }
                     }
                 }

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -7,6 +7,9 @@ const std = @import("std");
 const simd = @import("../simd.zig");
 const utils = @import("../utils.zig");
 
+const toU5 = color.ScaleValue(u5);
+const toU8 = color.ScaleValue(u8);
+
 pub const TGAImageType = packed struct(u8) {
     indexed: bool = false,
     truecolor: bool = false,
@@ -994,9 +997,9 @@ pub const TGA = struct {
         while (data_index < data_end) : (data_index += 1) {
             const read_color = try utils.readStruct(reader, color.Rgb555, .little);
 
-            data.palette[data_index].r = color.scaleToIntColor(u8, read_color.r);
-            data.palette[data_index].g = color.scaleToIntColor(u8, read_color.g);
-            data.palette[data_index].b = color.scaleToIntColor(u8, read_color.b);
+            data.palette[data_index].r = toU8(read_color.r);
+            data.palette[data_index].g = toU8(read_color.g);
+            data.palette[data_index].b = toU8(read_color.b);
             data.palette[data_index].a = 255;
         }
     }
@@ -1375,9 +1378,9 @@ pub const TGA = struct {
 
         while (data_index < data_end) : (data_index += 1) {
             const converted_color = color.Rgb555{
-                .r = color.scaleToIntColor(u5, indexed.palette[data_index].r),
-                .g = color.scaleToIntColor(u5, indexed.palette[data_index].g),
-                .b = color.scaleToIntColor(u5, indexed.palette[data_index].b),
+                .r = toU5(indexed.palette[data_index].r),
+                .g = toU5(indexed.palette[data_index].g),
+                .b = toU5(indexed.palette[data_index].b),
             };
 
             try writer.writeInt(u16, @as(u15, @bitCast(converted_color)), .little);

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -81,7 +81,7 @@ pub const TIFF = struct {
                     color_map.resize(num_colors);
                     for (0..num_colors) |color_index| {
                         // TIFF colors are stored as 16-bit components
-                        color_map.data[color_index] = color.Rgba32.initRgb(@truncate(palette[color_index] / 256), @truncate(palette[color_index + num_colors] / 256), @truncate(palette[color_index + num_colors * 2] / 256));
+                        color_map.data[color_index] = color.Rgba32.from.rgb(@truncate(palette[color_index] / 256), @truncate(palette[color_index + num_colors] / 256), @truncate(palette[color_index + num_colors * 2] / 256));
                     }
                 },
                 .strip_byte_counts => {
@@ -273,10 +273,10 @@ pub const TIFF = struct {
                     var strip_index: usize = 0;
                     while (strip_index < byte_count) : (strip_index += 3) {
                         if (predictor == 1 or pixel_index % image_width == 0) {
-                            storage[pixel_index] = color.Rgb24.initRgb(strip_buffer[strip_index], strip_buffer[strip_index + 1], strip_buffer[strip_index + 2]);
+                            storage[pixel_index] = color.Rgb24.from.rgb(strip_buffer[strip_index], strip_buffer[strip_index + 1], strip_buffer[strip_index + 2]);
                         } else {
                             const previous_color = storage[pixel_index - 1];
-                            storage[pixel_index] = color.Rgb24.initRgb(previous_color.r +% strip_buffer[strip_index], previous_color.g +% strip_buffer[strip_index + 1], previous_color.b +% strip_buffer[strip_index + 2]);
+                            storage[pixel_index] = color.Rgb24.from.rgb(previous_color.r +% strip_buffer[strip_index], previous_color.g +% strip_buffer[strip_index + 1], previous_color.b +% strip_buffer[strip_index + 2]);
                         }
                         pixel_index += 1;
                         if (pixel_index >= storage.len)
@@ -287,10 +287,10 @@ pub const TIFF = struct {
                     var strip_index: usize = 0;
                     while (strip_index < byte_count) : (strip_index += 4) {
                         if (predictor == 1 or pixel_index % image_width == 0) {
-                            storage[pixel_index] = color.Rgba32.initRgba(strip_buffer[strip_index], strip_buffer[strip_index + 1], strip_buffer[strip_index + 2], strip_buffer[strip_index + 3]);
+                            storage[pixel_index] = color.Rgba32.from.rgba(strip_buffer[strip_index], strip_buffer[strip_index + 1], strip_buffer[strip_index + 2], strip_buffer[strip_index + 3]);
                         } else {
                             const previous_color = storage[pixel_index - 1];
-                            storage[pixel_index] = color.Rgba32.initRgba(previous_color.r +% strip_buffer[strip_index], previous_color.g +% strip_buffer[strip_index + 1], previous_color.b +% strip_buffer[strip_index + 2], previous_color.a +% strip_buffer[strip_index + 3]);
+                            storage[pixel_index] = color.Rgba32.from.rgba(previous_color.r +% strip_buffer[strip_index], previous_color.g +% strip_buffer[strip_index + 1], previous_color.b +% strip_buffer[strip_index + 2], previous_color.a +% strip_buffer[strip_index + 3]);
                         }
                         pixel_index += 1;
                         if (pixel_index >= storage.len)

--- a/src/predefined_colors.zig
+++ b/src/predefined_colors.zig
@@ -4,64 +4,28 @@ const std = @import("std");
 /// This a generic function to generate a struct with a set of predefined colors
 pub fn Colors(comptime T: type) type {
     return struct {
-        const RedT = std.meta.fieldInfo(T, .r).type;
-        const GreenT = std.meta.fieldInfo(T, .g).type;
-        const BlueT = std.meta.fieldInfo(T, .b).type;
+        pub const Red: T =
+            T.from.color(color.Colorf32.from.rgb(1.0, 0.0, 0.0));
 
-        inline fn toColorValue(comptime TargetType: type, value: f32) TargetType {
-            if (TargetType == f32) {
-                return value;
-            }
+        pub const Green: T =
+            T.from.color(color.Colorf32.from.rgb(0.0, 1.0, 0.0));
 
-            return color.toIntColor(TargetType, value);
-        }
+        pub const Blue: T =
+            T.from.color(color.Colorf32.from.rgb(0.0, 0.0, 1.0));
 
-        pub const Red = T.initRgb(
-            toColorValue(RedT, 1.0),
-            toColorValue(GreenT, 0.0),
-            toColorValue(BlueT, 0.0),
-        );
+        pub const White: T =
+            T.from.color(color.Colorf32.from.rgb(1.0, 1.0, 1.0));
 
-        pub const Green = T.initRgb(
-            toColorValue(RedT, 0.0),
-            toColorValue(GreenT, 1.0),
-            toColorValue(BlueT, 0.0),
-        );
+        pub const Black: T =
+            T.from.color(color.Colorf32.from.rgb(0.0, 0.0, 0.0));
 
-        pub const Blue = T.initRgb(
-            toColorValue(RedT, 0.0),
-            toColorValue(GreenT, 0.0),
-            toColorValue(BlueT, 1.0),
-        );
+        pub const Cyan: T =
+            T.from.color(color.Colorf32.from.rgb(0.0, 1.0, 1.0));
 
-        pub const White = T.initRgb(
-            toColorValue(RedT, 1.0),
-            toColorValue(GreenT, 1.0),
-            toColorValue(BlueT, 1.0),
-        );
+        pub const Magenta: T =
+            T.from.color(color.Colorf32.from.rgb(1.0, 0.0, 1.0));
 
-        pub const Black = T.initRgb(
-            toColorValue(RedT, 0.0),
-            toColorValue(GreenT, 0.0),
-            toColorValue(BlueT, 0.0),
-        );
-
-        pub const Cyan = T.initRgb(
-            toColorValue(RedT, 0.0),
-            toColorValue(GreenT, 1.0),
-            toColorValue(BlueT, 1.0),
-        );
-
-        pub const Magenta = T.initRgb(
-            toColorValue(RedT, 1.0),
-            toColorValue(GreenT, 0.0),
-            toColorValue(BlueT, 1.0),
-        );
-
-        pub const Yellow = T.initRgb(
-            toColorValue(RedT, 1.0),
-            toColorValue(GreenT, 1.0),
-            toColorValue(BlueT, 0.0),
-        );
+        pub const Yellow: T =
+            T.from.color(color.Colorf32.from.rgb(1.0, 1.0, 0.0));
     };
 }

--- a/tests/color_test.zig
+++ b/tests/color_test.zig
@@ -4,28 +4,28 @@ const color = @import("../src/color.zig");
 const helpers = @import("helpers.zig");
 
 test "Convert color to premultipled alpha" {
-    const originalColor = color.Colorf32.initRgba(100 / 255, 128 / 255, 210 / 255, 100 / 255);
-    const premultipliedAlpha = originalColor.toPremultipliedAlpha();
+    const originalColor = color.Colorf32.from.rgba(100 / 255, 128 / 255, 210 / 255, 100 / 255);
+    const premultipliedAlpha = originalColor.to.premultipliedAlpha();
 
     try helpers.expectEq(premultipliedAlpha.r, 39 / 255);
     try helpers.expectEq(premultipliedAlpha.g, 50 / 255);
     try helpers.expectEq(premultipliedAlpha.b, 82 / 255);
     try helpers.expectEq(premultipliedAlpha.a, 100 / 255);
 
-    const expectedRgba32 = premultipliedAlpha.toRgba32();
-    const originalRgba32 = originalColor.toRgba32();
-    const premultipliedAlphaRgba32 = originalRgba32.toPremultipliedAlpha();
+    const expectedRgba32 = premultipliedAlpha.to.color(color.Rgba32);
+    const originalRgba32 = originalColor.to.color(color.Rgba32);
+    const premultipliedAlphaRgba32 = originalRgba32.to.premultipliedAlpha();
     try helpers.expectEq(premultipliedAlphaRgba32, expectedRgba32);
 
-    const expectedRgba64 = premultipliedAlpha.toRgba64();
-    const originalRgba64 = originalColor.toRgba64();
-    const premultipliedAlphaRgba64 = originalRgba64.toPremultipliedAlpha();
+    const expectedRgba64 = premultipliedAlpha.to.color(color.Rgba64);
+    const originalRgba64 = originalColor.to.color(color.Rgba64);
+    const premultipliedAlphaRgba64 = originalRgba64.to.premultipliedAlpha();
     try helpers.expectEq(premultipliedAlphaRgba64, expectedRgba64);
 }
 
 test "Convert Rgb24 to Colorf32" {
-    const originalColor = color.Rgb24.initRgb(100, 128, 210);
-    const result = originalColor.toColorf32().toRgba32();
+    const originalColor = color.Rgb24.from.rgb(100, 128, 210);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 100);
     try helpers.expectEq(result.g, 128);
@@ -34,8 +34,8 @@ test "Convert Rgb24 to Colorf32" {
 }
 
 test "Convert Rgb48 to Colorf32" {
-    const originalColor = color.Rgb48.initRgb(25500, 32640, 53550);
-    const result = originalColor.toColorf32().toRgba64();
+    const originalColor = color.Rgb48.from.rgb(25500, 32640, 53550);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba64);
 
     try helpers.expectEq(result.r, 25500);
     try helpers.expectEq(result.g, 32640);
@@ -44,8 +44,8 @@ test "Convert Rgb48 to Colorf32" {
 }
 
 test "Convert Rgba32 to Colorf32" {
-    const originalColor = color.Rgba32.initRgba(1, 2, 3, 4);
-    const result = originalColor.toColorf32().toRgba32();
+    const originalColor = color.Rgba32.from.rgba(1, 2, 3, 4);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 1);
     try helpers.expectEq(result.g, 2);
@@ -54,8 +54,8 @@ test "Convert Rgba32 to Colorf32" {
 }
 
 test "Convert Rgba64 to Colorf32" {
-    const originalColor = color.Rgba64.initRgba(1, 2, 3, 4);
-    const result = originalColor.toColorf32().toRgba64();
+    const originalColor = color.Rgba64.from.rgba(1, 2, 3, 4);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba64);
 
     try helpers.expectEq(result.r, 1);
     try helpers.expectEq(result.g, 2);
@@ -64,8 +64,8 @@ test "Convert Rgba64 to Colorf32" {
 }
 
 test "Convert Rgb332 to Colorf32" {
-    const originalColor = color.Rgb332.initRgb(7, 4, 2);
-    const result = originalColor.toColorf32().toRgba32();
+    const originalColor = color.Rgb332.from.rgb(7, 4, 2);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 255);
     try helpers.expectEq(result.g, 146);
@@ -74,8 +74,8 @@ test "Convert Rgb332 to Colorf32" {
 }
 
 test "Convert Rgb565 to Colorf32" {
-    const originalColor = color.Rgb565.initRgb(10, 30, 20);
-    const result = originalColor.toColorf32().toRgba32();
+    const originalColor = color.Rgb565.from.rgb(10, 30, 20);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 82);
     try helpers.expectEq(result.g, 121);
@@ -84,8 +84,8 @@ test "Convert Rgb565 to Colorf32" {
 }
 
 test "Convert Rgb555 to Colorf32" {
-    const originalColor = color.Rgb555.initRgb(16, 20, 24);
-    const result = originalColor.toColorf32().toRgba32();
+    const originalColor = color.Rgb555.from.rgb(16, 20, 24);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 132);
     try helpers.expectEq(result.g, 165);
@@ -94,8 +94,8 @@ test "Convert Rgb555 to Colorf32" {
 }
 
 test "Convert Bgra32 to Colorf32" {
-    const originalColor = color.Bgra32.initRgba(50, 100, 150, 200);
-    const result = originalColor.toColorf32().toRgba32();
+    const originalColor = color.Bgra32.from.rgba(50, 100, 150, 200);
+    const result = originalColor.to.color(color.Colorf32).to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 50);
     try helpers.expectEq(result.g, 100);
@@ -105,7 +105,7 @@ test "Convert Bgra32 to Colorf32" {
 
 test "Convert Grayscale1 to Colorf32" {
     const white = color.Grayscale1{ .value = 1 };
-    const whiteColor = white.toColorf32().toRgba32();
+    const whiteColor = white.toColorf32().to.color(color.Rgba32);
 
     try helpers.expectEq(whiteColor.r, 255);
     try helpers.expectEq(whiteColor.g, 255);
@@ -113,7 +113,7 @@ test "Convert Grayscale1 to Colorf32" {
     try helpers.expectEq(whiteColor.a, 255);
 
     const black = color.Grayscale1{ .value = 0 };
-    const blackColor = black.toColorf32().toRgba32();
+    const blackColor = black.toColorf32().to.color(color.Rgba32);
 
     try helpers.expectEq(blackColor.r, 0);
     try helpers.expectEq(blackColor.g, 0);
@@ -123,7 +123,7 @@ test "Convert Grayscale1 to Colorf32" {
 
 test "Convert Grayscale8 to Colorf32" {
     const original = color.Grayscale8{ .value = 128 };
-    const result = original.toColorf32().toRgba32();
+    const result = original.toColorf32().to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 128);
     try helpers.expectEq(result.g, 128);
@@ -133,7 +133,7 @@ test "Convert Grayscale8 to Colorf32" {
 
 test "Convert Grayscale16 to Colorf32" {
     const original = color.Grayscale16{ .value = 21845 };
-    const result = original.toColorf32().toRgba32();
+    const result = original.toColorf32().to.color(color.Rgba32);
 
     try helpers.expectEq(result.r, 85);
     try helpers.expectEq(result.g, 85);
@@ -142,14 +142,14 @@ test "Convert Grayscale16 to Colorf32" {
 }
 
 test "Rgb from and to U32" {
-    const expected = color.Rgba32.initRgba(0x87, 0x63, 0x47, 0xff);
-    const actualU32 = expected.toU32Rgba();
-    const actual = color.Rgba32.fromU32Rgba(actualU32);
+    const expected = color.Rgba32.from.rgba(0x87, 0x63, 0x47, 0xff);
+    const actualU32 = expected.to.u32Rgba();
+    const actual = color.Rgba32.from.u32Rgba(actualU32);
 
     try helpers.expectEq(actualU32, 0x876347FF);
     try helpers.expectEq(actual, expected);
 
-    const actualRgb = color.Rgba32.fromU32Rgb(0x876347);
+    const actualRgb = color.Rgba32.from.u32Rgb(0x876347);
 
     try helpers.expectEq(actualRgb.r, 0x87);
     try helpers.expectEq(actualRgb.g, 0x63);
@@ -157,253 +157,255 @@ test "Rgb from and to U32" {
     try helpers.expectEq(actualRgb.a, 0xff);
 }
 
-test "toIntColor" {
-    try helpers.expectEq(color.toIntColor(u8, 0), 0);
-    try helpers.expectEq(color.toIntColor(u8, 0.33), 84);
-    try helpers.expectEq(color.toIntColor(u8, 1), 255);
-    try helpers.expectEq(color.toIntColor(u8, 1.33), 255);
-    try helpers.expectEq(color.toIntColor(u8, -0.33), 0);
+test "ScaleValue" {
+    const toU8 = color.ScaleValue(u8);
+    try helpers.expectEq(toU8(@as(f32, 0)), 0);
+    try helpers.expectEq(toU8(@as(f32, 0.33)), 84);
+    try helpers.expectEq(toU8(@as(f32, 1)), 255);
+    try helpers.expectEq(toU8(@as(f32, 1.33)), 255);
+    try helpers.expectEq(toU8(@as(f32, -0.33)), 0);
 
-    try helpers.expectEq(color.toIntColor(u16, 0), 0);
-    try helpers.expectEq(color.toIntColor(u16, 0.33), 21627);
-    try helpers.expectEq(color.toIntColor(u16, 1), 65535);
-    try helpers.expectEq(color.toIntColor(u16, 1.33), 65535);
-    try helpers.expectEq(color.toIntColor(u16, -0.33), 0);
+    const toU16 = color.ScaleValue(u16);
+    try helpers.expectEq(toU16(@as(f32, 0)), 0);
+    try helpers.expectEq(toU16(@as(f32, 0.33)), 21627);
+    try helpers.expectEq(toU16(@as(f32, 1)), 65535);
+    try helpers.expectEq(toU16(@as(f32, 1.33)), 65535);
+    try helpers.expectEq(toU16(@as(f32, -0.33)), 0);
 }
 
 test "Colorf32.toFromU32Rgba()" {
     const expected_u32 = [_]u32{ 0xb7e795d2, 0x9967044f, 0xefa1f714, 0x26ce0589, 0xf50f68ea };
     const expected_c32 = [_]color.Colorf32{
-        color.Colorf32.initRgba(0xb7.0 / 255.0, 0xe7.0 / 255.0, 0x95.0 / 255.0, 0xd2.0 / 255.0),
-        color.Colorf32.initRgba(0x99.0 / 255.0, 0x67.0 / 255.0, 0x04.0 / 255.0, 0x4f.0 / 255.0),
-        color.Colorf32.initRgba(0xef.0 / 255.0, 0xa1.0 / 255.0, 0xf7.0 / 255.0, 0x14.0 / 255.0),
-        color.Colorf32.initRgba(0x26.0 / 255.0, 0xce.0 / 255.0, 0x05.0 / 255.0, 0x89.0 / 255.0),
-        color.Colorf32.initRgba(0xf5.0 / 255.0, 0x0f.0 / 255.0, 0x68.0 / 255.0, 0xea.0 / 255.0),
+        color.Colorf32.from.rgba(0xb7.0 / 255.0, 0xe7.0 / 255.0, 0x95.0 / 255.0, 0xd2.0 / 255.0),
+        color.Colorf32.from.rgba(0x99.0 / 255.0, 0x67.0 / 255.0, 0x04.0 / 255.0, 0x4f.0 / 255.0),
+        color.Colorf32.from.rgba(0xef.0 / 255.0, 0xa1.0 / 255.0, 0xf7.0 / 255.0, 0x14.0 / 255.0),
+        color.Colorf32.from.rgba(0x26.0 / 255.0, 0xce.0 / 255.0, 0x05.0 / 255.0, 0x89.0 / 255.0),
+        color.Colorf32.from.rgba(0xf5.0 / 255.0, 0x0f.0 / 255.0, 0x68.0 / 255.0, 0xea.0 / 255.0),
     };
     for (expected_u32, 0..) |expected, i| {
-        const actual = color.Colorf32.fromU32Rgba(expected);
+        const actual = color.Colorf32.from.u32Rgba(expected);
         try helpers.expectEq(actual, expected_c32[i]);
-        try helpers.expectEq(actual.toU32Rgba(), expected);
+        try helpers.expectEq(actual.to.u32Rgba(), expected);
     }
 }
 
 test "Colorf32.toFromU64Rgba()" {
     const expected_u64 = [_]u64{ 0xf034da495288b4f0, 0x8f43957daf1fad51, 0xb2c84b7efea70316, 0x68bb87b393a1c104, 0x48b7f617a4520099 };
     const expected_c32 = [_]color.Colorf32{
-        color.Colorf32.initRgba(0xf034.0 / 65535.0, 0xda49.0 / 65535.0, 0x5288.0 / 65535.0, 0xb4f0.0 / 65535.0),
-        color.Colorf32.initRgba(0x8f43.0 / 65535.0, 0x957d.0 / 65535.0, 0xaf1f.0 / 65535.0, 0xad51.0 / 65535.0),
-        color.Colorf32.initRgba(0xb2c8.0 / 65535.0, 0x4b7e.0 / 65535.0, 0xfea7.0 / 65535.0, 0x0316.0 / 65535.0),
-        color.Colorf32.initRgba(0x68bb.0 / 65535.0, 0x87b3.0 / 65535.0, 0x93a1.0 / 65535.0, 0xc104.0 / 65535.0),
-        color.Colorf32.initRgba(0x48b7.0 / 65535.0, 0xf617.0 / 65535.0, 0xa452.0 / 65535.0, 0x0099.0 / 65535.0),
+        color.Colorf32.from.rgba(0xf034.0 / 65535.0, 0xda49.0 / 65535.0, 0x5288.0 / 65535.0, 0xb4f0.0 / 65535.0),
+        color.Colorf32.from.rgba(0x8f43.0 / 65535.0, 0x957d.0 / 65535.0, 0xaf1f.0 / 65535.0, 0xad51.0 / 65535.0),
+        color.Colorf32.from.rgba(0xb2c8.0 / 65535.0, 0x4b7e.0 / 65535.0, 0xfea7.0 / 65535.0, 0x0316.0 / 65535.0),
+        color.Colorf32.from.rgba(0x68bb.0 / 65535.0, 0x87b3.0 / 65535.0, 0x93a1.0 / 65535.0, 0xc104.0 / 65535.0),
+        color.Colorf32.from.rgba(0x48b7.0 / 65535.0, 0xf617.0 / 65535.0, 0xa452.0 / 65535.0, 0x0099.0 / 65535.0),
     };
     for (expected_u64, 0..) |expected, i| {
-        const actual = color.Colorf32.fromU64Rgba(expected);
+        const actual = color.Colorf32.from.u64Rgba(expected);
         try helpers.expectEq(actual, expected_c32[i]);
-        try helpers.expectEq(actual.toU64Rgba(), expected);
+        try helpers.expectEq(actual.to.u64Rgba(), expected);
     }
 }
 
 test "Rgb.toFromU32Rgba()" {
     const expected_u32 = [_]u32{ 0xb7e795d2, 0x9967044f, 0xefa1f714, 0x26ce0589, 0xf50f68ea };
     const expected_rgb24_from_rgba = [_]color.Rgb24{
-        color.Rgb24.initRgb(0xb7, 0xe7, 0x95),
-        color.Rgb24.initRgb(0x99, 0x67, 0x04),
-        color.Rgb24.initRgb(0xef, 0xa1, 0xf7),
-        color.Rgb24.initRgb(0x26, 0xce, 0x05),
-        color.Rgb24.initRgb(0xf5, 0x0f, 0x68),
+        color.Rgb24.from.rgb(0xb7, 0xe7, 0x95),
+        color.Rgb24.from.rgb(0x99, 0x67, 0x04),
+        color.Rgb24.from.rgb(0xef, 0xa1, 0xf7),
+        color.Rgb24.from.rgb(0x26, 0xce, 0x05),
+        color.Rgb24.from.rgb(0xf5, 0x0f, 0x68),
     };
     const expected_rgb24_from_rgb = [_]color.Rgb24{
-        color.Rgb24.initRgb(0xe7, 0x95, 0xd2),
-        color.Rgb24.initRgb(0x67, 0x04, 0x4f),
-        color.Rgb24.initRgb(0xa1, 0xf7, 0x14),
-        color.Rgb24.initRgb(0xce, 0x05, 0x89),
-        color.Rgb24.initRgb(0x0f, 0x68, 0xea),
+        color.Rgb24.from.rgb(0xe7, 0x95, 0xd2),
+        color.Rgb24.from.rgb(0x67, 0x04, 0x4f),
+        color.Rgb24.from.rgb(0xa1, 0xf7, 0x14),
+        color.Rgb24.from.rgb(0xce, 0x05, 0x89),
+        color.Rgb24.from.rgb(0x0f, 0x68, 0xea),
     };
     const expected_rgb555_from_rgb = [_]color.Rgb555{
-        color.Rgb555.initRgb(0xe7 >> 3, 0x95 >> 3, 0xd2 >> 3),
-        color.Rgb555.initRgb(0x67 >> 3, 0x04 >> 3, 0x4f >> 3),
-        color.Rgb555.initRgb(0xa1 >> 3, 0xf7 >> 3, 0x14 >> 3),
-        color.Rgb555.initRgb(0xce >> 3, 0x05 >> 3, 0x89 >> 3),
-        color.Rgb555.initRgb(0x0f >> 3, 0x68 >> 3, 0xea >> 3),
+        color.Rgb555.from.rgb(0xe7 >> 3, 0x95 >> 3, 0xd2 >> 3),
+        color.Rgb555.from.rgb(0x67 >> 3, 0x04 >> 3, 0x4f >> 3),
+        color.Rgb555.from.rgb(0xa1 >> 3, 0xf7 >> 3, 0x14 >> 3),
+        color.Rgb555.from.rgb(0xce >> 3, 0x05 >> 3, 0x89 >> 3),
+        color.Rgb555.from.rgb(0x0f >> 3, 0x68 >> 3, 0xea >> 3),
     };
     const expected_rgb565_from_rgb = [_]color.Rgb565{
-        color.Rgb565.initRgb(0xe7 >> 3, 0x95 >> 2, 0xd2 >> 3),
-        color.Rgb565.initRgb(0x67 >> 3, 0x04 >> 2, 0x4f >> 3),
-        color.Rgb565.initRgb(0xa1 >> 3, 0xf7 >> 2, 0x14 >> 3),
-        color.Rgb565.initRgb(0xce >> 3, 0x05 >> 2, 0x89 >> 3),
-        color.Rgb565.initRgb(0x0f >> 3, 0x68 >> 2, 0xea >> 3),
+        color.Rgb565.from.rgb(0xe7 >> 3, 0x95 >> 2, 0xd2 >> 3),
+        color.Rgb565.from.rgb(0x67 >> 3, 0x04 >> 2, 0x4f >> 3),
+        color.Rgb565.from.rgb(0xa1 >> 3, 0xf7 >> 2, 0x14 >> 3),
+        color.Rgb565.from.rgb(0xce >> 3, 0x05 >> 2, 0x89 >> 3),
+        color.Rgb565.from.rgb(0x0f >> 3, 0x68 >> 2, 0xea >> 3),
     };
 
     const expected_colorf32 = [_]color.Colorf32{
-        expected_rgb24_from_rgba[0].toColorf32(),
-        expected_rgb24_from_rgba[1].toColorf32(),
-        expected_rgb24_from_rgba[2].toColorf32(),
-        expected_rgb24_from_rgba[3].toColorf32(),
-        expected_rgb24_from_rgba[4].toColorf32(),
+        expected_rgb24_from_rgba[0].to.color(color.Colorf32),
+        expected_rgb24_from_rgba[1].to.color(color.Colorf32),
+        expected_rgb24_from_rgba[2].to.color(color.Colorf32),
+        expected_rgb24_from_rgba[3].to.color(color.Colorf32),
+        expected_rgb24_from_rgba[4].to.color(color.Colorf32),
     };
 
     const expected_rgb48_from_rgba = [_]color.Rgb48{
-        color.Rgb48.initRgb(0xb7 * 257, 0xe7 * 257, 0x95 * 257),
-        color.Rgb48.initRgb(0x99 * 257, 0x67 * 257, 0x04 * 257),
-        color.Rgb48.initRgb(0xef * 257, 0xa1 * 257, 0xf7 * 257),
-        color.Rgb48.initRgb(0x26 * 257, 0xce * 257, 0x05 * 257),
-        color.Rgb48.initRgb(0xf5 * 257, 0x0f * 257, 0x68 * 257),
+        color.Rgb48.from.rgb(0xb7 * 257, 0xe7 * 257, 0x95 * 257),
+        color.Rgb48.from.rgb(0x99 * 257, 0x67 * 257, 0x04 * 257),
+        color.Rgb48.from.rgb(0xef * 257, 0xa1 * 257, 0xf7 * 257),
+        color.Rgb48.from.rgb(0x26 * 257, 0xce * 257, 0x05 * 257),
+        color.Rgb48.from.rgb(0xf5 * 257, 0x0f * 257, 0x68 * 257),
     };
     const expected_rgb48_from_rgb = [_]color.Rgb48{
-        color.Rgb48.initRgb(0xe7 * 257, 0x95 * 257, 0xd2 * 257),
-        color.Rgb48.initRgb(0x67 * 257, 0x04 * 257, 0x4f * 257),
-        color.Rgb48.initRgb(0xa1 * 257, 0xf7 * 257, 0x14 * 257),
-        color.Rgb48.initRgb(0xce * 257, 0x05 * 257, 0x89 * 257),
-        color.Rgb48.initRgb(0x0f * 257, 0x68 * 257, 0xea * 257),
+        color.Rgb48.from.rgb(0xe7 * 257, 0x95 * 257, 0xd2 * 257),
+        color.Rgb48.from.rgb(0x67 * 257, 0x04 * 257, 0x4f * 257),
+        color.Rgb48.from.rgb(0xa1 * 257, 0xf7 * 257, 0x14 * 257),
+        color.Rgb48.from.rgb(0xce * 257, 0x05 * 257, 0x89 * 257),
+        color.Rgb48.from.rgb(0x0f * 257, 0x68 * 257, 0xea * 257),
     };
     for (expected_u32, 0..) |expected, i| {
-        const actual24_from_rgba = color.Rgb24.fromU32Rgba(expected);
+        const actual24_from_rgba = color.Rgb24.from.u32Rgba(expected);
         try helpers.expectEq(actual24_from_rgba, expected_rgb24_from_rgba[i]);
-        try helpers.expectEq(actual24_from_rgba.toU32Rgba(), expected | 0xff);
-        const actual24_from_rgb = color.Rgb24.fromU32Rgb(expected);
+        try helpers.expectEq(actual24_from_rgba.to.u32Rgba(), expected | 0xff);
+        const actual24_from_rgb = color.Rgb24.from.u32Rgb(expected);
         try helpers.expectEq(actual24_from_rgb, expected_rgb24_from_rgb[i]);
-        try helpers.expectEq(actual24_from_rgb.toU32Rgba(), expected << 8 | 0xff);
-        const actual555_from_rgb = color.Rgb555.fromU32Rgb(expected);
+        try helpers.expectEq(actual24_from_rgb.to.u32Rgba(), expected << 8 | 0xff);
+        const actual555_from_rgb = color.Rgb555.from.u32Rgb(expected);
         try helpers.expectEq(actual555_from_rgb, expected_rgb555_from_rgb[i]);
-        try helpers.expectEq(actual555_from_rgb.toU32Rgba(), expected_rgb555_from_rgb[i].toColorf32().toU32Rgba());
-        const actual565_from_rgb = color.Rgb565.fromU32Rgb(expected);
+        try helpers.expectEq(actual555_from_rgb.to.u32Rgba(), expected_rgb555_from_rgb[i].to.color(color.Colorf32).to.u32Rgba());
+        const actual565_from_rgb = color.Rgb565.from.u32Rgb(expected);
         try helpers.expectEq(actual565_from_rgb, expected_rgb565_from_rgb[i]);
-        try helpers.expectEq(actual565_from_rgb.toU32Rgba(), expected_rgb565_from_rgb[i].toColorf32().toU32Rgba());
+        try helpers.expectEq(actual565_from_rgb.to.u32Rgba(), expected_rgb565_from_rgb[i].to.color(color.Colorf32).to.u32Rgba());
 
         // We make sure that conversion through u32 give the same result as through f32
-        try helpers.expectEq(actual24_from_rgba.toU32Rgba(), expected_colorf32[i].toU32Rgba());
+        try helpers.expectEq(actual24_from_rgba.to.u32Rgba(), expected_colorf32[i].to.u32Rgba());
 
-        const actual48_from_rgba = color.Rgb48.fromU32Rgba(expected);
+        const actual48_from_rgba = color.Rgb48.from.u32Rgba(expected);
         try helpers.expectEq(actual48_from_rgba, expected_rgb48_from_rgba[i]);
-        try helpers.expectEq(actual48_from_rgba.toU32Rgba(), expected | 0xff);
-        const actual48_from_rgb = color.Rgb48.fromU32Rgb(expected);
+        try helpers.expectEq(actual48_from_rgba.to.u32Rgba(), expected | 0xff);
+        const actual48_from_rgb = color.Rgb48.from.u32Rgb(expected);
         try helpers.expectEq(actual48_from_rgb, expected_rgb48_from_rgb[i]);
-        try helpers.expectEq(actual48_from_rgb.toU32Rgba(), expected << 8 | 0xff);
+        try helpers.expectEq(actual48_from_rgb.to.u32Rgba(), expected << 8 | 0xff);
 
         // We make sure that conversion through u64 give the same result as through f32
-        try helpers.expectEq(actual48_from_rgba.toU64Rgba(), expected_colorf32[i].toU64Rgba());
+        try helpers.expectEq(actual48_from_rgba.to.u64Rgba(), expected_colorf32[i].to.u64Rgba());
     }
 }
 
 test "Rgb.toFromU64Rgba()" {
     const expected_u64 = [_]u64{ 0xf034da495288b4f0, 0x8f43957daf1fad51, 0xb2c84b7efea70316, 0x68bb87b393a1c104, 0x48b7f617a4520099 };
     const expected_rgb48_from_rgba = [_]color.Rgb48{
-        color.Rgb48.initRgb(0xf034, 0xda49, 0x5288),
-        color.Rgb48.initRgb(0x8f43, 0x957d, 0xaf1f),
-        color.Rgb48.initRgb(0xb2c8, 0x4b7e, 0xfea7),
-        color.Rgb48.initRgb(0x68bb, 0x87b3, 0x93a1),
-        color.Rgb48.initRgb(0x48b7, 0xf617, 0xa452),
+        color.Rgb48.from.rgb(0xf034, 0xda49, 0x5288),
+        color.Rgb48.from.rgb(0x8f43, 0x957d, 0xaf1f),
+        color.Rgb48.from.rgb(0xb2c8, 0x4b7e, 0xfea7),
+        color.Rgb48.from.rgb(0x68bb, 0x87b3, 0x93a1),
+        color.Rgb48.from.rgb(0x48b7, 0xf617, 0xa452),
     };
     const expected_rgb48_from_rgb = [_]color.Rgb48{
-        color.Rgb48.initRgb(0xda49, 0x5288, 0xb4f0),
-        color.Rgb48.initRgb(0x957d, 0xaf1f, 0xad51),
-        color.Rgb48.initRgb(0x4b7e, 0xfea7, 0x0316),
-        color.Rgb48.initRgb(0x87b3, 0x93a1, 0xc104),
-        color.Rgb48.initRgb(0xf617, 0xa452, 0x0099),
+        color.Rgb48.from.rgb(0xda49, 0x5288, 0xb4f0),
+        color.Rgb48.from.rgb(0x957d, 0xaf1f, 0xad51),
+        color.Rgb48.from.rgb(0x4b7e, 0xfea7, 0x0316),
+        color.Rgb48.from.rgb(0x87b3, 0x93a1, 0xc104),
+        color.Rgb48.from.rgb(0xf617, 0xa452, 0x0099),
     };
 
     const expected_colorf32 = [_]color.Colorf32{
-        expected_rgb48_from_rgba[0].toColorf32(),
-        expected_rgb48_from_rgba[1].toColorf32(),
-        expected_rgb48_from_rgba[2].toColorf32(),
-        expected_rgb48_from_rgba[3].toColorf32(),
-        expected_rgb48_from_rgba[4].toColorf32(),
+        expected_rgb48_from_rgba[0].to.color(color.Colorf32),
+        expected_rgb48_from_rgba[1].to.color(color.Colorf32),
+        expected_rgb48_from_rgba[2].to.color(color.Colorf32),
+        expected_rgb48_from_rgba[3].to.color(color.Colorf32),
+        expected_rgb48_from_rgba[4].to.color(color.Colorf32),
     };
     for (expected_u64, 0..) |expected, i| {
-        const actual_from_rgba = color.Rgb48.fromU64Rgba(expected);
+        const actual_from_rgba = color.Rgb48.from.u64Rgba(expected);
         try helpers.expectEq(actual_from_rgba, expected_rgb48_from_rgba[i]);
-        try helpers.expectEq(actual_from_rgba.toU64Rgba(), expected | 0xffff);
-        const actual_from_rgb = color.Rgb48.fromU64Rgb(expected);
+        try helpers.expectEq(actual_from_rgba.to.u64Rgba(), expected | 0xffff);
+        const actual_from_rgb = color.Rgb48.from.u64Rgb(expected);
         try helpers.expectEq(actual_from_rgb, expected_rgb48_from_rgb[i]);
-        try helpers.expectEq(actual_from_rgb.toU64Rgba(), expected << 16 | 0xffff);
+        try helpers.expectEq(actual_from_rgb.to.u64Rgba(), expected << 16 | 0xffff);
 
         // We make sure that conversion through u64 give the same result as through f32
-        try helpers.expectEq(actual_from_rgba.toU64Rgba(), expected_colorf32[i].toU64Rgba());
+        try helpers.expectEq(actual_from_rgba.to.u64Rgba(), expected_colorf32[i].to.u64Rgba());
     }
 }
 
 test "Rgba.toFromU32Rgba()" {
     const expected_u32 = [_]u32{ 0xb7e795d2, 0x9967044f, 0xefa1f714, 0x26ce0589, 0xf50f68ea };
     const expected_rgba32_from_rgba = [_]color.Rgba32{
-        color.Rgba32.initRgba(0xb7, 0xe7, 0x95, 0xd2),
-        color.Rgba32.initRgba(0x99, 0x67, 0x04, 0x4f),
-        color.Rgba32.initRgba(0xef, 0xa1, 0xf7, 0x14),
-        color.Rgba32.initRgba(0x26, 0xce, 0x05, 0x89),
-        color.Rgba32.initRgba(0xf5, 0x0f, 0x68, 0xea),
+        color.Rgba32.from.rgba(0xb7, 0xe7, 0x95, 0xd2),
+        color.Rgba32.from.rgba(0x99, 0x67, 0x04, 0x4f),
+        color.Rgba32.from.rgba(0xef, 0xa1, 0xf7, 0x14),
+        color.Rgba32.from.rgba(0x26, 0xce, 0x05, 0x89),
+        color.Rgba32.from.rgba(0xf5, 0x0f, 0x68, 0xea),
     };
 
     const expected_colorf32 = [_]color.Colorf32{
-        expected_rgba32_from_rgba[0].toColorf32(),
-        expected_rgba32_from_rgba[1].toColorf32(),
-        expected_rgba32_from_rgba[2].toColorf32(),
-        expected_rgba32_from_rgba[3].toColorf32(),
-        expected_rgba32_from_rgba[4].toColorf32(),
+        expected_rgba32_from_rgba[0].to.color(color.Colorf32),
+        expected_rgba32_from_rgba[1].to.color(color.Colorf32),
+        expected_rgba32_from_rgba[2].to.color(color.Colorf32),
+        expected_rgba32_from_rgba[3].to.color(color.Colorf32),
+        expected_rgba32_from_rgba[4].to.color(color.Colorf32),
     };
 
     const expected_rgba64_from_rgba = [_]color.Rgba64{
-        color.Rgba64.initRgba(0xb7 * 257, 0xe7 * 257, 0x95 * 257, 0xd2 * 257),
-        color.Rgba64.initRgba(0x99 * 257, 0x67 * 257, 0x04 * 257, 0x4f * 257),
-        color.Rgba64.initRgba(0xef * 257, 0xa1 * 257, 0xf7 * 257, 0x14 * 257),
-        color.Rgba64.initRgba(0x26 * 257, 0xce * 257, 0x05 * 257, 0x89 * 257),
-        color.Rgba64.initRgba(0xf5 * 257, 0x0f * 257, 0x68 * 257, 0xea * 257),
+        color.Rgba64.from.rgba(0xb7 * 257, 0xe7 * 257, 0x95 * 257, 0xd2 * 257),
+        color.Rgba64.from.rgba(0x99 * 257, 0x67 * 257, 0x04 * 257, 0x4f * 257),
+        color.Rgba64.from.rgba(0xef * 257, 0xa1 * 257, 0xf7 * 257, 0x14 * 257),
+        color.Rgba64.from.rgba(0x26 * 257, 0xce * 257, 0x05 * 257, 0x89 * 257),
+        color.Rgba64.from.rgba(0xf5 * 257, 0x0f * 257, 0x68 * 257, 0xea * 257),
     };
     for (expected_u32, 0..) |expected, i| {
-        const actual32_from_rgba = color.Rgba32.fromU32Rgba(expected);
+        const actual32_from_rgba = color.Rgba32.from.u32Rgba(expected);
         try helpers.expectEq(actual32_from_rgba, expected_rgba32_from_rgba[i]);
-        try helpers.expectEq(actual32_from_rgba.toU32Rgba(), expected);
+        try helpers.expectEq(actual32_from_rgba.to.u32Rgba(), expected);
 
         // We make sure that conversion through u32 give the same result as through f32
-        try helpers.expectEq(actual32_from_rgba.toU32Rgba(), expected_colorf32[i].toU32Rgba());
+        try helpers.expectEq(actual32_from_rgba.to.u32Rgba(), expected_colorf32[i].to.u32Rgba());
 
-        const actual64_from_rgba = color.Rgba64.fromU32Rgba(expected);
+        const actual64_from_rgba = color.Rgba64.from.u32Rgba(expected);
         try helpers.expectEq(actual64_from_rgba, expected_rgba64_from_rgba[i]);
-        try helpers.expectEq(actual64_from_rgba.toU32Rgba(), expected);
+        try helpers.expectEq(actual64_from_rgba.to.u32Rgba(), expected);
 
         // We make sure that conversion through u64 give the same result as through f32
-        try helpers.expectEq(actual64_from_rgba.toU64Rgba(), expected_colorf32[i].toU64Rgba());
+        try helpers.expectEq(actual64_from_rgba.to.u64Rgba(), expected_colorf32[i].to.u64Rgba());
     }
 }
 
 test "Rgba.toFromU64Rgba())" {
     const expected_u64 = [_]u64{ 0xf034da495288b4f0, 0x8f43957daf1fad51, 0xb2c84b7efea70316, 0x68bb87b393a1c104, 0x48b7f617a4520099 };
     const expected_rgba64_from_rgba = [_]color.Rgba64{
-        color.Rgba64.initRgba(0xf034, 0xda49, 0x5288, 0xb4f0),
-        color.Rgba64.initRgba(0x8f43, 0x957d, 0xaf1f, 0xad51),
-        color.Rgba64.initRgba(0xb2c8, 0x4b7e, 0xfea7, 0x0316),
-        color.Rgba64.initRgba(0x68bb, 0x87b3, 0x93a1, 0xc104),
-        color.Rgba64.initRgba(0x48b7, 0xf617, 0xa452, 0x0099),
+        color.Rgba64.from.rgba(0xf034, 0xda49, 0x5288, 0xb4f0),
+        color.Rgba64.from.rgba(0x8f43, 0x957d, 0xaf1f, 0xad51),
+        color.Rgba64.from.rgba(0xb2c8, 0x4b7e, 0xfea7, 0x0316),
+        color.Rgba64.from.rgba(0x68bb, 0x87b3, 0x93a1, 0xc104),
+        color.Rgba64.from.rgba(0x48b7, 0xf617, 0xa452, 0x0099),
     };
 
     const expected_colorf32 = [_]color.Colorf32{
-        expected_rgba64_from_rgba[0].toColorf32(),
-        expected_rgba64_from_rgba[1].toColorf32(),
-        expected_rgba64_from_rgba[2].toColorf32(),
-        expected_rgba64_from_rgba[3].toColorf32(),
-        expected_rgba64_from_rgba[4].toColorf32(),
+        expected_rgba64_from_rgba[0].to.color(color.Colorf32),
+        expected_rgba64_from_rgba[1].to.color(color.Colorf32),
+        expected_rgba64_from_rgba[2].to.color(color.Colorf32),
+        expected_rgba64_from_rgba[3].to.color(color.Colorf32),
+        expected_rgba64_from_rgba[4].to.color(color.Colorf32),
     };
     for (expected_u64, 0..) |expected, i| {
-        const actual_from_rgba = color.Rgba64.fromU64Rgba(expected);
+        const actual_from_rgba = color.Rgba64.from.u64Rgba(expected);
         try helpers.expectEq(actual_from_rgba, expected_rgba64_from_rgba[i]);
-        try helpers.expectEq(actual_from_rgba.toU64Rgba(), expected);
+        try helpers.expectEq(actual_from_rgba.to.u64Rgba(), expected);
 
         // We make sure that conversion through u64 give the same result as through f32
-        try helpers.expectEq(actual_from_rgba.toU64Rgba(), expected_colorf32[i].toU64Rgba());
+        try helpers.expectEq(actual_from_rgba.to.u64Rgba(), expected_colorf32[i].to.u64Rgba());
     }
 }
 
 test "Colorf32 from and to [4]f32 array" {
     const expected = [_]f32{ 0.12, 0.34, 0.56, 0.78 };
-    const sample = color.Colorf32.fromArray(expected);
+    const sample = color.Colorf32.from.array(expected);
 
     try helpers.expectEq(sample.r, 0.12);
     try helpers.expectEq(sample.g, 0.34);
     try helpers.expectEq(sample.b, 0.56);
     try helpers.expectEq(sample.a, 0.78);
-    const actual = sample.toArray();
+    const actual = sample.to.array();
     try helpers.expectEqSlice(f32, actual[0..], expected[0..]);
 }
 
-test "Rgb.fromHtmlHex() with valid inputs" {
+test "Rgb.from.htmlHex() with valid inputs" {
     const inputs = [_][]const u8{
         "#fff",
         "#ffffff",
@@ -415,20 +417,20 @@ test "Rgb.fromHtmlHex() with valid inputs" {
     };
 
     const expected_colors = [_]color.Rgb24{
-        color.Rgb24.initRgb(0xff, 0xff, 0xff),
-        color.Rgb24.initRgb(0xff, 0xff, 0xff),
-        color.Rgb24.initRgb(0x00, 0x00, 0x00),
-        color.Rgb24.initRgb(0x00, 0x00, 0x00),
-        color.Rgb24.initRgb(0x12, 0x34, 0x56),
-        color.Rgb24.initRgb(0x11, 0x22, 0x33),
-        color.Rgb24.initRgb(0xAF, 0xCD, 0xEB),
+        color.Rgb24.from.rgb(0xff, 0xff, 0xff),
+        color.Rgb24.from.rgb(0xff, 0xff, 0xff),
+        color.Rgb24.from.rgb(0x00, 0x00, 0x00),
+        color.Rgb24.from.rgb(0x00, 0x00, 0x00),
+        color.Rgb24.from.rgb(0x12, 0x34, 0x56),
+        color.Rgb24.from.rgb(0x11, 0x22, 0x33),
+        color.Rgb24.from.rgb(0xAF, 0xCD, 0xEB),
     };
 
     std.debug.assert(inputs.len == expected_colors.len);
 
     var index: usize = 0;
     while (index < inputs.len) : (index += 1) {
-        const actual_color = try color.Rgb24.fromHtmlHex(inputs[index]);
+        const actual_color = try color.Rgb24.from.htmlHex(inputs[index]);
 
         const expected_color = expected_colors[index];
 
@@ -438,7 +440,7 @@ test "Rgb.fromHtmlHex() with valid inputs" {
     }
 }
 
-test "Rgba.fromHtmlHex() with valid inputs" {
+test "Rgba.from.htmlHex() with valid inputs" {
     const inputs = [_][]const u8{
         "#ffff",
         "#1234",
@@ -449,19 +451,19 @@ test "Rgba.fromHtmlHex() with valid inputs" {
     };
 
     const expected_colors = [_]color.Rgba32{
-        color.Rgba32.initRgba(0xff, 0xff, 0xff, 0xff),
-        color.Rgba32.initRgba(0x11, 0x22, 0x33, 0x44),
-        color.Rgba32.initRgba(0xff, 0xff, 0xff, 0xff),
-        color.Rgba32.initRgba(0x12, 0x34, 0x56, 0x78),
-        color.Rgba32.initRgba(0xAB, 0xCD, 0xEF, 0x9D),
-        color.Rgba32.initRgba(0xfe, 0xdc, 0xba, 0x34),
+        color.Rgba32.from.rgba(0xff, 0xff, 0xff, 0xff),
+        color.Rgba32.from.rgba(0x11, 0x22, 0x33, 0x44),
+        color.Rgba32.from.rgba(0xff, 0xff, 0xff, 0xff),
+        color.Rgba32.from.rgba(0x12, 0x34, 0x56, 0x78),
+        color.Rgba32.from.rgba(0xAB, 0xCD, 0xEF, 0x9D),
+        color.Rgba32.from.rgba(0xfe, 0xdc, 0xba, 0x34),
     };
 
     std.debug.assert(inputs.len == expected_colors.len);
 
     var index: usize = 0;
     while (index < inputs.len) : (index += 1) {
-        const actual_color = try color.Rgba32.fromHtmlHex(inputs[index]);
+        const actual_color = try color.Rgba32.from.htmlHex(inputs[index]);
 
         const expected_color = expected_colors[index];
 
@@ -472,7 +474,7 @@ test "Rgba.fromHtmlHex() with valid inputs" {
     }
 }
 
-test "Rgb.fromHtmlHex() with invalid inputs" {
+test "Rgb.from.htmlHex() with invalid inputs" {
     const inputs = [_][]const u8{
         "#zzz",
         "#ag",
@@ -489,13 +491,13 @@ test "Rgb.fromHtmlHex() with invalid inputs" {
 
     var index: usize = 0;
     while (index < inputs.len) : (index += 1) {
-        const actual_error = color.Rgb24.fromHtmlHex(inputs[index]);
+        const actual_error = color.Rgb24.from.htmlHex(inputs[index]);
 
         try helpers.expectError(actual_error, error.InvalidHtmlHexString);
     }
 }
 
-test "Rgba.fromHtmlHex() with invalid inputs" {
+test "Rgba.from.htmlHex() with invalid inputs" {
     const inputs = [_][]const u8{
         "#zzz",
         "#ag",
@@ -512,24 +514,10 @@ test "Rgba.fromHtmlHex() with invalid inputs" {
 
     var index: usize = 0;
     while (index < inputs.len) : (index += 1) {
-        const actual_error = color.Rgba32.fromHtmlHex(inputs[index]);
+        const actual_error = color.Rgba32.from.htmlHex(inputs[index]);
 
         try helpers.expectError(actual_error, error.InvalidHtmlHexString);
     }
-}
-
-test "u8 Rgb colors should have fromHtmlHex" {
-    try helpers.expectEq(@hasDecl(color.Rgb24, "fromHtmlHex"), true);
-    try helpers.expectEq(@hasDecl(color.Rgba32, "fromHtmlHex"), true);
-    try helpers.expectEq(@hasDecl(color.Bgr24, "fromHtmlHex"), true);
-    try helpers.expectEq(@hasDecl(color.Bgra32, "fromHtmlHex"), true);
-}
-
-test "Non u8 Rgb colors should not have fromHtmlHex" {
-    try helpers.expectEq(@hasDecl(color.Rgb555, "fromHtmlHex"), false);
-    try helpers.expectEq(@hasDecl(color.Rgb48, "fromHtmlHex"), false);
-    try helpers.expectEq(@hasDecl(color.Rgba64, "fromHtmlHex"), false);
-    try helpers.expectEq(@hasDecl(color.Rgb565, "fromHtmlHex"), false);
 }
 
 const RgbHslTestDataEntry = struct {
@@ -672,7 +660,7 @@ test "Compute Linear sRGB RGB to XYZ matrix" {
 }
 
 test "Linear sRGB to CIE XYZ" {
-    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const color_to_convert = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.toXYZ(color_to_convert);
 
@@ -683,7 +671,7 @@ test "Linear sRGB to CIE XYZ" {
 }
 
 test "Convert Linear sRGB color to AdobeWideGamutRGB" {
-    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const color_to_convert = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.convertColor(color.AdobeWideGamutRGB, color_to_convert);
 
@@ -695,7 +683,7 @@ test "Convert Linear sRGB color to AdobeWideGamutRGB" {
 }
 
 test "Convert Linear sRGB to DCI-P3 Display" {
-    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const color_to_convert = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.convertColor(color.DCIP3.Display, color_to_convert);
 
@@ -707,7 +695,7 @@ test "Convert Linear sRGB to DCI-P3 Display" {
 }
 
 test "Convert Linear sRGB to BT709 (sanity check)" {
-    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const color_to_convert = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.convertColor(color.BT709, color_to_convert);
 
@@ -719,7 +707,7 @@ test "Convert Linear sRGB to BT709 (sanity check)" {
 }
 
 test "Convert Linear sRGB to BT2020" {
-    const color_to_convert = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const color_to_convert = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.convertColor(color.BT2020, color_to_convert);
 
@@ -732,19 +720,19 @@ test "Convert Linear sRGB to BT2020" {
 
 test "Convert an array of Linear sRGB to ProPhotoRGB" {
     var colors = [_]color.Colorf32{
-        color.Colorf32.initRgb(0.2, 0.1, 0.8),
-        color.Colorf32.initRgb(1.0, 1.0, 1.0),
-        color.Colorf32.initRgb(0.5, 0.5, 0.0),
-        color.Colorf32.initRgb(0.0, 0.0, 0.0),
-        color.Colorf32.initRgb(0.0, 0.2, 0.4),
+        color.Colorf32.from.rgb(0.2, 0.1, 0.8),
+        color.Colorf32.from.rgb(1.0, 1.0, 1.0),
+        color.Colorf32.from.rgb(0.5, 0.5, 0.0),
+        color.Colorf32.from.rgb(0.0, 0.0, 0.0),
+        color.Colorf32.from.rgb(0.0, 0.2, 0.4),
     };
 
     const expected_results = [_]color.Colorf32{
-        color.Colorf32.initRgb(0.251338661, 0.129547358, 0.707502544),
-        color.Colorf32.initRgb(1.0, 1.0, 1.0),
-        color.Colorf32.initRgb(0.429706693, 0.485920370, 0.0672753304),
-        color.Colorf32.initRgb(0.0, 0.0, 0.0),
-        color.Colorf32.initRgb(0.122260347, 0.185960293, 0.369714200),
+        color.Colorf32.from.rgb(0.251338661, 0.129547358, 0.707502544),
+        color.Colorf32.from.rgb(1.0, 1.0, 1.0),
+        color.Colorf32.from.rgb(0.429706693, 0.485920370, 0.0672753304),
+        color.Colorf32.from.rgb(0.0, 0.0, 0.0),
+        color.Colorf32.from.rgb(0.122260347, 0.185960293, 0.369714200),
     };
 
     color.sRGB.convertColors(color.ProPhotoRGB, colors[0..]);
@@ -760,7 +748,7 @@ test "Convert an array of Linear sRGB to ProPhotoRGB" {
 }
 
 test "Convert a sRGB color to CIELab" {
-    const source_color = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const source_color = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.toLab(source_color);
 
@@ -771,7 +759,7 @@ test "Convert a sRGB color to CIELab" {
 }
 
 test "Convert a sRGB color to CIELab with alpha" {
-    const source_color = color.Colorf32.initRgba(0.2, 0.1, 0.8, 0.5);
+    const source_color = color.Colorf32.from.rgba(0.2, 0.1, 0.8, 0.5);
 
     const result = color.sRGB.toLabAlpha(source_color);
 
@@ -835,7 +823,7 @@ test "Convert a CIELab color to linear sRGB with alpha" {
     try helpers.expectApproxEqAbs(red_rgba_float.b, 0.0, 0.001);
     try helpers.expectApproxEqAbs(red_rgba_float.a, 1.0, 0.001);
 
-    const red_rgba = red_rgba_float.toRgba32();
+    const red_rgba = red_rgba_float.to.color(color.Rgba32);
     try helpers.expectEq(red_rgba.r, 255);
     try helpers.expectEq(red_rgba.g, 0);
     try helpers.expectEq(red_rgba.b, 0);
@@ -1308,7 +1296,7 @@ test "Convert from CIELCh(ab) with alpha to CIE Lab with alpha" {
 }
 
 test "Convert a sRGB RGBA to CIELuv" {
-    const rgba = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const rgba = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.toLuv(rgba);
 
@@ -1330,7 +1318,7 @@ test "Conveert a CIELuv to linear sRGB RGBA" {
 }
 
 test "Convert a sRGB RGBA to CIELuvAlpha" {
-    const rgba = color.Colorf32.initRgb(0.2, 0.1, 0.8);
+    const rgba = color.Colorf32.from.rgb(0.2, 0.1, 0.8);
 
     const result = color.sRGB.toLuvAlpha(rgba);
 
@@ -1562,7 +1550,7 @@ test "Convert a HSLuv color to gamma sRGB color" {
     try helpers.expectApproxEqAbs(result.b, 0.651108801, float_tolerance);
     try helpers.expectApproxEqAbs(result.a, 1.0, float_tolerance);
 
-    const rgba = result.toRgba32();
+    const rgba = result.to.color(color.Rgba32);
     try helpers.expectEq(rgba.r, 0x53);
     try helpers.expectEq(rgba.g, 0x7d);
     try helpers.expectEq(rgba.b, 0xa6);
@@ -1596,7 +1584,7 @@ test "Convert a HSLuv with alpha color to gamma sRGB color with alpha" {
     try helpers.expectApproxEqAbs(result.b, 0.651108801, float_tolerance);
     try helpers.expectApproxEqAbs(result.a, 0.12345, float_tolerance);
 
-    const rgba = result.toRgba32();
+    const rgba = result.to.color(color.Rgba32);
     try helpers.expectEq(rgba.r, 0x53);
     try helpers.expectEq(rgba.g, 0x7d);
     try helpers.expectEq(rgba.b, 0xa6);

--- a/tests/formats/bmp_test.zig
+++ b/tests/formats/bmp_test.zig
@@ -202,18 +202,18 @@ test "Write a v4 bitmap when writing an image with bgr24 pixel format" {
     try testing.expect(pixels.bgr24.len == width * height);
 
     // R, G, B
-    pixels.bgr24[0] = color.Bgr24.initRgb(255, 0, 0);
-    pixels.bgr24[1] = color.Bgr24.initRgb(0, 255, 0);
-    pixels.bgr24[2] = color.Bgr24.initRgb(0, 0, 255);
+    pixels.bgr24[0] = color.Bgr24.from.rgb(255, 0, 0);
+    pixels.bgr24[1] = color.Bgr24.from.rgb(0, 255, 0);
+    pixels.bgr24[2] = color.Bgr24.from.rgb(0, 0, 255);
 
     // Black, white
-    pixels.bgr24[3] = color.Bgr24.initRgb(0, 0, 0);
-    pixels.bgr24[4] = color.Bgr24.initRgb(255, 255, 255);
+    pixels.bgr24[3] = color.Bgr24.from.rgb(0, 0, 0);
+    pixels.bgr24[4] = color.Bgr24.from.rgb(255, 255, 255);
 
     // Cyan, Magenta, Yellow
-    pixels.bgr24[5] = color.Bgr24.initRgb(0, 255, 255);
-    pixels.bgr24[6] = color.Bgr24.initRgb(255, 0, 255);
-    pixels.bgr24[7] = color.Bgr24.initRgb(255, 255, 0);
+    pixels.bgr24[5] = color.Bgr24.from.rgb(0, 255, 255);
+    pixels.bgr24[6] = color.Bgr24.from.rgb(255, 0, 255);
+    pixels.bgr24[7] = color.Bgr24.from.rgb(255, 255, 0);
 
     try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .bmp = .{},
@@ -241,7 +241,7 @@ test "Write a v4 bitmap when writing an image with bgr24 pixel format" {
     try testing.expect(read_image_pixels == .bgr24);
 
     for (expected_colors, 0..) |hex_color, index| {
-        try helpers.expectEq(read_image_pixels.bgr24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(read_image_pixels.bgr24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -261,21 +261,21 @@ test "Write a v5 bitmap when writing an image with bgra32 pixel format" {
     try testing.expect(pixels.bgra32.len == width * height);
 
     // R, G, B
-    pixels.bgra32[0] = color.Bgra32.initRgb(255, 0, 0);
-    pixels.bgra32[1] = color.Bgra32.initRgb(0, 255, 0);
-    pixels.bgra32[2] = color.Bgra32.initRgb(0, 0, 255);
+    pixels.bgra32[0] = color.Bgra32.from.rgb(255, 0, 0);
+    pixels.bgra32[1] = color.Bgra32.from.rgb(0, 255, 0);
+    pixels.bgra32[2] = color.Bgra32.from.rgb(0, 0, 255);
 
     // Black, white
-    pixels.bgra32[3] = color.Bgra32.initRgb(0, 0, 0);
-    pixels.bgra32[4] = color.Bgra32.initRgb(255, 255, 255);
+    pixels.bgra32[3] = color.Bgra32.from.rgb(0, 0, 0);
+    pixels.bgra32[4] = color.Bgra32.from.rgb(255, 255, 255);
 
     // Cyan, Magenta, Yellow
-    pixels.bgra32[5] = color.Bgra32.initRgb(0, 255, 255);
-    pixels.bgra32[6] = color.Bgra32.initRgb(255, 0, 255);
-    pixels.bgra32[7] = color.Bgra32.initRgb(255, 255, 0);
+    pixels.bgra32[5] = color.Bgra32.from.rgb(0, 255, 255);
+    pixels.bgra32[6] = color.Bgra32.from.rgb(255, 0, 255);
+    pixels.bgra32[7] = color.Bgra32.from.rgb(255, 255, 0);
 
     // Transparent pixel
-    pixels.bgra32[8] = color.Bgra32.initRgba(0, 0, 0, 0);
+    pixels.bgra32[8] = color.Bgra32.from.rgba(0, 0, 0, 0);
 
     try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .bmp = .{},
@@ -303,6 +303,6 @@ test "Write a v5 bitmap when writing an image with bgra32 pixel format" {
     try testing.expect(read_image_pixels == .bgra32);
 
     for (expected_colors, 0..) |hex_color, index| {
-        try helpers.expectEq(read_image_pixels.bgra32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(read_image_pixels.bgra32[index].to.u32Rgb(), hex_color);
     }
 }

--- a/tests/formats/gif_test.zig
+++ b/tests/formats/gif_test.zig
@@ -216,7 +216,7 @@ fn doGifTest(entry_name: []const u8) !void {
 
         const expected_background_color_opt = blk: {
             if (config_section.getValue("background")) |string_background_color| {
-                break :blk @as(?color.Rgba32, try color.Rgba32.fromHtmlHex(string_background_color.string));
+                break :blk @as(?color.Rgba32, try color.Rgba32.from.htmlHex(string_background_color.string));
             }
 
             break :blk @as(?color.Rgba32, null);
@@ -253,7 +253,7 @@ fn doGifTest(entry_name: []const u8) !void {
         try helpers.expectEq(gif_file.header.height, @as(u16, @intCast(expected_height.number)));
 
         if (expected_background_color_opt) |expected_background_color| {
-            try helpers.expectEq(gif_file.global_color_table.data[gif_file.header.background_color_index].toU32Rgba(), expected_background_color.toU32Rgba());
+            try helpers.expectEq(gif_file.global_color_table.data[gif_file.header.background_color_index].to.u32Rgba(), expected_background_color.to.u32Rgba());
         }
 
         try helpers.expectEq(gif_file.loopCount(), expected_loop_count);
@@ -306,19 +306,19 @@ fn doGifTest(entry_name: []const u8) !void {
                     const background_color_index = gif_file.header.background_color_index;
 
                     const gif_background_color = switch (frames.items[frame_index].pixels) {
-                        .indexed1 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.initRgba(0, 0, 0, 0),
-                        .indexed2 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.initRgba(0, 0, 0, 0),
-                        .indexed4 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.initRgba(0, 0, 0, 0),
-                        .indexed8 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.initRgba(0, 0, 0, 0),
-                        else => color.Rgba32.initRgba(0, 0, 0, 0),
+                        .indexed1 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.from.rgba(0, 0, 0, 0),
+                        .indexed2 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.from.rgba(0, 0, 0, 0),
+                        .indexed4 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.from.rgba(0, 0, 0, 0),
+                        .indexed8 => |pixels| if (background_color_index < pixels.palette.len) pixels.palette[background_color_index] else color.Rgba32.from.rgba(0, 0, 0, 0),
+                        else => color.Rgba32.from.rgba(0, 0, 0, 0),
                     };
 
                     for (pixel_list.items) |expected_color| {
                         if (frame_data_iterator.next()) |actual_color| {
-                            if (expected_color.toU32Rgba() == 0) {
-                                try helpers.expectEq(actual_color.toRgba32(), gif_background_color);
+                            if (expected_color.to.u32Rgba() == 0) {
+                                try helpers.expectEq(actual_color.to.color(color.Rgba32), gif_background_color);
                             } else {
-                                try helpers.expectEq(actual_color.toRgba32(), expected_color);
+                                try helpers.expectEq(actual_color.to.color(color.Rgba32), expected_color);
                             }
                         }
                     }

--- a/tests/formats/iff_test.zig
+++ b/tests/formats/iff_test.zig
@@ -144,7 +144,7 @@ test "IFF-ILBM indexed8 4 bitplanes HAM" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -172,7 +172,7 @@ test "IFF-ILBM indexed8 6 bitplanes HAM8" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -200,7 +200,7 @@ test "IFF-ILBM 24bit" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 

--- a/tests/formats/jpeg_test.zig
+++ b/tests/formats/jpeg_test.zig
@@ -86,9 +86,9 @@ test "Read the tuba properly" {
         try testing.expect(pixels == .rgb24);
 
         // Just for fun, let's sample a few pixels. :^)
-        try helpers.expectEq(pixels.rgb24[(126 * 512 + 163)], color.Rgb24.initRgb(0xAC, 0x78, 0x54));
-        try helpers.expectEq(pixels.rgb24[(265 * 512 + 284)], color.Rgb24.initRgb(0x37, 0x30, 0x33));
-        try helpers.expectEq(pixels.rgb24[(431 * 512 + 300)], color.Rgb24.initRgb(0xFE, 0xE7, 0xC9));
+        try helpers.expectEq(pixels.rgb24[(126 * 512 + 163)], color.Rgb24.from.rgb(0xAC, 0x78, 0x54));
+        try helpers.expectEq(pixels.rgb24[(265 * 512 + 284)], color.Rgb24.from.rgb(0x37, 0x30, 0x33));
+        try helpers.expectEq(pixels.rgb24[(431 * 512 + 300)], color.Rgb24.from.rgb(0xFE, 0xE7, 0xC9));
     }
 }
 
@@ -160,17 +160,17 @@ test "Read subsampling images" {
                 try testing.expect(pixels == .rgb24);
 
                 // Just for fun, let's sample a few pixels. :^)
-                const actual: color.Colorf32 = pixels.rgb24[(0 * 32 + 0)].toColorf32();
+                const actual: color.Colorf32 = pixels.rgb24[(0 * 32 + 0)].to.color(color.Colorf32);
                 try testing.expectApproxEqAbs(@as(f32, 1.0), actual.r, 0.05);
                 try testing.expectApproxEqAbs(@as(f32, 1.0), actual.g, 0.05);
                 try testing.expectApproxEqAbs(@as(f32, 0.0), actual.b, 0.05);
 
-                const actual1: color.Colorf32 = pixels.rgb24[(13 * 32 + 9)].toColorf32();
+                const actual1: color.Colorf32 = pixels.rgb24[(13 * 32 + 9)].to.color(color.Colorf32);
                 try testing.expectApproxEqAbs(@as(f32, 0.71), actual1.r, 0.05);
                 try testing.expectApproxEqAbs(@as(f32, 0.55), actual1.g, 0.05);
                 try testing.expectApproxEqAbs(@as(f32, 0.0), actual1.b, 0.05);
 
-                const actual2: color.Colorf32 = pixels.rgb24[(25 * 32 + 18)].toColorf32();
+                const actual2: color.Colorf32 = pixels.rgb24[(25 * 32 + 18)].to.color(color.Colorf32);
                 try testing.expectApproxEqAbs(@as(f32, 0.42), actual2.r, 0.05);
                 try testing.expectApproxEqAbs(@as(f32, 0.19), actual2.g, 0.05);
                 try testing.expectApproxEqAbs(@as(f32, 0.39), actual2.b, 0.05);

--- a/tests/formats/netpbm_test.zig
+++ b/tests/formats/netpbm_test.zig
@@ -394,18 +394,18 @@ test "Writing Rgb24 ASCII PPM format" {
     try testing.expect(pixels.rgb24.len == width * height);
 
     // R, G, B
-    pixels.rgb24[0] = color.Rgb24.initRgb(255, 0, 0);
-    pixels.rgb24[1] = color.Rgb24.initRgb(0, 255, 0);
-    pixels.rgb24[2] = color.Rgb24.initRgb(0, 0, 255);
+    pixels.rgb24[0] = color.Rgb24.from.rgb(255, 0, 0);
+    pixels.rgb24[1] = color.Rgb24.from.rgb(0, 255, 0);
+    pixels.rgb24[2] = color.Rgb24.from.rgb(0, 0, 255);
 
     // Black, white
-    pixels.rgb24[3] = color.Rgb24.initRgb(0, 0, 0);
-    pixels.rgb24[4] = color.Rgb24.initRgb(255, 255, 255);
+    pixels.rgb24[3] = color.Rgb24.from.rgb(0, 0, 0);
+    pixels.rgb24[4] = color.Rgb24.from.rgb(255, 255, 255);
 
     // Cyan, Magenta, Yellow
-    pixels.rgb24[5] = color.Rgb24.initRgb(0, 255, 255);
-    pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
-    pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
+    pixels.rgb24[5] = color.Rgb24.from.rgb(0, 255, 255);
+    pixels.rgb24[6] = color.Rgb24.from.rgb(255, 0, 255);
+    pixels.rgb24[7] = color.Rgb24.from.rgb(255, 255, 0);
 
     try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .ppm = .{ .binary = false },
@@ -426,7 +426,7 @@ test "Writing Rgb24 ASCII PPM format" {
     try testing.expect(read_image_pixels == .rgb24);
 
     for (expected_colors, 0..) |hex_color, index| {
-        try helpers.expectEq(read_image_pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(read_image_pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -446,18 +446,18 @@ test "Writing Rgb24 binary PPM format" {
     try testing.expect(pixels.rgb24.len == width * height);
 
     // R, G, B
-    pixels.rgb24[0] = color.Rgb24.initRgb(255, 0, 0);
-    pixels.rgb24[1] = color.Rgb24.initRgb(0, 255, 0);
-    pixels.rgb24[2] = color.Rgb24.initRgb(0, 0, 255);
+    pixels.rgb24[0] = color.Rgb24.from.rgb(255, 0, 0);
+    pixels.rgb24[1] = color.Rgb24.from.rgb(0, 255, 0);
+    pixels.rgb24[2] = color.Rgb24.from.rgb(0, 0, 255);
 
     // Black, white
-    pixels.rgb24[3] = color.Rgb24.initRgb(0, 0, 0);
-    pixels.rgb24[4] = color.Rgb24.initRgb(255, 255, 255);
+    pixels.rgb24[3] = color.Rgb24.from.rgb(0, 0, 0);
+    pixels.rgb24[4] = color.Rgb24.from.rgb(255, 255, 255);
 
     // Cyan, Magenta, Yellow
-    pixels.rgb24[5] = color.Rgb24.initRgb(0, 255, 255);
-    pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
-    pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
+    pixels.rgb24[5] = color.Rgb24.from.rgb(0, 255, 255);
+    pixels.rgb24[6] = color.Rgb24.from.rgb(255, 0, 255);
+    pixels.rgb24[7] = color.Rgb24.from.rgb(255, 255, 0);
 
     try source_image.writeToFilePath(image_file_name, Image.EncoderOptions{
         .ppm = .{ .binary = true },
@@ -478,7 +478,7 @@ test "Writing Rgb24 binary PPM format" {
     try testing.expect(read_image_pixels == .rgb24);
 
     for (expected_colors, 0..) |hex_color, index| {
-        try helpers.expectEq(read_image_pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(read_image_pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -495,18 +495,18 @@ test "Trying to write a bitmap or grayscale Netpbm with an true color pixel form
     const pixels = source_image.pixels;
 
     // R, G, B
-    pixels.rgb24[0] = color.Rgb24.initRgb(255, 0, 0);
-    pixels.rgb24[1] = color.Rgb24.initRgb(0, 255, 0);
-    pixels.rgb24[2] = color.Rgb24.initRgb(0, 0, 255);
+    pixels.rgb24[0] = color.Rgb24.from.rgb(255, 0, 0);
+    pixels.rgb24[1] = color.Rgb24.from.rgb(0, 255, 0);
+    pixels.rgb24[2] = color.Rgb24.from.rgb(0, 0, 255);
 
     // Black, white
-    pixels.rgb24[3] = color.Rgb24.initRgb(0, 0, 0);
-    pixels.rgb24[4] = color.Rgb24.initRgb(255, 255, 255);
+    pixels.rgb24[3] = color.Rgb24.from.rgb(0, 0, 0);
+    pixels.rgb24[4] = color.Rgb24.from.rgb(255, 255, 255);
 
     // Cyan, Magenta, Yellow
-    pixels.rgb24[5] = color.Rgb24.initRgb(0, 255, 255);
-    pixels.rgb24[6] = color.Rgb24.initRgb(255, 0, 255);
-    pixels.rgb24[7] = color.Rgb24.initRgb(255, 255, 0);
+    pixels.rgb24[5] = color.Rgb24.from.rgb(0, 255, 255);
+    pixels.rgb24[6] = color.Rgb24.from.rgb(255, 0, 255);
+    pixels.rgb24[7] = color.Rgb24.from.rgb(255, 255, 0);
 
     {
         const write_error = source_image.writeToFilePath(image_file_name, .{ .pbm = .{} });

--- a/tests/formats/pcx_test.zig
+++ b/tests/formats/pcx_test.zig
@@ -7,6 +7,8 @@ const testing = std.testing;
 const Image = @import("../../src/Image.zig");
 const helpers = @import("../helpers.zig");
 
+const toU8 = color.ScaleValue(u8);
+
 test "PCX indexed1 (linear)" {
     const file = try helpers.testOpenFile(helpers.fixtures_path ++ "pcx/test-bpp1.pcx");
     defer file.close();
@@ -219,8 +221,8 @@ test "Write PCX indexed 1 (even width)" {
     defer image_pattern.deinit();
 
     // Generate palette
-    image_pattern.pixels.indexed1.palette[0] = color.Rgba32.initRgb(0, 0, 0);
-    image_pattern.pixels.indexed1.palette[1] = color.Rgba32.initRgb(255, 255, 255);
+    image_pattern.pixels.indexed1.palette[0] = color.Rgba32.from.rgb(0, 0, 0);
+    image_pattern.pixels.indexed1.palette[1] = color.Rgba32.from.rgb(255, 255, 255);
 
     // Generate pattern
     for (0..image_height) |y| {
@@ -330,7 +332,7 @@ test "Write PCX indexed 4 (even width)" {
     for (0..16) |index| {
         const current_step = index % colors_per_channel;
         const current_channel = index / colors_per_channel;
-        const current_intensity = color.toIntColor(u8, @as(f32, @floatFromInt(current_step)) / @as(f32, @floatFromInt(colors_per_channel)));
+        const current_intensity = toU8(@as(f32, @floatFromInt(current_step)) / @as(f32, @floatFromInt(colors_per_channel)));
         rainbow_test.pixels.indexed4.palette[index].a = 255;
         switch (current_channel) {
             0 => rainbow_test.pixels.indexed4.palette[index].r = current_intensity,
@@ -435,7 +437,7 @@ test "Write PCX indexed 8 (even width)" {
     for (0..255) |index| {
         const current_step = index % colors_per_channel;
         const current_channel = index / colors_per_channel;
-        const current_intensity = color.toIntColor(u8, @as(f32, @floatFromInt(current_step)) / @as(f32, @floatFromInt(colors_per_channel)));
+        const current_intensity = toU8(@as(f32, @floatFromInt(current_step)) / @as(f32, @floatFromInt(colors_per_channel)));
 
         rainbow_test.pixels.indexed8.palette[index].r = 0;
         rainbow_test.pixels.indexed8.palette[index].g = 0;

--- a/tests/formats/ras_test.zig
+++ b/tests/formats/ras_test.zig
@@ -42,7 +42,7 @@ test "Sun-Raster 24-bit RGB24 uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -69,7 +69,7 @@ test "Sun-Raster 24-bit BGR24 uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.bgr24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.bgr24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -92,7 +92,7 @@ test "Sun-Raster 32-bit xRGB uncompressed" {
     const expected_colors = [_]u32{ 0x0, 0xf7a41d, 0x121212 };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -182,6 +182,6 @@ test "Sun-Raster bgr24 rle compressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.bgr24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.bgr24[index].to.u32Rgb(), hex_color);
     }
 }

--- a/tests/formats/sgi_test.zig
+++ b/tests/formats/sgi_test.zig
@@ -42,7 +42,7 @@ test "SGI 24-bit uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -88,7 +88,7 @@ test "SGI 32-bit RGBA uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -115,7 +115,7 @@ test "SGI RGB48be uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb48[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb48[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -161,7 +161,7 @@ test "SGI 24-bit rle compressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -188,7 +188,7 @@ test "SGI RGB48be rle uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb48[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb48[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -215,6 +215,6 @@ test "SGI 32-bit RGBA rle compressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }

--- a/tests/formats/tga_test.zig
+++ b/tests/formats/tga_test.zig
@@ -78,11 +78,11 @@ test "Read ucm8 TGA file" {
 
     try helpers.expectEq(pixels.indexed8.indices.len, 128 * 128);
 
-    try helpers.expectEq(pixels.indexed8.palette[0].toU32Rgba(), 0x000000ff);
-    try helpers.expectEq(pixels.indexed8.palette[64].toU32Rgba(), 0xff0000ff);
-    try helpers.expectEq(pixels.indexed8.palette[128].toU32Rgba(), 0x00ff00ff);
-    try helpers.expectEq(pixels.indexed8.palette[192].toU32Rgba(), 0x0000ffff);
-    try helpers.expectEq(pixels.indexed8.palette[255].toU32Rgba(), 0xffffffff);
+    try helpers.expectEq(pixels.indexed8.palette[0].to.u32Rgba(), 0x000000ff);
+    try helpers.expectEq(pixels.indexed8.palette[64].to.u32Rgba(), 0xff0000ff);
+    try helpers.expectEq(pixels.indexed8.palette[128].to.u32Rgba(), 0x00ff00ff);
+    try helpers.expectEq(pixels.indexed8.palette[192].to.u32Rgba(), 0x0000ffff);
+    try helpers.expectEq(pixels.indexed8.palette[255].to.u32Rgba(), 0xffffffff);
 
     const width = tga_file.width();
     const height = tga_file.height();
@@ -134,7 +134,7 @@ test "Read utc16 TGA file" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.rgb555[stride + x].toU32Rgb(), expected_strip[strip_index]);
+            try helpers.expectEq(pixels.rgb555[stride + x].to.u32Rgb(), expected_strip[strip_index]);
         }
     }
 }
@@ -172,7 +172,7 @@ test "Read utc24 TGA file" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.bgr24[stride + x].toU32Rgb(), expected_strip[strip_index]);
+            try helpers.expectEq(pixels.bgr24[stride + x].to.u32Rgb(), expected_strip[strip_index]);
         }
     }
 }
@@ -210,7 +210,7 @@ test "Read utc32 TGA file" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.bgra32[stride + x].toU32Rgba(), expected_strip[strip_index] << 8 | 0xff);
+            try helpers.expectEq(pixels.bgra32[stride + x].to.u32Rgba(), expected_strip[strip_index] << 8 | 0xff);
         }
     }
 }
@@ -272,11 +272,11 @@ test "Read ccm8 TGA file" {
 
     try helpers.expectEq(pixels.indexed8.indices.len, 128 * 128);
 
-    try helpers.expectEq(pixels.indexed8.palette[0].toU32Rgba(), 0x000000ff);
-    try helpers.expectEq(pixels.indexed8.palette[64].toU32Rgba(), 0xff0000ff);
-    try helpers.expectEq(pixels.indexed8.palette[128].toU32Rgba(), 0x00ff00ff);
-    try helpers.expectEq(pixels.indexed8.palette[192].toU32Rgba(), 0x0000ffff);
-    try helpers.expectEq(pixels.indexed8.palette[255].toU32Rgba(), 0xffffffff);
+    try helpers.expectEq(pixels.indexed8.palette[0].to.u32Rgba(), 0x000000ff);
+    try helpers.expectEq(pixels.indexed8.palette[64].to.u32Rgba(), 0xff0000ff);
+    try helpers.expectEq(pixels.indexed8.palette[128].to.u32Rgba(), 0x00ff00ff);
+    try helpers.expectEq(pixels.indexed8.palette[192].to.u32Rgba(), 0x0000ffff);
+    try helpers.expectEq(pixels.indexed8.palette[255].to.u32Rgba(), 0xffffffff);
 
     const width = tga_file.width();
     const height = tga_file.height();
@@ -328,7 +328,7 @@ test "Read ctc24 TGA file" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.bgr24[stride + x].toU32Rgb(), expected_strip[strip_index]);
+            try helpers.expectEq(pixels.bgr24[stride + x].to.u32Rgb(), expected_strip[strip_index]);
         }
     }
 }
@@ -373,7 +373,7 @@ test "Read matte-01 TGA file" {
     for (test_inputs) |input| {
         const index = tga_file.header.image_spec.width * input.y + input.x;
 
-        try helpers.expectEq(pixels.bgra32[index].toU32Rgba(), input.hex);
+        try helpers.expectEq(pixels.bgra32[index].to.u32Rgba(), input.hex);
     }
 }
 
@@ -398,9 +398,9 @@ test "Read font TGA file" {
 
     const width = tga_file.width();
 
-    try helpers.expectEq(pixels.bgra32[64 * width + 16].toColorf32().toRgba32(), color.Rgba32.initRgba(0, 0, 0, 0));
-    try helpers.expectEq(pixels.bgra32[64 * width + 17].toColorf32().toRgba32(), color.Rgba32.initRgba(209, 209, 209, 255));
-    try helpers.expectEq(pixels.bgra32[65 * width + 17].toColorf32().toRgba32(), color.Rgba32.initRgba(255, 255, 255, 255));
+    try helpers.expectEq(pixels.bgra32[64 * width + 16].to.color(color.Rgba32), color.Rgba32.from.rgba(0, 0, 0, 0));
+    try helpers.expectEq(pixels.bgra32[64 * width + 17].to.color(color.Rgba32), color.Rgba32.from.rgba(209, 209, 209, 255));
+    try helpers.expectEq(pixels.bgra32[65 * width + 17].to.color(color.Rgba32), color.Rgba32.from.rgba(255, 255, 255, 255));
 }
 
 test "Read stopsignsmall TGA v1 file" {
@@ -423,8 +423,8 @@ test "Read stopsignsmall TGA v1 file" {
 
     const width = tga_file.width();
 
-    try helpers.expectEq(pixels.bgr24[143 * width + 93], color.Bgr24.initRgb(188, 34, 24));
-    try helpers.expectEq(pixels.bgr24[479 * width + 215], color.Bgr24.initRgb(33, 29, 17));
+    try helpers.expectEq(pixels.bgr24[143 * width + 93], color.Bgr24.from.rgb(188, 34, 24));
+    try helpers.expectEq(pixels.bgr24[479 * width + 215], color.Bgr24.from.rgb(33, 29, 17));
 }
 
 test "Read stopsignsmallcompressed TGA v1 file" {
@@ -447,8 +447,8 @@ test "Read stopsignsmallcompressed TGA v1 file" {
 
     const width = tga_file.width();
 
-    try helpers.expectEq(pixels.bgr24[143 * width + 93], color.Bgr24.initRgb(188, 34, 24));
-    try helpers.expectEq(pixels.bgr24[479 * width + 215], color.Bgr24.initRgb(33, 29, 17));
+    try helpers.expectEq(pixels.bgr24[143 * width + 93], color.Bgr24.from.rgb(188, 34, 24));
+    try helpers.expectEq(pixels.bgr24[479 * width + 215], color.Bgr24.from.rgb(33, 29, 17));
 }
 
 test "Write TGA uncompressed grayscale8" {
@@ -640,11 +640,11 @@ test "Write uncompressed indexed8 (color map 16-bit)" {
 
     try helpers.expectEq(pixels.indexed8.indices.len, 128 * 128);
 
-    try helpers.expectEq(pixels.indexed8.palette[0].toU32Rgba(), 0x000000ff);
-    try helpers.expectEq(pixels.indexed8.palette[64].toU32Rgba(), 0xff0000ff);
-    try helpers.expectEq(pixels.indexed8.palette[128].toU32Rgba(), 0x00ff00ff);
-    try helpers.expectEq(pixels.indexed8.palette[192].toU32Rgba(), 0x0000ffff);
-    try helpers.expectEq(pixels.indexed8.palette[255].toU32Rgba(), 0xffffffff);
+    try helpers.expectEq(pixels.indexed8.palette[0].to.u32Rgba(), 0x000000ff);
+    try helpers.expectEq(pixels.indexed8.palette[64].to.u32Rgba(), 0xff0000ff);
+    try helpers.expectEq(pixels.indexed8.palette[128].to.u32Rgba(), 0x00ff00ff);
+    try helpers.expectEq(pixels.indexed8.palette[192].to.u32Rgba(), 0x0000ffff);
+    try helpers.expectEq(pixels.indexed8.palette[255].to.u32Rgba(), 0xffffffff);
 
     const width = tga_file.width();
     const height = tga_file.height();
@@ -704,11 +704,11 @@ test "Write uncompressed indexed8 (color map 24-bit)" {
 
     try helpers.expectEq(pixels.indexed8.indices.len, 128 * 128);
 
-    try helpers.expectEq(pixels.indexed8.palette[0].toU32Rgba(), 0x000000ff);
-    try helpers.expectEq(pixels.indexed8.palette[64].toU32Rgba(), 0xff0000ff);
-    try helpers.expectEq(pixels.indexed8.palette[128].toU32Rgba(), 0x00ff00ff);
-    try helpers.expectEq(pixels.indexed8.palette[192].toU32Rgba(), 0x0000ffff);
-    try helpers.expectEq(pixels.indexed8.palette[255].toU32Rgba(), 0xffffffff);
+    try helpers.expectEq(pixels.indexed8.palette[0].to.u32Rgba(), 0x000000ff);
+    try helpers.expectEq(pixels.indexed8.palette[64].to.u32Rgba(), 0xff0000ff);
+    try helpers.expectEq(pixels.indexed8.palette[128].to.u32Rgba(), 0x00ff00ff);
+    try helpers.expectEq(pixels.indexed8.palette[192].to.u32Rgba(), 0x0000ffff);
+    try helpers.expectEq(pixels.indexed8.palette[255].to.u32Rgba(), 0xffffffff);
 
     const width = tga_file.width();
     const height = tga_file.height();
@@ -768,11 +768,11 @@ test "Write compressed indexed8 (color map 16-bit)" {
 
     try helpers.expectEq(pixels.indexed8.indices.len, 128 * 128);
 
-    try helpers.expectEq(pixels.indexed8.palette[0].toU32Rgba(), 0x000000ff);
-    try helpers.expectEq(pixels.indexed8.palette[64].toU32Rgba(), 0xff0000ff);
-    try helpers.expectEq(pixels.indexed8.palette[128].toU32Rgba(), 0x00ff00ff);
-    try helpers.expectEq(pixels.indexed8.palette[192].toU32Rgba(), 0x0000ffff);
-    try helpers.expectEq(pixels.indexed8.palette[255].toU32Rgba(), 0xffffffff);
+    try helpers.expectEq(pixels.indexed8.palette[0].to.u32Rgba(), 0x000000ff);
+    try helpers.expectEq(pixels.indexed8.palette[64].to.u32Rgba(), 0xff0000ff);
+    try helpers.expectEq(pixels.indexed8.palette[128].to.u32Rgba(), 0x00ff00ff);
+    try helpers.expectEq(pixels.indexed8.palette[192].to.u32Rgba(), 0x0000ffff);
+    try helpers.expectEq(pixels.indexed8.palette[255].to.u32Rgba(), 0xffffffff);
 
     const width = tga_file.width();
     const height = tga_file.height();
@@ -832,11 +832,11 @@ test "Write compressed indexed8 (color map 24-bit)" {
 
     try helpers.expectEq(pixels.indexed8.indices.len, 128 * 128);
 
-    try helpers.expectEq(pixels.indexed8.palette[0].toU32Rgba(), 0x000000ff);
-    try helpers.expectEq(pixels.indexed8.palette[64].toU32Rgba(), 0xff0000ff);
-    try helpers.expectEq(pixels.indexed8.palette[128].toU32Rgba(), 0x00ff00ff);
-    try helpers.expectEq(pixels.indexed8.palette[192].toU32Rgba(), 0x0000ffff);
-    try helpers.expectEq(pixels.indexed8.palette[255].toU32Rgba(), 0xffffffff);
+    try helpers.expectEq(pixels.indexed8.palette[0].to.u32Rgba(), 0x000000ff);
+    try helpers.expectEq(pixels.indexed8.palette[64].to.u32Rgba(), 0xff0000ff);
+    try helpers.expectEq(pixels.indexed8.palette[128].to.u32Rgba(), 0x00ff00ff);
+    try helpers.expectEq(pixels.indexed8.palette[192].to.u32Rgba(), 0x0000ffff);
+    try helpers.expectEq(pixels.indexed8.palette[255].to.u32Rgba(), 0xffffffff);
 
     const width = tga_file.width();
     const height = tga_file.height();
@@ -908,7 +908,7 @@ test "Write uncompressed 16-bit true color TGA" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.rgb555[stride + x].toU32Rgb(), expected_strip[strip_index]);
+            try helpers.expectEq(pixels.rgb555[stride + x].to.u32Rgb(), expected_strip[strip_index]);
         }
     }
 }
@@ -966,7 +966,7 @@ test "Write compressed 16-bit true color TGA" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.rgb555[stride + x].toU32Rgb(), expected_strip[strip_index]);
+            try helpers.expectEq(pixels.rgb555[stride + x].to.u32Rgb(), expected_strip[strip_index]);
         }
     }
 }
@@ -1024,7 +1024,7 @@ test "Write uncompressed 24-bit true color TGA" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.bgr24[stride + x].toU32Rgb(), expected_strip[strip_index]);
+            try helpers.expectEq(pixels.bgr24[stride + x].to.u32Rgb(), expected_strip[strip_index]);
         }
     }
 }
@@ -1082,7 +1082,7 @@ test "Write compressed 24-bit true color TGA" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.bgr24[stride + x].toU32Rgb(), expected_strip[strip_index]);
+            try helpers.expectEq(pixels.bgr24[stride + x].to.u32Rgb(), expected_strip[strip_index]);
         }
     }
 }
@@ -1140,7 +1140,7 @@ test "Write uncompressed 32-bit true color TGA" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.bgra32[stride + x].toU32Rgba(), expected_strip[strip_index] << 8 | 0xff);
+            try helpers.expectEq(pixels.bgra32[stride + x].to.u32Rgba(), expected_strip[strip_index] << 8 | 0xff);
         }
     }
 }
@@ -1198,7 +1198,7 @@ test "Write compressed 32-bit true color TGA" {
         while (x < width) : (x += 1) {
             const strip_index = x / 8;
 
-            try helpers.expectEq(pixels.bgra32[stride + x].toU32Rgba(), expected_strip[strip_index] << 8 | 0xff);
+            try helpers.expectEq(pixels.bgra32[stride + x].to.u32Rgba(), expected_strip[strip_index] << 8 | 0xff);
         }
     }
 }

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -107,7 +107,7 @@ test "TIFF/LE 24-bit uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -134,7 +134,7 @@ test "TIFF/BE rgb24 gray single strip uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -161,7 +161,7 @@ test "TIFF/BE rgb24 color single strip uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -188,7 +188,7 @@ test "TIFF/BE 24-bit uncompressed" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -211,7 +211,7 @@ test "TIFF/LE RGBA uncompressed" {
     const expected_colors = [_]u32{ 0xf6ff00, 0xbe0042, 0x2900d7 };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -304,7 +304,7 @@ test "TIFF/LE 24-bit packbits" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -327,7 +327,7 @@ test "TIFF/LE RGBA packbits" {
     const expected_colors = [_]u32{ 0xf6ff00, 0xbe0042, 0x2900d7 };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -439,7 +439,7 @@ test "TIFF/LE 24-bit LZW" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -462,7 +462,7 @@ test "TIFF/LE RGBA LZW" {
     const expected_colors = [_]u32{ 0xf6ff00, 0xbe0042, 0x2900d7 };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -555,7 +555,7 @@ test "TIFF/LE 24-bit Deflate" {
     };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgb24[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgb24[index].to.u32Rgb(), hex_color);
     }
 }
 
@@ -578,6 +578,6 @@ test "TIFF/LE RGBA Deflate" {
     const expected_colors = [_]u32{ 0xf6ff00, 0xbe0042, 0x2900d7 };
 
     for (expected_colors, indexes) |hex_color, index| {
-        try helpers.expectEq(pixels.rgba32[index].toU32Rgb(), hex_color);
+        try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -484,14 +484,14 @@ test "Test Colorf32 iterator" {
     defer test_image.deinit();
 
     const expectedColors = [_]color.Colorf32{
-        color.Colorf32.initRgb(1.0, 0.0, 0.0),
-        color.Colorf32.initRgb(0.0, 1.0, 0.0),
-        color.Colorf32.initRgb(0.0, 0.0, 1.0),
-        color.Colorf32.initRgb(0.0, 1.0, 1.0),
-        color.Colorf32.initRgb(1.0, 0.0, 1.0),
-        color.Colorf32.initRgb(1.0, 1.0, 0.0),
-        color.Colorf32.initRgb(0.0, 0.0, 0.0),
-        color.Colorf32.initRgb(1.0, 1.0, 1.0),
+        color.Colorf32.from.rgb(1.0, 0.0, 0.0),
+        color.Colorf32.from.rgb(0.0, 1.0, 0.0),
+        color.Colorf32.from.rgb(0.0, 0.0, 1.0),
+        color.Colorf32.from.rgb(0.0, 1.0, 1.0),
+        color.Colorf32.from.rgb(1.0, 0.0, 1.0),
+        color.Colorf32.from.rgb(1.0, 1.0, 0.0),
+        color.Colorf32.from.rgb(0.0, 0.0, 0.0),
+        color.Colorf32.from.rgb(1.0, 1.0, 1.0),
     };
 
     try helpers.expectEq(test_image.width, 8);
@@ -513,14 +513,14 @@ test "Convert Image from rgb24 to float32 (Colorf32)" {
     defer test_image.deinit();
 
     const expected_colors = [_]color.Colorf32{
-        color.Colorf32.initRgb(1.0, 0.0, 0.0),
-        color.Colorf32.initRgb(0.0, 1.0, 0.0),
-        color.Colorf32.initRgb(0.0, 0.0, 1.0),
-        color.Colorf32.initRgb(0.0, 1.0, 1.0),
-        color.Colorf32.initRgb(1.0, 0.0, 1.0),
-        color.Colorf32.initRgb(1.0, 1.0, 0.0),
-        color.Colorf32.initRgb(0.0, 0.0, 0.0),
-        color.Colorf32.initRgb(1.0, 1.0, 1.0),
+        color.Colorf32.from.rgb(1.0, 0.0, 0.0),
+        color.Colorf32.from.rgb(0.0, 1.0, 0.0),
+        color.Colorf32.from.rgb(0.0, 0.0, 1.0),
+        color.Colorf32.from.rgb(0.0, 1.0, 1.0),
+        color.Colorf32.from.rgb(1.0, 0.0, 1.0),
+        color.Colorf32.from.rgb(1.0, 1.0, 0.0),
+        color.Colorf32.from.rgb(0.0, 0.0, 0.0),
+        color.Colorf32.from.rgb(1.0, 1.0, 1.0),
     };
 
     try helpers.expectEq(test_image.width, 8);

--- a/tests/octree_quantizer_test.zig
+++ b/tests/octree_quantizer_test.zig
@@ -8,9 +8,9 @@ test "Build the oct tree with 3 colors" {
     var quantizer = OctTreeQuantizer.init(helpers.zigimg_test_allocator);
     defer quantizer.deinit();
 
-    const red = color.Rgba32.initRgb(0xFF, 0, 0);
-    const green = color.Rgba32.initRgb(0, 0xFF, 0);
-    const blue = color.Rgba32.initRgb(0, 0, 0xFF);
+    const red = color.Rgba32.from.rgb(0xFF, 0, 0);
+    const green = color.Rgba32.from.rgb(0, 0xFF, 0);
+    const blue = color.Rgba32.from.rgb(0, 0, 0xFF);
 
     try quantizer.addColor(red);
     try quantizer.addColor(green);
@@ -51,14 +51,14 @@ test "Build a oct tree with 32-bit RGBA bitmap" {
 
     try helpers.expectEq(palette.len, 255);
 
-    const palette_index = try quantizer.getPaletteIndex(color.Rgba32.initRgba(110, 0, 0, 255));
+    const palette_index = try quantizer.getPaletteIndex(color.Rgba32.from.rgba(110, 0, 0, 255));
     try helpers.expectEq(palette_index, 87);
     try helpers.expectEq(palette[palette_index].r, 110);
     try helpers.expectEq(palette[palette_index].g, 2);
     try helpers.expectEq(palette[palette_index].b, 2);
     try helpers.expectEq(palette[palette_index].a, 255);
 
-    const second_palette_index = try quantizer.getPaletteIndex(color.Rgba32.initRgba(0, 0, 119, 255));
+    const second_palette_index = try quantizer.getPaletteIndex(color.Rgba32.from.rgba(0, 0, 119, 255));
     try helpers.expectEq(second_palette_index, 50);
     try helpers.expectEq(palette[second_palette_index].r, 0);
     try helpers.expectEq(palette[second_palette_index].g, 0);

--- a/tests/pixel_format_converter_test.zig
+++ b/tests/pixel_format_converter_test.zig
@@ -8,6 +8,14 @@ const helpers = @import("helpers.zig");
 // mlarouche: Not all conversion are tested, just the most important ones
 // If any pixel conversion cause issues, we will add a test for it
 
+const toU2 = color.ScaleValue(u2);
+const toU3 = color.ScaleValue(u3);
+const toU5 = color.ScaleValue(u5);
+const toU6 = color.ScaleValue(u6);
+const toU8 = color.ScaleValue(u8);
+const toU16 = color.ScaleValue(u16);
+const toF32 = color.ScaleValue(f32);
+
 test "PixelFormatConverter: convert from indexed1 to indexed2" {
     const indexed1_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .indexed1, 4);
     defer indexed1_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1008,11 +1016,11 @@ test "PixelFormatConverter: convvert from rgb555 to rgb332" {
     const rgb555_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .rgb555, 5);
     defer rgb555_pixels.deinit(helpers.zigimg_test_allocator);
 
-    rgb555_pixels.rgb555[0] = color.Rgb555.initRgb(31, 0, 0);
-    rgb555_pixels.rgb555[1] = color.Rgb555.initRgb(0, 31, 0);
-    rgb555_pixels.rgb555[2] = color.Rgb555.initRgb(0, 0, 31);
-    rgb555_pixels.rgb555[3] = color.Rgb555.initRgb(31, 31, 31);
-    rgb555_pixels.rgb555[4] = color.Rgb555.initRgb(0, 0, 0);
+    rgb555_pixels.rgb555[0] = color.Rgb555.from.rgb(31, 0, 0);
+    rgb555_pixels.rgb555[1] = color.Rgb555.from.rgb(0, 31, 0);
+    rgb555_pixels.rgb555[2] = color.Rgb555.from.rgb(0, 0, 31);
+    rgb555_pixels.rgb555[3] = color.Rgb555.from.rgb(31, 31, 31);
+    rgb555_pixels.rgb555[4] = color.Rgb555.from.rgb(0, 0, 0);
 
     const rgb332_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &rgb555_pixels, .rgb332);
     defer rgb332_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1042,11 +1050,11 @@ test "PixelFormatConverter: convvert from rgb555 to rgb565" {
     const rgb555_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .rgb555, 5);
     defer rgb555_pixels.deinit(helpers.zigimg_test_allocator);
 
-    rgb555_pixels.rgb555[0] = color.Rgb555.initRgb(31, 0, 0);
-    rgb555_pixels.rgb555[1] = color.Rgb555.initRgb(0, 31, 0);
-    rgb555_pixels.rgb555[2] = color.Rgb555.initRgb(0, 0, 31);
-    rgb555_pixels.rgb555[3] = color.Rgb555.initRgb(31, 31, 31);
-    rgb555_pixels.rgb555[4] = color.Rgb555.initRgb(0, 0, 0);
+    rgb555_pixels.rgb555[0] = color.Rgb555.from.rgb(31, 0, 0);
+    rgb555_pixels.rgb555[1] = color.Rgb555.from.rgb(0, 31, 0);
+    rgb555_pixels.rgb555[2] = color.Rgb555.from.rgb(0, 0, 31);
+    rgb555_pixels.rgb555[3] = color.Rgb555.from.rgb(31, 31, 31);
+    rgb555_pixels.rgb555[4] = color.Rgb555.from.rgb(0, 0, 0);
 
     const rgb565_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &rgb555_pixels, .rgb565);
     defer rgb565_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1076,11 +1084,11 @@ test "PixelFormatConverter: convert from rgb555 to rgb24" {
     const rgb555_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .rgb555, 5);
     defer rgb555_pixels.deinit(helpers.zigimg_test_allocator);
 
-    rgb555_pixels.rgb555[0] = color.Rgb555.initRgb(31, 0, 0);
-    rgb555_pixels.rgb555[1] = color.Rgb555.initRgb(0, 31, 0);
-    rgb555_pixels.rgb555[2] = color.Rgb555.initRgb(0, 0, 31);
-    rgb555_pixels.rgb555[3] = color.Rgb555.initRgb(31, 31, 31);
-    rgb555_pixels.rgb555[4] = color.Rgb555.initRgb(0, 0, 0);
+    rgb555_pixels.rgb555[0] = color.Rgb555.from.rgb(31, 0, 0);
+    rgb555_pixels.rgb555[1] = color.Rgb555.from.rgb(0, 31, 0);
+    rgb555_pixels.rgb555[2] = color.Rgb555.from.rgb(0, 0, 31);
+    rgb555_pixels.rgb555[3] = color.Rgb555.from.rgb(31, 31, 31);
+    rgb555_pixels.rgb555[4] = color.Rgb555.from.rgb(0, 0, 0);
 
     const rgb24_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &rgb555_pixels, .rgb24);
     defer rgb24_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1110,11 +1118,11 @@ test "PixelFormatConverter: convert from rgb555 to rgba32" {
     const rgb555_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .rgb555, 5);
     defer rgb555_pixels.deinit(helpers.zigimg_test_allocator);
 
-    rgb555_pixels.rgb555[0] = color.Rgb555.initRgb(31, 0, 0);
-    rgb555_pixels.rgb555[1] = color.Rgb555.initRgb(0, 31, 0);
-    rgb555_pixels.rgb555[2] = color.Rgb555.initRgb(0, 0, 31);
-    rgb555_pixels.rgb555[3] = color.Rgb555.initRgb(31, 31, 31);
-    rgb555_pixels.rgb555[4] = color.Rgb555.initRgb(0, 0, 0);
+    rgb555_pixels.rgb555[0] = color.Rgb555.from.rgb(31, 0, 0);
+    rgb555_pixels.rgb555[1] = color.Rgb555.from.rgb(0, 31, 0);
+    rgb555_pixels.rgb555[2] = color.Rgb555.from.rgb(0, 0, 31);
+    rgb555_pixels.rgb555[3] = color.Rgb555.from.rgb(31, 31, 31);
+    rgb555_pixels.rgb555[4] = color.Rgb555.from.rgb(0, 0, 0);
 
     const rgba32_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &rgb555_pixels, .rgba32);
     defer rgba32_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1149,11 +1157,11 @@ test "PixelFormatConverter: convert from rgb555 to float32" {
     const rgb555_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .rgb555, 5);
     defer rgb555_pixels.deinit(helpers.zigimg_test_allocator);
 
-    rgb555_pixels.rgb555[0] = color.Rgb555.initRgb(31, 0, 0);
-    rgb555_pixels.rgb555[1] = color.Rgb555.initRgb(0, 31, 0);
-    rgb555_pixels.rgb555[2] = color.Rgb555.initRgb(0, 0, 31);
-    rgb555_pixels.rgb555[3] = color.Rgb555.initRgb(31, 31, 31);
-    rgb555_pixels.rgb555[4] = color.Rgb555.initRgb(0, 0, 0);
+    rgb555_pixels.rgb555[0] = color.Rgb555.from.rgb(31, 0, 0);
+    rgb555_pixels.rgb555[1] = color.Rgb555.from.rgb(0, 31, 0);
+    rgb555_pixels.rgb555[2] = color.Rgb555.from.rgb(0, 0, 31);
+    rgb555_pixels.rgb555[3] = color.Rgb555.from.rgb(31, 31, 31);
+    rgb555_pixels.rgb555[4] = color.Rgb555.from.rgb(0, 0, 0);
 
     const float32_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &rgb555_pixels, .float32);
     defer float32_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1195,13 +1203,13 @@ test "PixelFormatConverter: convert rgba32 to bgra32" {
         const column: u8 = @truncate(index % 256);
 
         switch (row) {
-            0 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, 0, 0),
-            1 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(0, column, 0),
-            2 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(0, 0, column),
-            3 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, column, 0),
-            4 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, 0, column),
-            5 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(0, column, column),
-            6 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, column, column),
+            0 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, 0, 0),
+            1 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(0, column, 0),
+            2 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(0, 0, column),
+            3 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, column, 0),
+            4 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, 0, column),
+            5 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(0, column, column),
+            6 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1226,13 +1234,13 @@ test "PixelFormatConverter: convert bgra32 to rgba32" {
         const column: u8 = @truncate(index % 256);
 
         switch (row) {
-            0 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, 0, 0),
-            1 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(0, column, 0),
-            2 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(0, 0, column),
-            3 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, column, 0),
-            4 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, 0, column),
-            5 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(0, column, column),
-            6 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, column, column),
+            0 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, 0, 0),
+            1 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(0, column, 0),
+            2 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(0, 0, column),
+            3 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, column, 0),
+            4 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, 0, column),
+            5 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(0, column, column),
+            6 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1257,13 +1265,13 @@ test "PixelFormatConverter: convert rgba32 to float32" {
         const column: u8 = @truncate(index % 256);
 
         switch (row) {
-            0 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, 0, 0),
-            1 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(0, column, 0),
-            2 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(0, 0, column),
-            3 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, column, 0),
-            4 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, 0, column),
-            5 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(0, column, column),
-            6 => rgba32_pixels.rgba32[index] = color.Rgba32.initRgb(column, column, column),
+            0 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, 0, 0),
+            1 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(0, column, 0),
+            2 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(0, 0, column),
+            3 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, column, 0),
+            4 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, 0, column),
+            5 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(0, column, column),
+            6 => rgba32_pixels.rgba32[index] = color.Rgba32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1273,10 +1281,10 @@ test "PixelFormatConverter: convert rgba32 to float32" {
 
     const float_tolerance = 0.0001;
     for (0..float32_pixels.float32.len) |index| {
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].r, color.toF32Color(rgba32_pixels.rgba32[index].r), float_tolerance);
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].g, color.toF32Color(rgba32_pixels.rgba32[index].g), float_tolerance);
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].b, color.toF32Color(rgba32_pixels.rgba32[index].b), float_tolerance);
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].a, color.toF32Color(rgba32_pixels.rgba32[index].a), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].r, toF32(rgba32_pixels.rgba32[index].r), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].g, toF32(rgba32_pixels.rgba32[index].g), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].b, toF32(rgba32_pixels.rgba32[index].b), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].a, toF32(rgba32_pixels.rgba32[index].a), float_tolerance);
     }
 }
 
@@ -1289,13 +1297,13 @@ test "PixelFormatConverter: convert bgra32 to float32" {
         const column: u8 = @truncate(index % 256);
 
         switch (row) {
-            0 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, 0, 0),
-            1 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(0, column, 0),
-            2 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(0, 0, column),
-            3 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, column, 0),
-            4 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, 0, column),
-            5 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(0, column, column),
-            6 => bgra32_pixels.bgra32[index] = color.Bgra32.initRgb(column, column, column),
+            0 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, 0, 0),
+            1 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(0, column, 0),
+            2 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(0, 0, column),
+            3 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, column, 0),
+            4 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, 0, column),
+            5 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(0, column, column),
+            6 => bgra32_pixels.bgra32[index] = color.Bgra32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1305,10 +1313,10 @@ test "PixelFormatConverter: convert bgra32 to float32" {
 
     const float_tolerance = 0.0001;
     for (0..float32_pixels.float32.len) |index| {
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].r, color.toF32Color(bgra32_pixels.bgra32[index].r), float_tolerance);
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].g, color.toF32Color(bgra32_pixels.bgra32[index].g), float_tolerance);
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].b, color.toF32Color(bgra32_pixels.bgra32[index].b), float_tolerance);
-        try helpers.expectApproxEqAbs(float32_pixels.float32[index].a, color.toF32Color(bgra32_pixels.bgra32[index].a), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].r, toF32(bgra32_pixels.bgra32[index].r), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].g, toF32(bgra32_pixels.bgra32[index].g), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].b, toF32(bgra32_pixels.bgra32[index].b), float_tolerance);
+        try helpers.expectApproxEqAbs(float32_pixels.float32[index].a, toF32(bgra32_pixels.bgra32[index].a), float_tolerance);
     }
 }
 
@@ -1318,16 +1326,16 @@ test "PixelFormatConverter: convert float32 to rgba32" {
 
     for (0..float32_pixels.float32.len) |index| {
         const row: u8 = @truncate(index / 256);
-        const column: f32 = color.toF32Color(@as(u8, @truncate(index % 256)));
+        const column: f32 = toF32(@as(u8, @truncate(index % 256)));
 
         switch (row) {
-            0 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, 0),
-            1 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, 0),
-            2 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, 0, column),
-            3 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, 0),
-            4 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, column),
-            5 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, column),
-            6 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, column),
+            0 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, 0),
+            1 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, 0),
+            2 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, 0, column),
+            3 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, 0),
+            4 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, column),
+            5 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, column),
+            6 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1336,10 +1344,10 @@ test "PixelFormatConverter: convert float32 to rgba32" {
     defer rgba32_pixels.deinit(helpers.zigimg_test_allocator);
 
     for (0..rgba32_pixels.rgba32.len) |index| {
-        try helpers.expectEq(rgba32_pixels.rgba32[index].r, color.toIntColor(u8, float32_pixels.float32[index].r));
-        try helpers.expectEq(rgba32_pixels.rgba32[index].g, color.toIntColor(u8, float32_pixels.float32[index].g));
-        try helpers.expectEq(rgba32_pixels.rgba32[index].b, color.toIntColor(u8, float32_pixels.float32[index].b));
-        try helpers.expectEq(rgba32_pixels.rgba32[index].a, color.toIntColor(u8, float32_pixels.float32[index].a));
+        try helpers.expectEq(rgba32_pixels.rgba32[index].r, toU8(float32_pixels.float32[index].r));
+        try helpers.expectEq(rgba32_pixels.rgba32[index].g, toU8(float32_pixels.float32[index].g));
+        try helpers.expectEq(rgba32_pixels.rgba32[index].b, toU8(float32_pixels.float32[index].b));
+        try helpers.expectEq(rgba32_pixels.rgba32[index].a, toU8(float32_pixels.float32[index].a));
     }
 }
 
@@ -1349,16 +1357,16 @@ test "PixelFormatConverter: convert float32 to bgra32" {
 
     for (0..float32_pixels.float32.len) |index| {
         const row: u8 = @truncate(index / 256);
-        const column: f32 = color.toF32Color(@as(u8, @truncate(index % 256)));
+        const column: f32 = toF32(@as(u8, @truncate(index % 256)));
 
         switch (row) {
-            0 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, 0),
-            1 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, 0),
-            2 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, 0, column),
-            3 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, 0),
-            4 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, column),
-            5 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, column),
-            6 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, column),
+            0 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, 0),
+            1 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, 0),
+            2 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, 0, column),
+            3 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, 0),
+            4 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, column),
+            5 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, column),
+            6 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1367,10 +1375,10 @@ test "PixelFormatConverter: convert float32 to bgra32" {
     defer bgra32_pixels.deinit(helpers.zigimg_test_allocator);
 
     for (0..bgra32_pixels.bgra32.len) |index| {
-        try helpers.expectEq(bgra32_pixels.bgra32[index].r, color.toIntColor(u8, float32_pixels.float32[index].r));
-        try helpers.expectEq(bgra32_pixels.bgra32[index].g, color.toIntColor(u8, float32_pixels.float32[index].g));
-        try helpers.expectEq(bgra32_pixels.bgra32[index].b, color.toIntColor(u8, float32_pixels.float32[index].b));
-        try helpers.expectEq(bgra32_pixels.bgra32[index].a, color.toIntColor(u8, float32_pixels.float32[index].a));
+        try helpers.expectEq(bgra32_pixels.bgra32[index].r, toU8(float32_pixels.float32[index].r));
+        try helpers.expectEq(bgra32_pixels.bgra32[index].g, toU8(float32_pixels.float32[index].g));
+        try helpers.expectEq(bgra32_pixels.bgra32[index].b, toU8(float32_pixels.float32[index].b));
+        try helpers.expectEq(bgra32_pixels.bgra32[index].a, toU8(float32_pixels.float32[index].a));
     }
 }
 
@@ -1380,16 +1388,16 @@ test "PixelFormatConverter: convert float32 to rgba64" {
 
     for (0..float32_pixels.float32.len) |index| {
         const row: u8 = @truncate(index / 256);
-        const column: f32 = color.toF32Color(@as(u8, @truncate(index % 256)));
+        const column: f32 = toF32(@as(u8, @truncate(index % 256)));
 
         switch (row) {
-            0 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, 0),
-            1 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, 0),
-            2 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, 0, column),
-            3 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, 0),
-            4 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, column),
-            5 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, column),
-            6 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, column),
+            0 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, 0),
+            1 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, 0),
+            2 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, 0, column),
+            3 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, 0),
+            4 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, column),
+            5 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, column),
+            6 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1398,10 +1406,10 @@ test "PixelFormatConverter: convert float32 to rgba64" {
     defer rgba64_pixels.deinit(helpers.zigimg_test_allocator);
 
     for (0..rgba64_pixels.rgba64.len) |index| {
-        try helpers.expectEq(rgba64_pixels.rgba64[index].r, color.toIntColor(u16, float32_pixels.float32[index].r));
-        try helpers.expectEq(rgba64_pixels.rgba64[index].g, color.toIntColor(u16, float32_pixels.float32[index].g));
-        try helpers.expectEq(rgba64_pixels.rgba64[index].b, color.toIntColor(u16, float32_pixels.float32[index].b));
-        try helpers.expectEq(rgba64_pixels.rgba64[index].a, color.toIntColor(u16, float32_pixels.float32[index].a));
+        try helpers.expectEq(rgba64_pixels.rgba64[index].r, toU16(float32_pixels.float32[index].r));
+        try helpers.expectEq(rgba64_pixels.rgba64[index].g, toU16(float32_pixels.float32[index].g));
+        try helpers.expectEq(rgba64_pixels.rgba64[index].b, toU16(float32_pixels.float32[index].b));
+        try helpers.expectEq(rgba64_pixels.rgba64[index].a, toU16(float32_pixels.float32[index].a));
     }
 }
 
@@ -1411,16 +1419,16 @@ test "PixelFormatConverter: convert float32 to rgb332" {
 
     for (0..float32_pixels.float32.len) |index| {
         const row: u8 = @truncate(index / 256);
-        const column: f32 = color.toF32Color(@as(u8, @truncate(index % 256)));
+        const column: f32 = toF32(@as(u8, @truncate(index % 256)));
 
         switch (row) {
-            0 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, 0),
-            1 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, 0),
-            2 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, 0, column),
-            3 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, 0),
-            4 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, column),
-            5 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, column),
-            6 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, column),
+            0 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, 0),
+            1 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, 0),
+            2 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, 0, column),
+            3 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, 0),
+            4 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, column),
+            5 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, column),
+            6 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1429,9 +1437,9 @@ test "PixelFormatConverter: convert float32 to rgb332" {
     defer rgb332_pixels.deinit(helpers.zigimg_test_allocator);
 
     for (0..rgb332_pixels.rgb332.len) |index| {
-        try helpers.expectEq(rgb332_pixels.rgb332[index].r, color.toIntColor(u3, float32_pixels.float32[index].r));
-        try helpers.expectEq(rgb332_pixels.rgb332[index].g, color.toIntColor(u3, float32_pixels.float32[index].g));
-        try helpers.expectEq(rgb332_pixels.rgb332[index].b, color.toIntColor(u2, float32_pixels.float32[index].b));
+        try helpers.expectEq(rgb332_pixels.rgb332[index].r, toU3(float32_pixels.float32[index].r));
+        try helpers.expectEq(rgb332_pixels.rgb332[index].g, toU3(float32_pixels.float32[index].g));
+        try helpers.expectEq(rgb332_pixels.rgb332[index].b, toU2(float32_pixels.float32[index].b));
     }
 }
 
@@ -1441,16 +1449,16 @@ test "PixelFormatConverter: convert float32 to rgb565" {
 
     for (0..float32_pixels.float32.len) |index| {
         const row: u8 = @truncate(index / 256);
-        const column: f32 = color.toF32Color(@as(u8, @truncate(index % 256)));
+        const column: f32 = toF32(@as(u8, @truncate(index % 256)));
 
         switch (row) {
-            0 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, 0),
-            1 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, 0),
-            2 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, 0, column),
-            3 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, 0),
-            4 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, 0, column),
-            5 => float32_pixels.float32[index] = color.Colorf32.initRgb(0, column, column),
-            6 => float32_pixels.float32[index] = color.Colorf32.initRgb(column, column, column),
+            0 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, 0),
+            1 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, 0),
+            2 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, 0, column),
+            3 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, 0),
+            4 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, 0, column),
+            5 => float32_pixels.float32[index] = color.Colorf32.from.rgb(0, column, column),
+            6 => float32_pixels.float32[index] = color.Colorf32.from.rgb(column, column, column),
             else => {},
         }
     }
@@ -1459,9 +1467,9 @@ test "PixelFormatConverter: convert float32 to rgb565" {
     defer rgb565_pixels.deinit(helpers.zigimg_test_allocator);
 
     for (0..rgb565_pixels.rgb565.len) |index| {
-        try helpers.expectEq(rgb565_pixels.rgb565[index].r, color.toIntColor(u5, float32_pixels.float32[index].r));
-        try helpers.expectEq(rgb565_pixels.rgb565[index].g, color.toIntColor(u6, float32_pixels.float32[index].g));
-        try helpers.expectEq(rgb565_pixels.rgb565[index].b, color.toIntColor(u5, float32_pixels.float32[index].b));
+        try helpers.expectEq(rgb565_pixels.rgb565[index].r, toU5(float32_pixels.float32[index].r));
+        try helpers.expectEq(rgb565_pixels.rgb565[index].g, toU6(float32_pixels.float32[index].g));
+        try helpers.expectEq(rgb565_pixels.rgb565[index].b, toU5(float32_pixels.float32[index].b));
     }
 }
 
@@ -1469,18 +1477,18 @@ test "PixelFormatConverter: convert float32 to grayscale16Alpha" {
     const float32_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .float32, 9);
     defer float32_pixels.deinit(helpers.zigimg_test_allocator);
 
-    float32_pixels.float32[0] = color.Colorf32.initRgb(1.0, 0.0, 0.0);
-    float32_pixels.float32[1] = color.Colorf32.initRgb(0.0, 1.0, 0.0);
-    float32_pixels.float32[2] = color.Colorf32.initRgb(0.0, 0.0, 1.0);
+    float32_pixels.float32[0] = color.Colorf32.from.rgb(1.0, 0.0, 0.0);
+    float32_pixels.float32[1] = color.Colorf32.from.rgb(0.0, 1.0, 0.0);
+    float32_pixels.float32[2] = color.Colorf32.from.rgb(0.0, 0.0, 1.0);
 
-    float32_pixels.float32[3] = color.Colorf32.initRgb(1.0, 0.0, 1.0);
-    float32_pixels.float32[4] = color.Colorf32.initRgb(1.0, 1.0, 0.0);
-    float32_pixels.float32[5] = color.Colorf32.initRgb(0.0, 1.0, 1.0);
+    float32_pixels.float32[3] = color.Colorf32.from.rgb(1.0, 0.0, 1.0);
+    float32_pixels.float32[4] = color.Colorf32.from.rgb(1.0, 1.0, 0.0);
+    float32_pixels.float32[5] = color.Colorf32.from.rgb(0.0, 1.0, 1.0);
 
-    float32_pixels.float32[6] = color.Colorf32.initRgb(1.0, 1.0, 1.0);
-    float32_pixels.float32[7] = color.Colorf32.initRgb(0.0, 0.0, 0.0);
+    float32_pixels.float32[6] = color.Colorf32.from.rgb(1.0, 1.0, 1.0);
+    float32_pixels.float32[7] = color.Colorf32.from.rgb(0.0, 0.0, 0.0);
 
-    float32_pixels.float32[8] = color.Colorf32.initRgba(0.2, 0.1, 0.8, 0.4);
+    float32_pixels.float32[8] = color.Colorf32.from.rgba(0.2, 0.1, 0.8, 0.4);
 
     const grayscale16_alpha_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &float32_pixels, .grayscale16Alpha);
     defer grayscale16_alpha_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1517,18 +1525,18 @@ test "PixelFormatConverter: convert float32 to grayscale8" {
     const float32_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .float32, 9);
     defer float32_pixels.deinit(helpers.zigimg_test_allocator);
 
-    float32_pixels.float32[0] = color.Colorf32.initRgb(1.0, 0.0, 0.0);
-    float32_pixels.float32[1] = color.Colorf32.initRgb(0.0, 1.0, 0.0);
-    float32_pixels.float32[2] = color.Colorf32.initRgb(0.0, 0.0, 1.0);
+    float32_pixels.float32[0] = color.Colorf32.from.rgb(1.0, 0.0, 0.0);
+    float32_pixels.float32[1] = color.Colorf32.from.rgb(0.0, 1.0, 0.0);
+    float32_pixels.float32[2] = color.Colorf32.from.rgb(0.0, 0.0, 1.0);
 
-    float32_pixels.float32[3] = color.Colorf32.initRgb(1.0, 0.0, 1.0);
-    float32_pixels.float32[4] = color.Colorf32.initRgb(1.0, 1.0, 0.0);
-    float32_pixels.float32[5] = color.Colorf32.initRgb(0.0, 1.0, 1.0);
+    float32_pixels.float32[3] = color.Colorf32.from.rgb(1.0, 0.0, 1.0);
+    float32_pixels.float32[4] = color.Colorf32.from.rgb(1.0, 1.0, 0.0);
+    float32_pixels.float32[5] = color.Colorf32.from.rgb(0.0, 1.0, 1.0);
 
-    float32_pixels.float32[6] = color.Colorf32.initRgb(1.0, 1.0, 1.0);
-    float32_pixels.float32[7] = color.Colorf32.initRgb(0.0, 0.0, 0.0);
+    float32_pixels.float32[6] = color.Colorf32.from.rgb(1.0, 1.0, 1.0);
+    float32_pixels.float32[7] = color.Colorf32.from.rgb(0.0, 0.0, 0.0);
 
-    float32_pixels.float32[8] = color.Colorf32.initRgba(0.2, 0.1, 0.8, 0.4);
+    float32_pixels.float32[8] = color.Colorf32.from.rgba(0.2, 0.1, 0.8, 0.4);
 
     const grayscale8_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &float32_pixels, .grayscale8);
     defer grayscale8_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1556,18 +1564,18 @@ test "PixelFormatConverter: convert rgba64 to grayscale16Alpha" {
     const rgba64_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .rgba64, 9);
     defer rgba64_pixels.deinit(helpers.zigimg_test_allocator);
 
-    rgba64_pixels.rgba64[0] = color.Rgba64.initRgb(65535, 0, 0);
-    rgba64_pixels.rgba64[1] = color.Rgba64.initRgb(0, 65535, 0);
-    rgba64_pixels.rgba64[2] = color.Rgba64.initRgb(0, 0, 65535);
+    rgba64_pixels.rgba64[0] = color.Rgba64.from.rgb(65535, 0, 0);
+    rgba64_pixels.rgba64[1] = color.Rgba64.from.rgb(0, 65535, 0);
+    rgba64_pixels.rgba64[2] = color.Rgba64.from.rgb(0, 0, 65535);
 
-    rgba64_pixels.rgba64[3] = color.Rgba64.initRgb(65535, 0, 65535);
-    rgba64_pixels.rgba64[4] = color.Rgba64.initRgb(65535, 65535, 0);
-    rgba64_pixels.rgba64[5] = color.Rgba64.initRgb(0, 65535, 65535);
+    rgba64_pixels.rgba64[3] = color.Rgba64.from.rgb(65535, 0, 65535);
+    rgba64_pixels.rgba64[4] = color.Rgba64.from.rgb(65535, 65535, 0);
+    rgba64_pixels.rgba64[5] = color.Rgba64.from.rgb(0, 65535, 65535);
 
-    rgba64_pixels.rgba64[6] = color.Rgba64.initRgb(65535, 65535, 65535);
-    rgba64_pixels.rgba64[7] = color.Rgba64.initRgb(0, 0, 0);
+    rgba64_pixels.rgba64[6] = color.Rgba64.from.rgb(65535, 65535, 65535);
+    rgba64_pixels.rgba64[7] = color.Rgba64.from.rgb(0, 0, 0);
 
-    rgba64_pixels.rgba64[8] = color.Rgba64.initRgba(13107, 6553, 52428, 26214);
+    rgba64_pixels.rgba64[8] = color.Rgba64.from.rgba(13107, 6553, 52428, 26214);
 
     const grayscale16_alpha_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &rgba64_pixels, .grayscale16Alpha);
     defer grayscale16_alpha_pixels.deinit(helpers.zigimg_test_allocator);
@@ -1604,18 +1612,18 @@ test "PixelFormatConverter: convert rgba32 to grayscale8" {
     const rgba32_pixels = try color.PixelStorage.init(helpers.zigimg_test_allocator, .rgba32, 9);
     defer rgba32_pixels.deinit(helpers.zigimg_test_allocator);
 
-    rgba32_pixels.rgba32[0] = color.Rgba32.initRgb(255, 0, 0);
-    rgba32_pixels.rgba32[1] = color.Rgba32.initRgb(0, 255, 0);
-    rgba32_pixels.rgba32[2] = color.Rgba32.initRgb(0, 0, 255);
+    rgba32_pixels.rgba32[0] = color.Rgba32.from.rgb(255, 0, 0);
+    rgba32_pixels.rgba32[1] = color.Rgba32.from.rgb(0, 255, 0);
+    rgba32_pixels.rgba32[2] = color.Rgba32.from.rgb(0, 0, 255);
 
-    rgba32_pixels.rgba32[3] = color.Rgba32.initRgb(255, 0, 255);
-    rgba32_pixels.rgba32[4] = color.Rgba32.initRgb(255, 255, 0);
-    rgba32_pixels.rgba32[5] = color.Rgba32.initRgb(0, 255, 255);
+    rgba32_pixels.rgba32[3] = color.Rgba32.from.rgb(255, 0, 255);
+    rgba32_pixels.rgba32[4] = color.Rgba32.from.rgb(255, 255, 0);
+    rgba32_pixels.rgba32[5] = color.Rgba32.from.rgb(0, 255, 255);
 
-    rgba32_pixels.rgba32[6] = color.Rgba32.initRgb(255, 255, 255);
-    rgba32_pixels.rgba32[7] = color.Rgba32.initRgb(0, 0, 0);
+    rgba32_pixels.rgba32[6] = color.Rgba32.from.rgb(255, 255, 255);
+    rgba32_pixels.rgba32[7] = color.Rgba32.from.rgb(0, 0, 0);
 
-    rgba32_pixels.rgba32[8] = color.Rgba32.initRgba(51, 25, 204, 102);
+    rgba32_pixels.rgba32[8] = color.Rgba32.from.rgba(51, 25, 204, 102);
 
     const grayscale8_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &rgba32_pixels, .grayscale8);
     defer grayscale8_pixels.deinit(helpers.zigimg_test_allocator);


### PR DESCRIPTION
Resolves #276 

This ended up being trickier than expected, I encountered 2 compiler bugs in the process of making these changes! (Both are packed struct misbehavior, interestingly.)
- https://github.com/ziglang/zig/issues/24071
- https://github.com/ziglang/zig/issues/20458

See commit message for more details.

As noted in the commit message, there is now a difference in API between RGB(A) colors and others such as grayscale, which should probably be remedied in the future by creating similar namespaces for them, so that functions can be written generically.

> [!NOTE]
> This does pass all tests (well, except GIF `high-color` which was already a failing test), but I can't promise it doesn't introduce some very subtle behavior difference somewhere compared to the old code.

---

Feel free to make any changes you deem necessary before merging, or if the compromises that had to be made aren't worth it to you and you'd rather not make this change, I understand. Thanks for the hard work on zigimg, it's quite useful!