### PR TITLE
Remove unconditional debug statement to make it work on freestanding targets

### DIFF
--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -323,8 +323,6 @@ pub const TIFF = struct {
 
         try self.decodeBitmap(stream, allocator);
 
-        self.bitmap.debug();
-
         const pixel_format = try self.bitmap.guessPixelFormat();
 
         var pixels = try color.PixelStorage.init(allocator, pixel_format, self.bitmap.image_width * self.bitmap.image_height);


### PR DESCRIPTION
This debug statement will produce a compile error on freestanding targets:

```
/home/fabian/.local/lib/std/Thread.zig:558:9: error: Unsupported operating system freestanding
        @compileError("Unsupported operating system " ++ @tagName(native_os));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabian/.local/lib/std/Thread/Futex.zig:103:9: error: Unsupported operating system freestanding
        @compileError("Unsupported operating system " ++ @tagName(builtin.target.os.tag));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabian/.local/lib/std/Thread/Futex.zig:103:9: error: Unsupported operating system freestanding
        @compileError("Unsupported operating system " ++ @tagName(builtin.target.os.tag));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabian/.local/lib/std/posix.zig:110:33: error: struct 'posix.system__struct_11554' has no member named 'STDERR_FILENO'
pub const STDERR_FILENO = system.STDERR_FILENO;
                          ~~~~~~^~~~~~~~~~~~~~
/home/fabian/.local/lib/std/posix.zig:49:13: note: struct declared here
    else => struct {
            ^~~~~~
/home/fabian/.local/lib/std/posix.zig:1262:26: error: struct 'posix.system__struct_11554' has no member named 'write'
        const rc = system.write(fd, bytes.ptr, @min(bytes.len, max_count));
                   ~~~~~~^~~~~~
/home/fabian/.local/lib/std/posix.zig:49:13: note: struct declared here
    else => struct {
    ```