### PR TITLE
Make PngWriter.writeTrailer function public

### DIFF
--- a/src/formats/png.zig
+++ b/src/formats/png.zig
@@ -280,7 +280,7 @@ const PngWriter = struct {
     }
 
     // IEND chunk
-    fn writeTrailer(self: *PngWriter) Image.WriteError!void {
+    pub fn writeTrailer(self: *PngWriter) Image.WriteError!void {
         var chunk_writer = ChunkWriter.init(self.writer, self.chunk_buffer, Chunks.IEND);
         var writer = &chunk_writer.writer;
         try writer.flush();


### PR DESCRIPTION
All other functions are public, so this should also be. Note it currently works without being public, so this fix is only for consistency.