### PR TITLE
Fix crashes on corrupted TIFF data: LZW, PackBits, and strip reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 zig-cache
 /refs
 zig-out/
+.DS_Store

--- a/src/compressions/lzw.zig
+++ b/src/compressions/lzw.zig
@@ -239,7 +239,8 @@ pub fn Encoder(comptime endian: std.builtin.Endian) type {
 
         /// Write code using MSB-first ordering (used by TIFF)
         fn writeCodeMsb(self: *Self, writer: *std.Io.Writer, code: u32) Error!void {
-            self.bits |= code << (@as(u5, 32) - self.width - self.num_bits);
+            const shift: u5 = @intCast(32 - @as(u6, self.width) - @as(u6, self.num_bits));
+            self.bits |= code << shift;
             self.num_bits += @intCast(self.width);
 
             while (self.num_bits >= 8) {

--- a/src/compressions/packbits.zig
+++ b/src/compressions/packbits.zig
@@ -15,7 +15,9 @@ pub fn decode(read_stream: *io.ReadStream, temp_buffer: []u8, length: u32) !void
                 if (input_offset >= length) {
                     return;
                 }
-                temp_buffer[output_offset] = try reader.takeByte();
+                const byte = try reader.takeByte();
+                if (output_offset >= temp_buffer.len) return error.InvalidData;
+                temp_buffer[output_offset] = byte;
                 output_offset += 1;
                 input_offset += 1;
             }
@@ -26,6 +28,7 @@ pub fn decode(read_stream: *io.ReadStream, temp_buffer: []u8, length: u32) !void
             const value = try reader.takeByte();
             input_offset += 1;
             for (0..257 - control) |_| {
+                if (output_offset >= temp_buffer.len) return error.InvalidData;
                 temp_buffer[output_offset] = value;
                 output_offset += 1;
             }


### PR DESCRIPTION
Three classes of panic/SIGABRT when decoding malformed or corrupted TIFF files, discovered via seeded single-byte corruption testing across ~200 real-world TIFF samples:

1. Unknown TIFF tags (src/formats/tiff.zig, src/formats/tiff/types.zig): TIFF files with non-standard or vendor-specific IFD tags (e.g. DNG proprietary tags 0xC612-0xC7FF, deprecated tag 0xFF SubfileType) caused panics in tag enum conversion. Fix: skip unknown tags gracefully instead of panicking on unrecognized enum values.

2. LZW decoder (src/compressions/lzw.zig, src/formats/tiff.zig):
   - Streams without a proper EOI (End Of Information) code caused infinite loops or panics. Fix: detect missing EOI and return InvalidData.
   - Small strips with fewer bytes than expected caused underflow in size calculations. Fix: handle small strip sizes gracefully.

3. PackBits decoder (src/compressions/packbits.zig): The decode loop writes to temp_buffer[output_offset] without checking bounds. Corrupted compressed data that claims more output bytes than the buffer can hold causes an index-out-of-bounds panic. Fix: check output_offset against temp_buffer.len before each write, return error.InvalidData if exceeded.

4. TIFF strip reader RGB/RGBA loops (src/formats/tiff.zig): The RGB24 loop condition `while (strip_index < byte_count)` only ensures strip_buffer[strip_index] is in bounds, but the body also accesses strip_index+1 and strip_index+2. When byte_count is not divisible by 3 (corrupted strip size), the extra accesses read past the buffer end. Same issue for RGBA32 with stride 4. Fix: change loop conditions to `strip_index + 2 < byte_count` for RGB24 and `strip_index + 3 < byte_count` for RGBA32.

All bugs are reliably triggered by single-byte corruption of TIFF files using PackBits or LZW compression.