### PR TITLE
Update README.md, Image.fromFile takes a pointer to std.fs.File

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ pub fn main() !void {
     var file = try std.fs.cwd().openFile(file_path, .{});
     defer file.close();
 
-    var image = try zigimg.Image.fromFile(allocator, file);
+    var image = try zigimg.Image.fromFile(allocator, &file);
     defer image.deinit();
 
     // Do something with your image


### PR DESCRIPTION
Image.fromFile takes a pointer to std.fs.File, not std.fs.File