### PR TITLE
tests: skip fixture-dependent cases without test-suite checkout

### DIFF
--- a/tests/formats/gif_test.zig
+++ b/tests/formats/gif_test.zig
@@ -565,7 +565,7 @@ const SINGLE_GIF_FILE_TEST = false;
 fn loadRotatingEarthImage(allocator: std.mem.Allocator) !zigimg.Image {
     var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
     const image_path = helpers.fixtures_path ++ "gif/rotating_earth.gif";
-    return zigimg.Image.fromFilePath(allocator, test_io, image_path, read_buffer[0..]);
+    return helpers.testImageFromFileWithAllocator(allocator, test_io, image_path, read_buffer[0..]);
 }
 
 test "GIF test suite" {

--- a/tests/helpers.zig
+++ b/tests/helpers.zig
@@ -35,9 +35,18 @@ pub fn testOpenFile(io: std.Io, file_path: []const u8) !std.Io.File {
         if (err == error.FileNotFound) return error.SkipZigTest else return err;
 }
 
-pub fn testImageFromFile(io: std.Io, image_path: []const u8, buffer: []u8) !zigimg.Image {
-    return zigimg.Image.fromFilePath(zigimg_test_allocator, io, image_path, buffer) catch |err|
+pub fn testDetectFormatFromFilePath(io: std.Io, file_path: []const u8, buffer: []u8) !zigimg.Image.Format {
+    return zigimg.Image.detectFormatFromFilePath(io, file_path, buffer) catch |err|
         if (err == error.FileNotFound) return error.SkipZigTest else return err;
+}
+
+pub fn testImageFromFileWithAllocator(allocator: std.mem.Allocator, io: std.Io, image_path: []const u8, buffer: []u8) !zigimg.Image {
+    return zigimg.Image.fromFilePath(allocator, io, image_path, buffer) catch |err|
+        if (err == error.FileNotFound) return error.SkipZigTest else return err;
+}
+
+pub fn testImageFromFile(io: std.Io, image_path: []const u8, buffer: []u8) !zigimg.Image {
+    return testImageFromFileWithAllocator(zigimg_test_allocator, io, image_path, buffer);
 }
 
 pub fn testReadFile(io: std.Io, file_path: []const u8, buffer: []u8) ![]u8 {

--- a/tests/image_test.zig
+++ b/tests/image_test.zig
@@ -189,7 +189,7 @@ test "Should detect BMP properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .bmp);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -215,7 +215,7 @@ test "Should detect GIF properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .gif);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -233,7 +233,7 @@ test "Should detect PCX properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .pcx);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -249,7 +249,7 @@ test "Should detect PBM properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .pbm);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -267,7 +267,7 @@ test "Should detect PGM properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .pgm);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -283,7 +283,7 @@ test "Should detect PPM properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .ppm);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -299,7 +299,7 @@ test "Should detect PNG properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .png);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -323,7 +323,7 @@ test "Should detect TGA properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .tga);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -336,7 +336,7 @@ test "Should detect QOI properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .qoi);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -352,7 +352,7 @@ test "Should detect JPEG properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .jpeg);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -368,7 +368,7 @@ test "Should detect Farbfeld properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .farbfeld);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -383,7 +383,7 @@ test "Should detect IFF/PBM properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .iff);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -398,7 +398,7 @@ test "Should detect RAS properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .ras);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -413,7 +413,7 @@ test "Should detect SGI properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .sgi);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -428,7 +428,7 @@ test "Should detect TIFF properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .tiff);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);
@@ -451,7 +451,7 @@ test "Should detect XBM properly" {
 
     for (image_tests) |image_path| {
         var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
-        const format = try Image.detectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
+        const format = try helpers.testDetectFormatFromFilePath(test_io, image_path, read_buffer[0..]);
         try std.testing.expect(format == .xbm);
 
         var test_image = try helpers.testImageFromFile(test_io, image_path, read_buffer[0..]);


### PR DESCRIPTION
## Summary
- add test helpers that convert missing fixture files into `error.SkipZigTest`
- use those helpers in `tests/image_test.zig` and the rotating earth GIF loader
- keep fixture-dependent tests from failing when `../test-suite/fixtures/` is not checked out

## Why
Some tests already treat a missing `../test-suite/fixtures/` checkout as `error.SkipZigTest`, but a few code paths were still calling the raw image APIs directly. In a plain checkout, that made `zig build test` fail with `FileNotFound` instead of skipping those cases.

## Validation
- `nix-shell -p zig --run 'zig build test'`
