### PR TITLE
jpeg: prevent potential panic

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -15,8 +15,6 @@ const FrameHeader = @import("./jpeg/FrameHeader.zig");
 const JFIFHeader = @import("./jpeg/JFIFHeader.zig");
 
 const Markers = @import("./jpeg/utils.zig").Markers;
-const ZigzagOffsets = @import("./jpeg/utils.zig").ZigzagOffsets;
-const IDCTMultipliers = @import("./jpeg/utils.zig").IDCTMultipliers;
 const QuantizationTable = @import("./jpeg/quantization.zig").Table;
 
 const HuffmanReader = @import("./jpeg/huffman.zig").Reader;

--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -172,11 +172,15 @@ pub const JPEG = struct {
             }
         }
 
-        try self.frame.?.dequantizeBlocks();
-        self.frame.?.idctBlocks();
-        try self.frame.?.renderToPixels(&pixels_opt.*.?);
+        if (self.frame) |*frame| {
+            try frame.dequantizeBlocks();
+            frame.idctBlocks();
+            try frame.renderToPixels(&pixels_opt.*.?);
 
-        return if (self.frame) |frame| frame else ImageReadError.InvalidData;
+            return frame.*;
+        }
+
+        return ImageReadError.InvalidData;
     }
 
     // Format interface


### PR DESCRIPTION
jpeg: add if around self.frame access
It's possible for a malformed jpeg to not have a start of frame marker (sof) and not allocate a frame. Then it can exit the marker reading loop.

Previously the frame would panic in this case. Instead check if the frame has been allocated and return an error otherwise.