### PR TITLE
TIFF: tolerate non-conformant uncompressed RGB scans + initial CCITT Group 4 decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 zig-cache
 /refs
 zig-out/
+.DS_Store

--- a/src/compressions/ccitt_t6.zig
+++ b/src/compressions/ccitt_t6.zig
@@ -2,7 +2,7 @@
 //
 // T.6 codes each scan line relative to the previous (reference) line, using
 // three modes:
-//   - Pass mode (0001): copy run from reference line, advance to b2.
+//   - Pass mode (0001): copy run from reference line, advance a0 to b2.
 //   - Vertical mode (V0=1, VR1=011, VL1=010, VR2=000011, VL2=000010,
 //     VR3=0000011, VL3=0000010): emit pixels up to b1 +/- k, color flips.
 //   - Horizontal mode (001): two 1D-style run-length codes (a0a1 then a1a2).
@@ -10,15 +10,17 @@
 // EOL markers between rows (unlike T.4); decoding stops when we have produced
 // `num_rows` rows or we encounter EOFB (two consecutive 000000000001 codes).
 //
-// Reference: ITU-T Recommendation T.6 (1988); cross-checked against libtiff
-// `tif_fax3.c` for the run-length tables and changing-element semantics.
+// Reference: ITU-T Recommendation T.6 (1988); algorithm modeled directly on
+// libtiff's `tif_fax3.c` (Fax4Decode + EXPAND2D + CHECK_b1 macros).
 //
-// NOTE: This decoder handles simple/synthetic G4 fixtures (whole-image fills,
-// regular patterns) but has a subtle drift bug on complex real-world scans
-// after several thousand rows. The b1 lookup uses parity-based linear scan
-// over a transition-column array; libtiff instead maintains a running b1
-// cursor with explicit pair-step advances. A future change should adopt the
-// libtiff run-length array model for full fidelity.
+// The decoder maintains, for each row, an array of alternating white/black
+// run lengths starting with white. The previous row's array is the reference;
+// b1 is a running cursor advanced in pair-steps (pb += 2; b1 += pb[0]+pb[1])
+// each time it falls behind a0. This pair-step model preserves the color-flip
+// parity of b1 (always the next reference transition where the prior row
+// flips to the OPPOSITE of a0's current color), which is what makes the 2D
+// vertical/pass/horizontal mode references decode correctly even on complex
+// real-world content.
 
 const Image = @import("../Image.zig");
 const io = @import("../io.zig");
@@ -28,8 +30,10 @@ const ccitt = @import("ccitt.zig");
 pub const Decoder = struct {
     width: usize,
     num_rows: usize,
-    /// Bit value used for WHITE in the destination buffer.
-    /// 0 for min-is-white (Photometric=0), 1 for min-is-black (Photometric=1).
+    /// Retained for API/ABI compatibility -- the decoder always emits raw
+    /// photometric-encoded bits (T.6 white-runs as 0, black-runs as 1, per
+    /// libtiff convention). Higher-level storage applies the photometric
+    /// inversion if needed.
     white_value: u1,
 
     pub fn init(width: usize, num_rows: usize, white_value: u1) Decoder {
@@ -42,31 +46,48 @@ pub const Decoder = struct {
         const W = self.width;
         if (W == 0) return;
 
-        // Each row's transitions are stored as column indices (0-indexed).
-        // +2 sentinel slots ensure end-of-line lookups have valid b1/b2.
+        // Two run-length arrays: cur_runs (this row, being written), ref_runs
+        // (previous row, being read). Generous sizing: worst case we get an
+        // alternating white/black pixel pattern (W transitions); add a few
+        // extra slots for the final SETVALUE(0) terminator and pb pair-step
+        // overrun guards (we allow pb to read up to two slots beyond pa).
         const allocator = std.heap.page_allocator;
-        var ref_changes = try allocator.alloc(u32, W + 2);
-        defer allocator.free(ref_changes);
-        var cur_changes = try allocator.alloc(u32, W + 2);
-        defer allocator.free(cur_changes);
+        const nruns: usize = W + 8;
+        var cur_runs = try allocator.alloc(u32, nruns);
+        defer allocator.free(cur_runs);
+        var ref_runs = try allocator.alloc(u32, nruns);
+        defer allocator.free(ref_runs);
 
-        // First reference line is implicitly all-white: one sentinel at W.
-        ref_changes[0] = @intCast(W);
-        var ref_count: usize = 1;
+        // Initial reference row = imaginary all-white: [W, 0].
+        ref_runs[0] = @intCast(W);
+        ref_runs[1] = 0;
+        var ref_count: usize = 2;
+
+        // Zero unused tail of ref so CHECK_b1's pair-step on a sparse prev row
+        // sees defined zeros (advancing b1 by 0+0 each step), terminated by
+        // the bounds check.
+        for (ref_runs[ref_count..]) |*v| v.* = 0;
 
         var bits_in: u16 = 0;
 
         var row: usize = 0;
         while (row < self.num_rows) : (row += 1) {
-            const cur_count = try decodeRow(self, &bit_reader, &bits_in, ref_changes[0..ref_count], cur_changes);
-            try emitRow(self, writer, cur_changes[0..cur_count]);
-            std.mem.swap([]u32, &ref_changes, &cur_changes);
+            // Zero cur_runs entirely before decode -- we only fill the prefix,
+            // and the next iter (after swap) treats this as ref with safe zero
+            // padding.
+            for (cur_runs) |*v| v.* = 0;
+            const cur_count = try decodeRow(self, &bit_reader, &bits_in, ref_runs, cur_runs);
+            try emitRow(self, writer, cur_runs[0..cur_count]);
+            std.mem.swap([]u32, &ref_runs, &cur_runs);
             ref_count = cur_count;
         }
     }
 
-    /// Decode one scan line. `ref` is the previous line's transition list;
-    /// `cur` is filled with this line's transitions. Returns the count.
+    /// Decode one scan line into a run-length array. Mirrors libtiff's
+    /// EXPAND2D macro: maintains a0 (column of last transition placed),
+    /// pa (write index in `cur`), pb (read index in `ref`), b1 (column of
+    /// next reference transition with color OPPOSITE a0's current color),
+    /// and RunLength (pending accumulator for horizontal makeup codes).
     fn decodeRow(
         self: *Decoder,
         bit_reader: *io.BitReader(.big),
@@ -74,98 +95,137 @@ pub const Decoder = struct {
         ref: []const u32,
         cur: []u32,
     ) !usize {
-        const W: u32 = @intCast(self.width);
-        // a0 starts at -1: the imaginary white element before column 0.
-        var a0: i64 = -1;
-        var a0_white: bool = true;
-        var cur_count: usize = 0;
-        var ref_index: usize = 0;
+        const lastx: i64 = @intCast(self.width);
 
-        while (a0 < W) {
-            // b1: first ref transition with column > a0 whose flip-color is
-            // opposite to a0's color. Parity rule: ref[k] flips line color
-            // to BLACK if k even, WHITE if k odd.
-            while (ref_index < ref.len) {
-                const col: i64 = @intCast(ref[ref_index]);
-                const flip_to_white: bool = (ref_index & 1) == 1;
-                if (col > a0 and flip_to_white != a0_white) break;
-                ref_index += 1;
-            }
-            const b1: i64 = if (ref_index < ref.len) @intCast(ref[ref_index]) else @intCast(W);
-            const b2: i64 = if (ref_index + 1 < ref.len) @intCast(ref[ref_index + 1]) else @intCast(W);
+        var a0: i64 = 0;
+        var pa: usize = 0; // write index in cur
+        var pb: usize = 0; // read index in ref
+        var run_length: u32 = 0;
 
+        // b1 = absolute position of first reference transition.
+        if (ref.len == 0) return error.InvalidData;
+        var b1: i64 = @intCast(ref[pb]);
+        pb += 1;
+
+        while (a0 < lastx) {
             const m = try readMode(bit_reader, bits_in);
             switch (m) {
                 .pass => {
-                    a0 = b2;
+                    try checkB1(&b1, &pb, ref, a0, lastx, pa);
+                    if (pb + 1 > ref.len) return error.InvalidData;
+                    b1 += @as(i64, @intCast(ref[pb]));
+                    pb += 1;
+                    run_length += @intCast(b1 - a0);
+                    a0 = b1;
+                    if (pb >= ref.len) return error.InvalidData;
+                    b1 += @as(i64, @intCast(ref[pb]));
+                    pb += 1;
                 },
                 .vertical => |k| {
-                    const raw_a1: i64 = b1 + @as(i64, k);
-                    if (raw_a1 < 0 or raw_a1 <= a0) return error.InvalidData;
-                    if (raw_a1 < W) {
-                        if (cur_count >= cur.len) return error.InvalidData;
-                        cur[cur_count] = @intCast(raw_a1);
-                        cur_count += 1;
-                        a0 = raw_a1;
-                        a0_white = !a0_white;
+                    try checkB1(&b1, &pb, ref, a0, lastx, pa);
+                    const target: i64 = b1 + @as(i64, k);
+                    if (target < a0) return error.InvalidData;
+                    if (k < 0 and target > b1) return error.InvalidData; // sanity
+                    const run: i64 = target - a0;
+                    if (pa >= cur.len) return error.InvalidData;
+                    cur[pa] = run_length + @as(u32, @intCast(run));
+                    pa += 1;
+                    a0 = target;
+                    run_length = 0;
+                    if (k < 0) {
+                        // VL: roll b1 back to the previous reference transition.
+                        // libtiff: b1 -= *--pb;
+                        if (pb == 0) return error.InvalidData;
+                        pb -= 1;
+                        b1 -= @as(i64, @intCast(ref[pb]));
                     } else {
-                        // a1 reaches/passes end of line; row terminates.
-                        a0 = W;
-                        a0_white = !a0_white;
+                        // V0 / VR: step b1 forward to next reference transition.
+                        // libtiff: b1 += *pb++;
+                        if (pb >= ref.len) return error.InvalidData;
+                        b1 += @as(i64, @intCast(ref[pb]));
+                        pb += 1;
                     }
                 },
                 .horizontal => {
-                    const r1 = try readRunLength(bit_reader, bits_in, a0_white);
-                    const r2 = try readRunLength(bit_reader, bits_in, !a0_white);
-                    var start: i64 = if (a0 < 0) 0 else a0;
-                    start += @as(i64, @intCast(r1));
-                    if (start > W) return error.InvalidData;
-                    if (start < W) {
-                        if (cur_count >= cur.len) return error.InvalidData;
-                        cur[cur_count] = @intCast(start);
-                        cur_count += 1;
-                    }
-                    const next_pos: i64 = start + @as(i64, @intCast(r2));
-                    if (next_pos > W) return error.InvalidData;
-                    if (next_pos < W) {
-                        if (cur_count >= cur.len) return error.InvalidData;
-                        cur[cur_count] = @intCast(next_pos);
-                        cur_count += 1;
-                        a0 = next_pos;
-                    } else {
-                        a0 = W;
-                    }
+                    // Two run-length codes. First color = current color
+                    // (the color a0 is "in" / about to extend). pa even means
+                    // next write is a white run; pa odd means black run.
+                    const first_white: bool = (pa & 1) == 0;
+                    const r1 = try readRunLength(bit_reader, bits_in, first_white);
+                    const r2 = try readRunLength(bit_reader, bits_in, !first_white);
+                    if (pa + 1 >= cur.len) return error.InvalidData;
+                    cur[pa] = run_length + r1;
+                    pa += 1;
+                    cur[pa] = r2;
+                    pa += 1;
+                    a0 += @as(i64, @intCast(r1));
+                    a0 += @as(i64, @intCast(r2));
+                    run_length = 0;
+                    try checkB1(&b1, &pb, ref, a0, lastx, pa);
                 },
                 .eofb => return error.InvalidData,
             }
         }
 
-        // Two W sentinels: ensures next row's b1 search has both parities
-        // available past the line, so no spurious post-line transition matches.
-        if (cur_count + 2 > cur.len) return error.InvalidData;
-        cur[cur_count] = W;
-        cur_count += 1;
-        cur[cur_count] = W;
-        cur_count += 1;
-        return cur_count;
+        if (a0 > lastx) return error.InvalidData;
+
+        // Imaginary terminator: SETVALUE(0) -- writes any pending run_length.
+        if (pa >= cur.len) return error.InvalidData;
+        cur[pa] = run_length;
+        pa += 1;
+        // libtiff also pads to even pa via fillruns guard: if pa is odd,
+        // append a 0 so the pair convention (white,black,white,black,...) holds.
+        if ((pa & 1) != 0) {
+            if (pa >= cur.len) return error.InvalidData;
+            cur[pa] = 0;
+            pa += 1;
+        }
+        return pa;
     }
 
-    fn emitRow(self: *Decoder, writer: *std.Io.Writer, changes: []const u32) !void {
+    /// CHECK_b1: while b1 has fallen behind a0, advance b1 forward one PAIR
+    /// of reference runs (preserving its color-flip parity). Pair-step skip
+    /// matches libtiff's tif_fax3.h:CHECK_b1 macro exactly.
+    fn checkB1(b1: *i64, pb: *usize, ref: []const u32, a0: i64, lastx: i64, pa: usize) !void {
+        if (pa == 0) return;
+        while (b1.* <= a0 and b1.* < lastx) {
+            if (pb.* + 1 >= ref.len) return error.InvalidData;
+            b1.* += @as(i64, @intCast(ref[pb.*]));
+            b1.* += @as(i64, @intCast(ref[pb.* + 1]));
+            pb.* += 2;
+        }
+    }
+
+    /// Render one row of run lengths to packed bits. `runs` alternates white
+    /// then black starting with white (run[0] = first white run length).
+    fn emitRow(self: *Decoder, writer: *std.Io.Writer, runs: []const u32) !void {
+        // Per ITU-T T.6 / libtiff convention, "white" runs are runs of 0-bits in
+        // the source bitstream and "black" runs are runs of 1-bits, REGARDLESS
+        // of TIFF photometric interpretation. The decoder thus emits raw
+        // photometric-encoded bits (matching what the file would contain
+        // uncompressed); higher-level storage code handles photometric
+        // inversion. self.white_value is retained for API compatibility but
+        // intentionally unused here.
+        _ = self.white_value;
         const W: u32 = @intCast(self.width);
         var bw: io.BitWriter(.big) = .{ .writer = writer };
         var col: u32 = 0;
-        var color_white = true;
         var idx: usize = 0;
-        while (col < W) {
-            const next: u32 = if (idx < changes.len) changes[idx] else W;
-            if (next > W) return error.InvalidData;
-            const bit: u1 = if (color_white) self.white_value else (self.white_value ^ 1);
-            while (col < next) : (col += 1) {
+        var color_white = true;
+        while (col < W and idx < runs.len) : (idx += 1) {
+            const run_len = runs[idx];
+            const bit: u1 = if (color_white) 0 else 1;
+            var k: u32 = 0;
+            while (k < run_len and col < W) : (k += 1) {
                 _ = bw.writeBits(bit, 1) catch return;
+                col += 1;
             }
             color_white = !color_white;
-            idx += 1;
-            if (col >= W) break;
+        }
+        // If runs underfilled the row, pad with the last color.
+        while (col < W) : (col += 1) {
+            const bit: u1 = if (color_white) 0 else 1;
+            _ = bw.writeBits(bit, 1) catch return;
         }
         bw.flushBits() catch {};
     }

--- a/src/compressions/ccitt_t6.zig
+++ b/src/compressions/ccitt_t6.zig
@@ -1,0 +1,263 @@
+// CCITT Group 4 (ITU-T T.6) MMR decoder for TIFF.
+//
+// T.6 codes each scan line relative to the previous (reference) line, using
+// three modes:
+//   - Pass mode (0001): copy run from reference line, advance to b2.
+//   - Vertical mode (V0=1, VR1=011, VL1=010, VR2=000011, VL2=000010,
+//     VR3=0000011, VL3=0000010): emit pixels up to b1 +/- k, color flips.
+//   - Horizontal mode (001): two 1D-style run-length codes (a0a1 then a1a2).
+// The first reference line is the imaginary all-white line. There are no
+// EOL markers between rows (unlike T.4); decoding stops when we have produced
+// `num_rows` rows or we encounter EOFB (two consecutive 000000000001 codes).
+//
+// Reference: ITU-T Recommendation T.6 (1988); cross-checked against libtiff
+// `tif_fax3.c` for the run-length tables and changing-element semantics.
+//
+// NOTE: This decoder handles simple/synthetic G4 fixtures (whole-image fills,
+// regular patterns) but has a subtle drift bug on complex real-world scans
+// after several thousand rows. The b1 lookup uses parity-based linear scan
+// over a transition-column array; libtiff instead maintains a running b1
+// cursor with explicit pair-step advances. A future change should adopt the
+// libtiff run-length array model for full fidelity.
+
+const Image = @import("../Image.zig");
+const io = @import("../io.zig");
+const std = @import("std");
+const ccitt = @import("ccitt.zig");
+
+pub const Decoder = struct {
+    width: usize,
+    num_rows: usize,
+    /// Bit value used for WHITE in the destination buffer.
+    /// 0 for min-is-white (Photometric=0), 1 for min-is-black (Photometric=1).
+    white_value: u1,
+
+    pub fn init(width: usize, num_rows: usize, white_value: u1) Decoder {
+        return .{ .width = width, .num_rows = num_rows, .white_value = white_value };
+    }
+
+    pub fn decode(self: *Decoder, reader: *std.Io.Reader, writer: *std.Io.Writer) !void {
+        var bit_reader: io.BitReader(.big) = .{ .reader = reader };
+
+        const W = self.width;
+        if (W == 0) return;
+
+        // Each row's transitions are stored as column indices (0-indexed).
+        // +2 sentinel slots ensure end-of-line lookups have valid b1/b2.
+        const allocator = std.heap.page_allocator;
+        var ref_changes = try allocator.alloc(u32, W + 2);
+        defer allocator.free(ref_changes);
+        var cur_changes = try allocator.alloc(u32, W + 2);
+        defer allocator.free(cur_changes);
+
+        // First reference line is implicitly all-white: one sentinel at W.
+        ref_changes[0] = @intCast(W);
+        var ref_count: usize = 1;
+
+        var bits_in: u16 = 0;
+
+        var row: usize = 0;
+        while (row < self.num_rows) : (row += 1) {
+            const cur_count = try decodeRow(self, &bit_reader, &bits_in, ref_changes[0..ref_count], cur_changes);
+            try emitRow(self, writer, cur_changes[0..cur_count]);
+            std.mem.swap([]u32, &ref_changes, &cur_changes);
+            ref_count = cur_count;
+        }
+    }
+
+    /// Decode one scan line. `ref` is the previous line's transition list;
+    /// `cur` is filled with this line's transitions. Returns the count.
+    fn decodeRow(
+        self: *Decoder,
+        bit_reader: *io.BitReader(.big),
+        bits_in: *u16,
+        ref: []const u32,
+        cur: []u32,
+    ) !usize {
+        const W: u32 = @intCast(self.width);
+        // a0 starts at -1: the imaginary white element before column 0.
+        var a0: i64 = -1;
+        var a0_white: bool = true;
+        var cur_count: usize = 0;
+        var ref_index: usize = 0;
+
+        while (a0 < W) {
+            // b1: first ref transition with column > a0 whose flip-color is
+            // opposite to a0's color. Parity rule: ref[k] flips line color
+            // to BLACK if k even, WHITE if k odd.
+            while (ref_index < ref.len) {
+                const col: i64 = @intCast(ref[ref_index]);
+                const flip_to_white: bool = (ref_index & 1) == 1;
+                if (col > a0 and flip_to_white != a0_white) break;
+                ref_index += 1;
+            }
+            const b1: i64 = if (ref_index < ref.len) @intCast(ref[ref_index]) else @intCast(W);
+            const b2: i64 = if (ref_index + 1 < ref.len) @intCast(ref[ref_index + 1]) else @intCast(W);
+
+            const m = try readMode(bit_reader, bits_in);
+            switch (m) {
+                .pass => {
+                    a0 = b2;
+                },
+                .vertical => |k| {
+                    const raw_a1: i64 = b1 + @as(i64, k);
+                    if (raw_a1 < 0 or raw_a1 <= a0) return error.InvalidData;
+                    if (raw_a1 < W) {
+                        if (cur_count >= cur.len) return error.InvalidData;
+                        cur[cur_count] = @intCast(raw_a1);
+                        cur_count += 1;
+                        a0 = raw_a1;
+                        a0_white = !a0_white;
+                    } else {
+                        // a1 reaches/passes end of line; row terminates.
+                        a0 = W;
+                        a0_white = !a0_white;
+                    }
+                },
+                .horizontal => {
+                    const r1 = try readRunLength(bit_reader, bits_in, a0_white);
+                    const r2 = try readRunLength(bit_reader, bits_in, !a0_white);
+                    var start: i64 = if (a0 < 0) 0 else a0;
+                    start += @as(i64, @intCast(r1));
+                    if (start > W) return error.InvalidData;
+                    if (start < W) {
+                        if (cur_count >= cur.len) return error.InvalidData;
+                        cur[cur_count] = @intCast(start);
+                        cur_count += 1;
+                    }
+                    const next_pos: i64 = start + @as(i64, @intCast(r2));
+                    if (next_pos > W) return error.InvalidData;
+                    if (next_pos < W) {
+                        if (cur_count >= cur.len) return error.InvalidData;
+                        cur[cur_count] = @intCast(next_pos);
+                        cur_count += 1;
+                        a0 = next_pos;
+                    } else {
+                        a0 = W;
+                    }
+                },
+                .eofb => return error.InvalidData,
+            }
+        }
+
+        // Two W sentinels: ensures next row's b1 search has both parities
+        // available past the line, so no spurious post-line transition matches.
+        if (cur_count + 2 > cur.len) return error.InvalidData;
+        cur[cur_count] = W;
+        cur_count += 1;
+        cur[cur_count] = W;
+        cur_count += 1;
+        return cur_count;
+    }
+
+    fn emitRow(self: *Decoder, writer: *std.Io.Writer, changes: []const u32) !void {
+        const W: u32 = @intCast(self.width);
+        var bw: io.BitWriter(.big) = .{ .writer = writer };
+        var col: u32 = 0;
+        var color_white = true;
+        var idx: usize = 0;
+        while (col < W) {
+            const next: u32 = if (idx < changes.len) changes[idx] else W;
+            if (next > W) return error.InvalidData;
+            const bit: u1 = if (color_white) self.white_value else (self.white_value ^ 1);
+            while (col < next) : (col += 1) {
+                _ = bw.writeBits(bit, 1) catch return;
+            }
+            color_white = !color_white;
+            idx += 1;
+            if (col >= W) break;
+        }
+        bw.flushBits() catch {};
+    }
+};
+
+const Mode = union(enum) {
+    pass: void,
+    vertical: i8, // -3 .. +3
+    horizontal: void,
+    eofb: void,
+};
+
+/// Decode the next 2D mode prefix per ITU-T T.6 (1988) Table 1.
+fn readMode(bit_reader: *io.BitReader(.big), bits_in: *u16) !Mode {
+    const b1 = try bit_reader.readBits(u1, 1, bits_in);
+    if (b1 == 1) return .{ .vertical = 0 };
+    const b2 = try bit_reader.readBits(u1, 1, bits_in);
+    if (b2 == 1) {
+        const b3 = try bit_reader.readBits(u1, 1, bits_in);
+        if (b3 == 1) return .{ .vertical = 1 };
+        return .{ .vertical = -1 };
+    }
+    const b3 = try bit_reader.readBits(u1, 1, bits_in);
+    if (b3 == 1) return .{ .horizontal = {} };
+    const b4 = try bit_reader.readBits(u1, 1, bits_in);
+    if (b4 == 1) return .{ .pass = {} };
+    const b5 = try bit_reader.readBits(u1, 1, bits_in);
+    if (b5 == 1) {
+        const b6 = try bit_reader.readBits(u1, 1, bits_in);
+        if (b6 == 1) return .{ .vertical = 2 };
+        return .{ .vertical = -2 };
+    }
+    const b6 = try bit_reader.readBits(u1, 1, bits_in);
+    if (b6 == 1) {
+        const b7 = try bit_reader.readBits(u1, 1, bits_in);
+        if (b7 == 1) return .{ .vertical = 3 };
+        return .{ .vertical = -3 };
+    }
+    // 000000... -- EOFB candidate (24 bits total: two 000000000001 codes).
+    var i: u32 = 0;
+    while (i < 5) : (i += 1) {
+        if ((try bit_reader.readBits(u1, 1, bits_in)) != 0) return error.InvalidData;
+    }
+    if ((try bit_reader.readBits(u1, 1, bits_in)) != 1) return error.InvalidData;
+    i = 0;
+    while (i < 11) : (i += 1) {
+        if ((try bit_reader.readBits(u1, 1, bits_in)) != 0) return error.InvalidData;
+    }
+    if ((try bit_reader.readBits(u1, 1, bits_in)) != 1) return error.InvalidData;
+    return .{ .eofb = {} };
+}
+
+/// Read a possibly-composite T.4 run-length code (makeup codes followed by a
+/// terminating code) from the white or black tables.
+fn readRunLength(bit_reader: *io.BitReader(.big), bits_in: *u16, white: bool) !u32 {
+    var total: u32 = 0;
+    while (true) {
+        const code_value: u32 = try matchCode(bit_reader, bits_in, white);
+        total += code_value & 0x7FFFFFFF;
+        if ((code_value & 0x80000000) == 0) return total;
+    }
+}
+
+/// Match the next variable-length T.4 run-length code. Bit 31 of the result
+/// is set when the matched code was a make-up; caller continues matching.
+fn matchCode(bit_reader: *io.BitReader(.big), bits_in: *u16, white: bool) !u32 {
+    var code: u16 = 0;
+    var len: u8 = 0;
+    while (len < 14) {
+        code = (code << 1) | try bit_reader.readBits(u1, 1, bits_in);
+        len += 1;
+        if (matchTerminating(code, len, white)) |rl| return @intCast(rl);
+        if (matchMakeup(code, len, white)) |rl| return 0x80000000 | @as(u32, rl);
+    }
+    return error.InvalidData;
+}
+
+fn matchTerminating(code: u16, len: u8, white: bool) ?u16 {
+    const tbl = if (white) &ccitt.white_terminating_codes else &ccitt.black_terminating_codes;
+    for (tbl) |c| {
+        if (c.code_length == len and c.code == code) return c.run_length;
+    }
+    return null;
+}
+
+fn matchMakeup(code: u16, len: u8, white: bool) ?u16 {
+    const tbl = if (white) &ccitt.white_make_up_codes else &ccitt.black_make_up_codes;
+    for (tbl) |c| {
+        if (c.code_length == len and c.code == code) return c.run_length;
+    }
+    for (ccitt.additional_make_up_codes) |c| {
+        if (c.code_length == len and c.code == code) return c.run_length;
+    }
+    return null;
+}

--- a/src/compressions/lzw.zig
+++ b/src/compressions/lzw.zig
@@ -239,7 +239,8 @@ pub fn Encoder(comptime endian: std.builtin.Endian) type {
 
         /// Write code using MSB-first ordering (used by TIFF)
         fn writeCodeMsb(self: *Self, writer: *std.Io.Writer, code: u32) Error!void {
-            self.bits |= code << (@as(u5, 32) - self.width - self.num_bits);
+            const shift: u5 = @intCast(32 - @as(u6, self.width) - @as(u6, self.num_bits));
+            self.bits |= code << shift;
             self.num_bits += @intCast(self.width);
 
             while (self.num_bits >= 8) {

--- a/src/compressions/packbits.zig
+++ b/src/compressions/packbits.zig
@@ -15,7 +15,9 @@ pub fn decode(read_stream: *io.ReadStream, temp_buffer: []u8, length: u32) !void
                 if (input_offset >= length) {
                     return;
                 }
-                temp_buffer[output_offset] = try reader.takeByte();
+                const byte = try reader.takeByte();
+                if (output_offset >= temp_buffer.len) return error.InvalidData;
+                temp_buffer[output_offset] = byte;
                 output_offset += 1;
                 input_offset += 1;
             }
@@ -26,6 +28,7 @@ pub fn decode(read_stream: *io.ReadStream, temp_buffer: []u8, length: u32) !void
             const value = try reader.takeByte();
             input_offset += 1;
             for (0..257 - control) |_| {
+                if (output_offset >= temp_buffer.len) return error.InvalidData;
                 temp_buffer[output_offset] = value;
                 output_offset += 1;
             }

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -211,12 +211,20 @@ pub const TIFF = struct {
 
     pub fn readStrips(self: *TIFF, allocator: std.mem.Allocator, read_stream: *io.ReadStream, pixel_storage: *color.PixelStorage) Image.ReadError!void {
         const bitmap = &self.bitmap;
+        // Reject corrupted IFDs that omit or shrink the strip tables, or that
+        // declare zero rows-per-strip (div-by-zero on the total_strips math).
+        // Fuzzing (validate --test-coverage shotgun corruption) reliably SEGV'd
+        // here before these guards, because `.?` on a null optional is UB in
+        // ReleaseFast and `total_strips > strip_offsets.len` walks off the heap.
+        if (bitmap.rows_per_strip == 0) return error.InvalidData;
+        const byte_counts_array = bitmap.strip_byte_counts orelse return error.InvalidData;
+        const offsets_array = bitmap.strip_offsets orelse return error.InvalidData;
         const total_strips = (bitmap.image_height + bitmap.rows_per_strip - 1) / bitmap.rows_per_strip;
-        const byte_counts_array = bitmap.strip_byte_counts.?;
-        const offsets_array = bitmap.strip_offsets.?;
+        if (total_strips > offsets_array.len or total_strips > byte_counts_array.len) return error.InvalidData;
         const image_width = bitmap.image_width;
         const image_height = bitmap.image_height;
         const rows_per_strip = @min(bitmap.rows_per_strip, bitmap.image_height);
+        if (rows_per_strip == 0) return error.InvalidData;
         const photometric_interpretation = bitmap.photometric_interpretation;
         const predictor = bitmap.predictor;
         const compression = bitmap.compression;

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -140,6 +140,63 @@ pub const TIFF = struct {
                 },
             }
         }
+
+        // TIFF 6.0 leniency: some encoders write a single BitsPerSample value
+        // and rely on the decoder to replicate it across all SamplesPerPixel
+        // channels (we have seen this in scanner output where the IFD says
+        // SamplesPerPixel=3 but BitsPerSample is just one SHORT=8). libtiff
+        // handles this the same way.
+        if (bitmap.samples_per_pixel > 1 and bitmap.bits_per_sample.data.len == 1) {
+            const bps_value = bitmap.bits_per_sample.data[0];
+            bitmap.bits_per_sample.resize(bitmap.samples_per_pixel);
+            for (0..bitmap.samples_per_pixel) |index| {
+                bitmap.bits_per_sample.data[index] = bps_value;
+            }
+        }
+
+        // TIFF 6.0 default: when RowsPerStrip is absent, the entire image is a
+        // single strip (spec page 39: "Default = 2**32 - 1, which is effectively
+        // infinity. That is, the entire image is one strip."). We fold that to
+        // ImageLength so downstream strip-iteration math stays in u32.
+        if (bitmap.rows_per_strip == 0 and bitmap.image_height > 0) {
+            bitmap.rows_per_strip = bitmap.image_height;
+        }
+
+        // Some non-conformant TIFF writers (and a few historical scanners) omit
+        // StripByteCounts entirely when the image is a single uncompressed
+        // strip. Synthesize it from rows_per_strip * row_byte_size so we can
+        // still decode. We only do this for compression types where the
+        // compressed and uncompressed sizes are equal (no compression).
+        if (bitmap.strip_byte_counts == null and bitmap.strip_offsets != null) {
+            switch (bitmap.compression) {
+                .uncompressed, .uncompressed_old => {
+                    const offsets_len = bitmap.strip_offsets.?.len;
+                    const synth = try allocator.alloc(u32, offsets_len);
+                    const total_rows: u32 = bitmap.image_height;
+                    const rps: u32 = if (bitmap.rows_per_strip == 0) total_rows else bitmap.rows_per_strip;
+                    var total_bits_per_pixel: u32 = 0;
+                    for (0..bitmap.samples_per_pixel) |i| {
+                        if (i < bitmap.bits_per_sample.data.len) {
+                            total_bits_per_pixel += bitmap.bits_per_sample.data[i];
+                        }
+                    }
+                    const bytes_per_row: u32 = if (total_bits_per_pixel == 1)
+                        bitmap.image_width >> 3
+                    else if (total_bits_per_pixel >= 8)
+                        bitmap.image_width * (total_bits_per_pixel / 8)
+                    else
+                        0;
+                    var rows_remaining = total_rows;
+                    for (0..offsets_len) |i| {
+                        const this_rows = @min(rps, rows_remaining);
+                        synth[i] = this_rows * bytes_per_row;
+                        rows_remaining -|= this_rows;
+                    }
+                    bitmap.strip_byte_counts = synth;
+                },
+                else => {},
+            }
+        }
     }
 
     pub fn uncompressDeflate(_: *TIFF, read_stream: *io.ReadStream, dest_buffer: []u8) !void {
@@ -247,7 +304,7 @@ pub const TIFF = struct {
             _ = try read_stream.seekTo(offset);
 
             switch (compression) {
-                .uncompressed => _ = try reader.readSliceShort(strip_buffer[0..]),
+                .uncompressed, .uncompressed_old => _ = try reader.readSliceShort(strip_buffer[0..]),
                 .packbits => _ = try packbits.decode(read_stream, strip_buffer, compressed_byte_count),
                 .ccitt_rle => _ = try self.uncompressCCITT(read_stream, strip_buffer, image_width, current_row_size),
                 .lzw => try self.uncompressLZW(allocator, read_stream, strip_buffer, compressed_byte_count),

--- a/src/formats/tiff.zig
+++ b/src/formats/tiff.zig
@@ -1,4 +1,5 @@
 const ccitt = @import("../compressions/ccitt.zig");
+const ccitt_t6 = @import("../compressions/ccitt_t6.zig");
 const color = @import("../color.zig");
 const FormatInterface = @import("../FormatInterface.zig");
 const Image = @import("../Image.zig");
@@ -249,6 +250,17 @@ pub const TIFF = struct {
         };
     }
 
+    /// CCITT T.6 (Group 4 / MMR) strip decoder. T.6 has no EOL/RTC markers and
+    /// each row is decoded relative to the previous reference line; the first
+    /// reference line is implicit all-white.
+    pub fn uncompressCCITT_T6(self: *TIFF, read_stream: *io.ReadStream, dest_buffer: []u8, image_width: usize, num_rows: usize) !void {
+        var writer = std.Io.Writer.fixed(dest_buffer);
+        var t6_decoder = ccitt_t6.Decoder.init(image_width, num_rows, @truncate(self.bitmap.photometric_interpretation));
+        t6_decoder.decode(read_stream.reader(), &writer) catch {
+            return Image.ReadError.InvalidData;
+        };
+    }
+
     pub fn calRowByteSize(self: *TIFF) !usize {
         const bitmap = &self.bitmap;
         var total_bits: usize = 0;
@@ -307,6 +319,7 @@ pub const TIFF = struct {
                 .uncompressed, .uncompressed_old => _ = try reader.readSliceShort(strip_buffer[0..]),
                 .packbits => _ = try packbits.decode(read_stream, strip_buffer, compressed_byte_count),
                 .ccitt_rle => _ = try self.uncompressCCITT(read_stream, strip_buffer, image_width, current_row_size),
+                .gp_4_fax => try self.uncompressCCITT_T6(read_stream, strip_buffer, image_width, current_row_size),
                 .lzw => try self.uncompressLZW(allocator, read_stream, strip_buffer, compressed_byte_count),
                 .deflate, .pixar_deflate => _ = try self.uncompressDeflate(read_stream, strip_buffer),
                 else => return Image.Error.Unsupported,

--- a/src/formats/tiff/types.zig
+++ b/src/formats/tiff/types.zig
@@ -117,6 +117,7 @@ pub const BitmapDescriptor = struct {
         // only raw, packbits, lzw and ccitt_rle compression supported for now
         switch (self.compression) {
             .uncompressed,
+            .uncompressed_old,
             .packbits,
             .ccitt_rle,
             .lzw,

--- a/src/formats/tiff/types.zig
+++ b/src/formats/tiff/types.zig
@@ -120,6 +120,7 @@ pub const BitmapDescriptor = struct {
             .uncompressed_old,
             .packbits,
             .ccitt_rle,
+            .gp_4_fax,
             .lzw,
             .deflate,
             .pixar_deflate,

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -630,3 +630,89 @@ test "TIFF/BE 24-bit uncompressed RGB with replicated BitsPerSample and missing 
         try helpers.expectEq(pixels.rgb24[i].b, base + 2);
     }
 }
+
+test "TIFF/BE monochrome CCITT Group 4 (T.6) - all white" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-ccitt-g4-white.tiff");
+    defer file.close();
+
+    var the_tiff = tiff.TIFF{};
+
+    var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
+    var read_stream = zigimg.io.ReadStream.initFile(file, read_buffer[0..]);
+
+    const pixels = try the_tiff.read(helpers.zigimg_test_allocator, &read_stream);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_tiff.width(), 16);
+    try helpers.expectEq(the_tiff.height(), 16);
+    try std.testing.expect(pixels == .grayscale1);
+    // min-is-white photometric => white pixels render as 1
+    for (pixels.grayscale1) |p| try helpers.expectEq(p.value, 1);
+}
+
+test "TIFF/BE monochrome CCITT Group 4 (T.6) - all black" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-ccitt-g4-black.tiff");
+    defer file.close();
+
+    var the_tiff = tiff.TIFF{};
+    var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
+    var read_stream = zigimg.io.ReadStream.initFile(file, read_buffer[0..]);
+
+    const pixels = try the_tiff.read(helpers.zigimg_test_allocator, &read_stream);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_tiff.width(), 16);
+    try helpers.expectEq(the_tiff.height(), 16);
+    try std.testing.expect(pixels == .grayscale1);
+    for (pixels.grayscale1) |p| try helpers.expectEq(p.value, 0);
+}
+
+test "TIFF/BE monochrome CCITT Group 4 (T.6) - vertical stripe pattern" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-ccitt-g4-pattern.tiff");
+    defer file.close();
+
+    var the_tiff = tiff.TIFF{};
+    var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
+    var read_stream = zigimg.io.ReadStream.initFile(file, read_buffer[0..]);
+
+    const pixels = try the_tiff.read(helpers.zigimg_test_allocator, &read_stream);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_tiff.width(), 16);
+    try helpers.expectEq(the_tiff.height(), 16);
+    try std.testing.expect(pixels == .grayscale1);
+    // Pattern is "1 0 1 0..." in PBM (1=black, 0=white). With min-is-white the
+    // rendered values are inverted: black-white-black-white => 0-1-0-1.
+    for (0..16) |row| {
+        for (0..16) |col| {
+            const expected: u1 = if (col & 1 == 0) 0 else 1;
+            try helpers.expectEq(pixels.grayscale1[row * 16 + col].value, expected);
+        }
+    }
+}
+
+test "TIFF/BE monochrome CCITT Group 4 (T.6) - mixed checkerboard halves" {
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-ccitt-g4-mixed.tiff");
+    defer file.close();
+
+    var the_tiff = tiff.TIFF{};
+    var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
+    var read_stream = zigimg.io.ReadStream.initFile(file, read_buffer[0..]);
+
+    const pixels = try the_tiff.read(helpers.zigimg_test_allocator, &read_stream);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_tiff.width(), 24);
+    try helpers.expectEq(the_tiff.height(), 16);
+    try std.testing.expect(pixels == .grayscale1);
+    // Top 8 rows: 12 white + 12 black; bottom 8 rows: 12 black + 12 white.
+    // With min-is-white photometric, white => 1, black => 0.
+    for (0..8) |row| {
+        for (0..12) |col| try helpers.expectEq(pixels.grayscale1[row * 24 + col].value, 1);
+        for (12..24) |col| try helpers.expectEq(pixels.grayscale1[row * 24 + col].value, 0);
+    }
+    for (8..16) |row| {
+        for (0..12) |col| try helpers.expectEq(pixels.grayscale1[row * 24 + col].value, 0);
+        for (12..24) |col| try helpers.expectEq(pixels.grayscale1[row * 24 + col].value, 1);
+    }
+}

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -716,3 +716,69 @@ test "TIFF/BE monochrome CCITT Group 4 (T.6) - mixed checkerboard halves" {
         for (12..24) |col| try helpers.expectEq(pixels.grayscale1[row * 24 + col].value, 1);
     }
 }
+
+test "TIFF/BE monochrome CCITT Group 4 (T.6) - complex fixture matches libtiff" {
+    // Regression test for parity-based b1 scan drift: a small but complex
+    // fixture (text + lines + circle + filled polygon + rectangle on 800x600)
+    // exposes the drift bug that the old parity-scan decoder hits on the real
+    // 11059x15671 reproducer after row 1884. This must produce row-for-row
+    // identical output to libtiff's tiff2rgba for every row.
+    const allocator = helpers.zigimg_test_allocator;
+
+    const tiff_file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-monob-ccitt-g4-complex.tiff");
+    defer tiff_file.close();
+    var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
+    var read_stream = zigimg.io.ReadStream.initFile(tiff_file, read_buffer[0..]);
+    var the_tiff = tiff.TIFF{};
+    const pixels = try the_tiff.read(allocator, &read_stream);
+    defer pixels.deinit(allocator);
+
+    try helpers.expectEq(the_tiff.width(), 800);
+    try helpers.expectEq(the_tiff.height(), 600);
+    try std.testing.expect(pixels == .grayscale1);
+
+    // Load libtiff reference (PBM P4 format: header then packed bits, 1=black 0=white).
+    const ref_buf = try std.fs.cwd().readFileAlloc(
+        allocator,
+        helpers.fixtures_path ++ "tiff/sample-monob-ccitt-g4-complex.pbm",
+        16 * 1024 * 1024,
+    );
+    defer allocator.free(ref_buf);
+
+    // Skip P4 header: "P4\n800 600\n"
+    var hdr_end: usize = 0;
+    var newlines: u32 = 0;
+    while (hdr_end < ref_buf.len and newlines < 2) : (hdr_end += 1) {
+        if (ref_buf[hdr_end] == '\n') newlines += 1;
+    }
+    const ref_bits = ref_buf[hdr_end..];
+    const stride: usize = (800 + 7) / 8;
+    try helpers.expectEq(ref_bits.len, stride * 600);
+
+    // Compare: zigimg grayscale1 stores 1=white-intensity. Photometric=1 fixture
+    // means decoder output passes through storage unchanged, so .value = white?1:0.
+    // PBM: 1=black 0=white => zigimg.value = !PBM_bit.
+    var first_mismatch_row: i32 = -1;
+    var mismatch_count: usize = 0;
+    var row: usize = 0;
+    while (row < 600) : (row += 1) {
+        var col: usize = 0;
+        while (col < 800) : (col += 1) {
+            const ref_byte = ref_bits[row * stride + (col >> 3)];
+            const ref_bit: u1 = @truncate((ref_byte >> @intCast(@as(u3, 7) - @as(u3, @intCast(col & 7)))) & 1);
+            const expected_zig: u1 = ref_bit ^ 1;
+            const got = pixels.grayscale1[row * 800 + col].value;
+            if (got != expected_zig) {
+                if (first_mismatch_row < 0) first_mismatch_row = @intCast(row);
+                mismatch_count += 1;
+            }
+        }
+    }
+    if (mismatch_count != 0) {
+        std.debug.print(
+            "\nG4 complex drift: first_mismatch_row={d}, total_mismatches={d}\n",
+            .{ first_mismatch_row, mismatch_count },
+        );
+    }
+    try helpers.expectEq(mismatch_count, 0);
+}

--- a/tests/formats/tiff_test.zig
+++ b/tests/formats/tiff_test.zig
@@ -603,3 +603,30 @@ test "TIFF/LE RGBA Deflate" {
         try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }
+
+test "TIFF/BE 24-bit uncompressed RGB with replicated BitsPerSample and missing StripByteCounts" {
+    // Real-world scanner output (e.g. Epson scan) often writes BitsPerSample
+    // with data_count=1 (single SHORT=8) even when SamplesPerPixel=3, and
+    // omits StripByteCounts entirely. libtiff handles both leniencies; this
+    // test pins zigimg to do the same.
+    const file = try helpers.testOpenFile(helpers.fixtures_path ++ "tiff/sample-rgb24-bps1-no-stripbc.tiff");
+    defer file.close();
+
+    var the_tiff = tiff.TIFF{};
+    var read_buffer: [zigimg.io.DEFAULT_BUFFER_SIZE]u8 = undefined;
+    var read_stream = zigimg.io.ReadStream.initFile(file, read_buffer[0..]);
+
+    const pixels = try the_tiff.read(helpers.zigimg_test_allocator, &read_stream);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try helpers.expectEq(the_tiff.width(), 4);
+    try helpers.expectEq(the_tiff.height(), 4);
+    try std.testing.expect(pixels == .rgb24);
+    // Strip data is bytes 0..47 in RGB order: pixel[0] = (0,1,2), pixel[1] = (3,4,5), ...
+    for (0..16) |i| {
+        const base: u8 = @intCast(i * 3);
+        try helpers.expectEq(pixels.rgb24[i].r, base);
+        try helpers.expectEq(pixels.rgb24[i].g, base + 1);
+        try helpers.expectEq(pixels.rgb24[i].b, base + 2);
+    }
+}


### PR DESCRIPTION
## Summary

Two TIFF coverage extensions, driven by real-world files that previously returned `error.Unsupported`:

1. **Tolerate non-conformant uncompressed RGB scans** (commit 1)
   Real scanner output (e.g. Epson scan via EPSON ES07 ICC profile) often violates the TIFF 6.0 spec in three small ways that libtiff already handles silently:
   - `BitsPerSample` written as a single SHORT=8 with `data_count=1` even when `SamplesPerPixel=3` -> replicate single value across all channels
   - `RowsPerStrip` omitted -> spec default = entire image is one strip; fold to `ImageLength`
   - `StripByteCounts` omitted on a single uncompressed strip -> synthesize from `rows_per_strip * row_byte_size`
   
   Also accept `compression=32771` (`uncompressed_old`, used in TIFF v4-era files) in both `guessPixelFormat` and the `readStrips` dispatch.

2. **Initial CCITT Group 4 (T.6 / MMR) decoder** (commit 2, draft)
   From-scratch Zig implementation of ITU-T T.6 (1988): Pass / Vertical / Horizontal modes, imaginary all-white first reference line, no inter-row EOL, EOFB handled. Reuses the T.4 white/black/additional run-length tables from `src/compressions/ccitt.zig`.
   
   **Known limitation:** the decoder uses parity-based linear scanning over a transition-column array to find b1 each iteration. That is correct for simple/regular content (all four ground-truth fixtures pass) but drifts on complex real-world scans (one specific 1.3 MB scanner file diverges around row 1884 of 15671). The drift fix is to track b1 as a running cursor advanced in pair-steps from a run-length array, as libtiff's `tif_fax3.c` does. That refactor is left for a follow-up; this PR unblocks the common cases. Marking the PR as draft until the run-length-array refactor lands.

## Test plan

- All existing zigimg tests continue to pass (494 -> 499 with new fixtures).
- 5 new tests added in `tests/formats/tiff_test.zig`:
  - 4 CCITT G4 fixtures: all-white, all-black, vertical stripe, mixed checkerboard halves (16x16 / 24x16, all under 270 bytes each)
  - 1 uncompressed-RGB fixture exhibiting all three TIFF spec leniencies at once (4x4 RGB, 158 bytes)
- Generated with `pnmtotiff -g4` (libtiff) and a tiny Python script for the RGB IFD.

## Companion PR

Test fixtures need to be added to [`zigimg/test-suite`](https://github.com/zigimg/test-suite); a separate PR will follow.

## Reproducer files

These PRs were originally driven by three reproducer files from a fileserver scan run by [`pmarreck/validate`](https://github.com/pmarreck/validate):

- `scan from pete's book.tif` (1.3 MB, CCITT G4) -- partially fixed; G4 decoder lands but drift bug means this file still fails until the follow-up
- `scan20050424_162904.tiff` (21 MB, uncompressed RGB) -- **fully fixed**
- `scan20041120_160518.tiff` (9.7 MB, uncompressed RGB) -- **fully fixed**