### PR TITLE
Make the library accessible via build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,7 @@
 const Build = @import("std").Build;
 
+pub const zigimg = @import("zigimg");
+
 pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const Build = @import("std").Build;
 
-pub const zigimg = @import("zigimg");
+pub const zigimg = @import("zigimg.zig");
 
 pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});


### PR DESCRIPTION
A project I've been contributing to uses zigimg as a build.zig dependency to load images as part of an asset pipeline. By exporting zigimg itself in build.zig, this project can refer to zigimg with a build.zig.zon dependency instead of having to use a git submodule. (`@import("zigimg")` in a dependent project's build.zig imports the contents of zigimg's build.zig)

Basically, this makes it easier to use zigimg as part of a build-time asset pipeline, not only as a runtime library.