### PR TITLE
replace leftover `**` operator usage with splat

### DIFF
--- a/src/compressions/deflate/Lookup.zig
+++ b/src/compressions/deflate/Lookup.zig
@@ -13,9 +13,9 @@ const prime4 = 0x9E3779B1; // 4 bytes prime number 2654435761
 const chain_len = 2 * consts.history.len;
 
 // Maps hash => first position
-head: [consts.lookup.len]u16 = [_]u16{0} ** consts.lookup.len,
+head: [consts.lookup.len]u16 = @splat(0),
 // Maps position => previous positions for the same hash value
-chain: [chain_len]u16 = [_]u16{0} ** (chain_len),
+chain: [chain_len]u16 = @splat(0),
 
 // Calculates hash of the 4 bytes from data.
 // Inserts `pos` position of that hash in the lookup tables.

--- a/src/compressions/deflate/huffman_encoder.zig
+++ b/src/compressions/deflate/huffman_encoder.zig
@@ -338,7 +338,7 @@ pub fn fixedDistanceEncoder() DistanceEncoder {
 }
 
 pub fn huffmanDistanceEncoder() DistanceEncoder {
-    var distance_freq = [1]u16{0} ** consts.distance_code_count;
+    var distance_freq: [consts.distance_code_count]u16 = @splat(0);
     distance_freq[0] = 1;
     // huff_distance is a static distance encoder used for huffman only encoding.
     // It can be reused since we will not be encoding distance values.

--- a/src/formats/jpeg/writer.zig
+++ b/src/formats/jpeg/writer.zig
@@ -156,7 +156,7 @@ const unzig = [block_size]u8{
 
 // Initialize Huffman LUT from Huffman specification
 fn initHuffmanLUT(spec: HuffmanSpec) [256]u32 {
-    var lut: [256]u32 = [_]u32{0} ** 256;
+    var lut: [256]u32 = @splat(0);
 
     var code: u32 = 0;
     var value_index: usize = 0;

--- a/src/io.zig
+++ b/src/io.zig
@@ -495,8 +495,8 @@ pub fn BitWriter(comptime endian: std.builtin.Endian) type {
 }
 
 test "BitWriter: api coverage" {
-    var mem_be = [_]u8{0} ** 2;
-    var mem_le = [_]u8{0} ** 2;
+    var mem_be: [2]u8 = @splat(0);
+    var mem_le: [2]u8 = @splat(0);
 
     var mem_out_be = std.Io.Writer.fixed(mem_be[0..]);
     var bit_stream_be: BitWriter(.big) = .{


### PR DESCRIPTION
this change brings zigimg closer to zig 0.17 without breaking 0.16 compatibility