### PR TITLE
Remove some deprecated things

### DIFF
--- a/src/Image.zig
+++ b/src/Image.zig
@@ -9,7 +9,7 @@ const utils = @import("utils.zig");
 
 width: usize = 0,
 height: usize = 0,
-pixels: color.PixelStorage = .{ .invalid = void{} },
+pixels: color.PixelStorage = .{ .invalid = {} },
 animation: Animation = .{},
 
 const Image = @This();

--- a/src/Image/Managed.zig
+++ b/src/Image/Managed.zig
@@ -18,7 +18,7 @@ pub const Editor = Image.Editor;
 // This layout must match the one in Image
 width: usize = 0,
 height: usize = 0,
-pixels: color.PixelStorage = .{ .invalid = void{} },
+pixels: color.PixelStorage = .{ .invalid = {} },
 animation: Animation = .{},
 allocator: std.mem.Allocator = undefined, // Allocator needs to be last in order to be able to ptrCast to Image
 

--- a/src/color.zig
+++ b/src/color.zig
@@ -61,7 +61,7 @@ pub fn ScaleValue(comptime T: type) fn (anytype) T {
                             } else return value;
                         },
 
-                        .float => return @intFromFloat(std.math.clamp(
+                        .float => return @trunc(std.math.clamp(
                             @round(value * @as(ValueT, @floatFromInt(out_max))),
                             0.0,
                             out_max,

--- a/src/color.zig
+++ b/src/color.zig
@@ -830,7 +830,7 @@ pub const PixelStorage = union(PixelFormat) {
         return switch (format) {
             .invalid => {
                 return .{
-                    .invalid = void{},
+                    .invalid = {},
                 };
             },
             .indexed1 => {

--- a/src/compressions/lzw.zig
+++ b/src/compressions/lzw.zig
@@ -82,7 +82,7 @@ pub fn Decoder(comptime endian: std.builtin.Endian) type {
                     if (self.previous_code) |previous_code| {
                         if (self.dictionary.get(previous_code)) |previous_value| {
                             var new_value = try allocator.alloc(u8, previous_value.len + 1);
-                            std.mem.copyForwards(u8, new_value[0..previous_value.len], previous_value);
+                            @memcpy(new_value[0..previous_value.len], previous_value);
                             new_value[previous_value.len] = value[0];
                             try self.dictionary.put(allocator, self.next_code, new_value);
 
@@ -106,7 +106,7 @@ pub fn Decoder(comptime endian: std.builtin.Endian) type {
                         if (self.previous_code) |previous_code| {
                             if (self.dictionary.get(previous_code)) |previous_value| {
                                 var new_value = try allocator.alloc(u8, previous_value.len + 1);
-                                @memmove(new_value[0..previous_value.len], previous_value);
+                                @memcpy(new_value[0..previous_value.len], previous_value);
                                 new_value[previous_value.len] = previous_value[0];
                                 try self.dictionary.put(allocator, self.next_code, new_value);
 

--- a/src/compressions/lzw.zig
+++ b/src/compressions/lzw.zig
@@ -82,7 +82,7 @@ pub fn Decoder(comptime endian: std.builtin.Endian) type {
                     if (self.previous_code) |previous_code| {
                         if (self.dictionary.get(previous_code)) |previous_value| {
                             var new_value = try allocator.alloc(u8, previous_value.len + 1);
-                            std.mem.copyForwards(u8, new_value, previous_value);
+                            std.mem.copyForwards(u8, new_value[0..previous_value.len], previous_value);
                             new_value[previous_value.len] = value[0];
                             try self.dictionary.put(allocator, self.next_code, new_value);
 
@@ -106,7 +106,7 @@ pub fn Decoder(comptime endian: std.builtin.Endian) type {
                         if (self.previous_code) |previous_code| {
                             if (self.dictionary.get(previous_code)) |previous_value| {
                                 var new_value = try allocator.alloc(u8, previous_value.len + 1);
-                                std.mem.copyForwards(u8, new_value, previous_value);
+                                @memmove(new_value[0..previous_value.len], previous_value);
                                 new_value[previous_value.len] = previous_value[0];
                                 try self.dictionary.put(allocator, self.next_code, new_value);
 

--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -266,7 +266,7 @@ pub const GIF = struct {
         if (image.animation.frames.items.len > 1) {
             // Multi-frame animated GIF - write each frame with its bounds
             for (image.animation.frames.items) |frame| {
-                const delay_cs: u16 = @intFromFloat(frame.duration * 100.0);
+                const delay_cs: u16 = @trunc(frame.duration * 100.0);
                 const disposal: DisposeMethod = @enumFromInt(frame.disposal);
 
                 // Use frame bounds if set, otherwise use full image dimensions

--- a/src/formats/gif.zig
+++ b/src/formats/gif.zig
@@ -722,7 +722,7 @@ pub const GIF = struct {
             var dispose_method: DisposeMethod = .none;
 
             if (frame.graphics_control) |graphics_control| {
-                current_animation_frame.duration = @as(f32, @floatFromInt(graphics_control.delay_time)) * (1.0 / 100.0);
+                current_animation_frame.duration = @as(f32, graphics_control.delay_time) * (1.0 / 100.0);
                 if (graphics_control.flags.has_transparent_color) {
                     transparency_index_opt = graphics_control.transparent_color_index;
                 }

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -192,9 +192,9 @@ pub fn yCbCrToRgbBlock(self: *Frame, y_block: *[3]Block, cbcr_block: *[3]Block, 
         g_vec = std.math.clamp(g_vec, vec_0, vec_255);
         b_vec = std.math.clamp(b_vec, vec_0, vec_255);
 
-        y_vec_i32 = @intFromFloat(r_vec);
-        cb_vec_i32 = @intFromFloat(g_vec);
-        cr_vec_i32 = @intFromFloat(b_vec);
+        y_vec_i32 = @trunc(r_vec);
+        cb_vec_i32 = @trunc(g_vec);
+        cr_vec_i32 = @trunc(b_vec);
 
         simd.store(i32, y_block[0][y * 8 ..][0..8], y_vec_i32, 8);
         simd.store(i32, y_block[1][y * 8 ..][0..8], cb_vec_i32, 8);
@@ -296,7 +296,7 @@ pub fn idctBlocks(self: *Frame) void {
 // https://github.com/nothings/stb/blob/5c205738c191bcb0abc65c4febfa9bd25ff35234/stb_image.h#L2430C9-L2430C22
 fn f2f(comptime x: f32) i32 {
     // 4096 = 1 << 12
-    return @intFromFloat(x * 4096 + 0.5);
+    return @trunc(x * 4096 + 0.5);
 }
 
 fn idct1D(s0: i32, s1: i32, s2: i32, s3: i32, s4: i32, s5: i32, s6: i32, s7: i32) struct { i32, i32, i32, i32, i32, i32, i32, i32 } {

--- a/src/formats/pam.zig
+++ b/src/formats/pam.zig
@@ -382,7 +382,7 @@ pub const PAM = struct {
 
         if (src_maxval == dst_maxval) return val;
 
-        const W = std.meta.Int(.unsigned, @bitSizeOf(T) * 2);
+        const W = @Int(.unsigned, @bitSizeOf(T) * 2);
         return @intCast(@min(std.math.maxInt(T), @as(W, dst_maxval) * @as(W, val) / @as(W, src_maxval)));
     }
 

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -364,7 +364,7 @@ pub const PCX = struct {
             },
         }
 
-        pcx.header.stride = @trunc((@as(f32, @floatFromInt(image.width)) / 8.0) * @as(f32, @floatFromInt(pcx.header.bpp)));
+        pcx.header.stride = @trunc((@as(f32, @floatFromInt(image.width)) / 8.0) * @as(f32, pcx.header.bpp));
         // Add one if the result is a odd number
         pcx.header.stride += (pcx.header.stride & 0x1);
 

--- a/src/formats/pcx.zig
+++ b/src/formats/pcx.zig
@@ -364,7 +364,7 @@ pub const PCX = struct {
             },
         }
 
-        pcx.header.stride = @as(u16, @intFromFloat((@as(f32, @floatFromInt(image.width)) / 8.0) * @as(f32, @floatFromInt(pcx.header.bpp))));
+        pcx.header.stride = @trunc((@as(f32, @floatFromInt(image.width)) / 8.0) * @as(f32, @floatFromInt(pcx.header.bpp)));
         // Add one if the result is a odd number
         pcx.header.stride += (pcx.header.stride & 0x1);
 

--- a/src/formats/png/InfoProcessor.zig
+++ b/src/formats/png/InfoProcessor.zig
@@ -78,7 +78,7 @@ fn processChunk(self: *InfoProcessor, data: *ChunkProcessData) Image.ReadError!P
                     try data.read_stream.seekBy(@as(i64, data.chunk_length) - buffer.len);
                 }
                 self.writer.print("tEXt Length {Bi}:\n", .{data.chunk_length}) catch return result_format;
-                const strEnd = std.mem.indexOfScalar(u8, txt, 0).?;
+                const strEnd = std.mem.findScalar(u8, txt, 0).?;
                 self.writer.print("               Keyword: {s}\n", .{txt[0..strEnd]}) catch return result_format;
                 txt = txt[strEnd + 1 ..];
                 self.writer.print("                  Text: {s}\n", .{txt[0..]}) catch return result_format;
@@ -88,7 +88,7 @@ fn processChunk(self: *InfoProcessor, data: *ChunkProcessData) Image.ReadError!P
                 var txt = buffer[0..to_read];
                 try reader.readSliceAll(txt);
                 self.writer.print("zTXt Length {Bi}:\n", .{data.chunk_length}) catch return result_format;
-                const strEnd = std.mem.indexOfScalar(u8, txt, 0).?;
+                const strEnd = std.mem.findScalar(u8, txt, 0).?;
                 self.writer.print("               Keyword: {s}\n", .{txt[0..strEnd]}) catch return result_format;
                 if (txt[strEnd + 1] == 0) {
                     self.writer.print("           Compression: Zlib Deflate\n", .{}) catch return result_format;
@@ -116,7 +116,7 @@ fn processChunk(self: *InfoProcessor, data: *ChunkProcessData) Image.ReadError!P
                     try data.read_stream.seekBy(@as(i64, data.chunk_length) - buffer.len);
                 }
                 self.writer.print("iTXt Length {Bi}:\n", .{data.chunk_length}) catch return result_format;
-                var strEnd = std.mem.indexOfScalar(u8, txt, 0).?;
+                var strEnd = std.mem.findScalar(u8, txt, 0).?;
                 self.writer.print("               Keyword: {s}\n", .{txt[0..strEnd]}) catch return result_format;
                 txt = txt[strEnd + 1 ..];
                 if (txt[0] == 1) {
@@ -125,10 +125,10 @@ fn processChunk(self: *InfoProcessor, data: *ChunkProcessData) Image.ReadError!P
                     self.writer.print("            Compressed: No\n", .{}) catch return result_format;
                 }
                 txt = txt[2..];
-                strEnd = std.mem.indexOfScalar(u8, txt, 0).?;
+                strEnd = std.mem.findScalar(u8, txt, 0).?;
                 self.writer.print("          Language Tag: {s}\n", .{txt[0..strEnd]}) catch return result_format;
                 txt = txt[strEnd + 1 ..];
-                strEnd = std.mem.indexOfScalar(u8, txt, 0).?;
+                strEnd = std.mem.findScalar(u8, txt, 0).?;
                 self.writer.print("    Translated Keyword: {s}\n", .{txt[0..strEnd]}) catch return result_format;
                 txt = txt[strEnd + 1 ..];
                 self.writer.print("                  Text: {s}\n", .{txt[0..]}) catch return result_format;
@@ -231,7 +231,7 @@ fn processChunk(self: *InfoProcessor, data: *ChunkProcessData) Image.ReadError!P
 
                     var iccp = buffer[0..data.chunk_length];
                     try reader.readSliceAll(iccp);
-                    if (std.mem.indexOfScalar(u8, iccp, 0)) |str_end| {
+                    if (std.mem.findScalar(u8, iccp, 0)) |str_end| {
                         self.writer.print("Profile Name: {s}\n", .{iccp[0..str_end]}) catch return result_format;
                     } else {
                         self.writer.print("Invalid Data\n", .{}) catch return result_format;

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -767,7 +767,7 @@ pub const TGA = struct {
                 return Image.WriteError.Unsupported;
             }
 
-            std.mem.copyForwards(u8, extension.author_name[0..], tga_encoder_options.author_name[0..]);
+            @memcpy(extension.author_name[0..tga_encoder_options.author_name.len], tga_encoder_options.author_name);
 
             var remaining_comment_length = @min(tga_encoder_options.author_comment.len, 4 * 80);
             var line: usize = 0;
@@ -791,14 +791,14 @@ pub const TGA = struct {
                 .year = tga_encoder_options.timestamp.year,
             };
 
-            std.mem.copyForwards(u8, extension.job_id[0..], tga_encoder_options.job_id[0..]);
+            @memcpy(extension.job_id[0..tga_encoder_options.job_id.len], tga_encoder_options.job_id);
             extension.job_time = .{
                 .hours = tga_encoder_options.job_time.hours,
                 .minutes = tga_encoder_options.job_time.minutes,
                 .seconds = tga_encoder_options.job_time.seconds,
             };
 
-            std.mem.copyForwards(u8, extension.software_id[0..], tga_encoder_options.software_id[0..]);
+            @memcpy(extension.software_id[0..tga_encoder_options.software_id.len], tga_encoder_options.software_id);
             extension.software_version = .{
                 .letter = tga_encoder_options.software_version.letter,
                 .number = tga_encoder_options.software_version.number,
@@ -1225,7 +1225,7 @@ pub const TGA = struct {
 
         var footer = TGAFooter{};
         footer.extension_offset = extension_offset;
-        std.mem.copyForwards(u8, footer.signature[0..], TGASignature[0..]);
+        footer.signature = TGASignature.*;
         try writer.writeStruct(footer, .little);
 
         try write_stream.flush();

--- a/src/formats/tga.zig
+++ b/src/formats/tga.zig
@@ -374,7 +374,7 @@ fn RunLengthSIMDEncoder(
         const VectorType = @Vector(VectorLength, IntType);
         const BytesPerPixels = (@typeInfo(IntType).int.bits + 7) / 8;
         const IndexStep = VectorLength * BytesPerPixels;
-        const MaskType = std.meta.Int(.unsigned, VectorLength);
+        const MaskType = @Int(.unsigned, VectorLength);
 
         comptime {
             if (!std.math.isPowerOfTwo(@typeInfo(IntType).int.bits)) {
@@ -1242,7 +1242,7 @@ pub const TGA = struct {
         if (self.header.image_type.run_length) {
             // The TGA spec recommend that the RLE compression should be done on scanline per scanline basis
             inline for (1..(4 + 1)) |bpp| {
-                const IntType = std.meta.Int(.unsigned, bpp * 8);
+                const IntType = @Int(.unsigned, bpp * 8);
 
                 if (bytes_per_pixel == bpp) {
                     if (comptime std.math.isPowerOfTwo(bpp)) {

--- a/src/io.zig
+++ b/src/io.zig
@@ -193,7 +193,7 @@ pub fn BitReader(comptime endian: std.builtin.Endian) type {
         }
 
         fn initBits(comptime T: type, out: anytype, num: u16) Bits(T) {
-            const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+            const UT = @Int(.unsigned, @bitSizeOf(T));
             return .{
                 @bitCast(@as(UT, @intCast(out))),
                 num,
@@ -222,7 +222,7 @@ pub fn BitReader(comptime endian: std.builtin.Endian) type {
         ///  containing them in the least significant end, and the number of bits successfully
         ///  read. Reaching the end of the stream is not an error.
         pub fn readBitsTuple(self: *@This(), comptime T: type, num: u16) !Bits(T) {
-            const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+            const UT = @Int(.unsigned, @bitSizeOf(T));
             const U = if (@bitSizeOf(T) < 8) u8 else UT; //it is a pain to work with <u8
 
             //dump any bits in our buffer first
@@ -412,7 +412,7 @@ pub fn BitWriter(comptime endian: std.builtin.Endian) type {
         ///  are enough to fill a byte.
         pub fn writeBits(self: *@This(), value: anytype, num: u16) !void {
             const T = @TypeOf(value);
-            const UT = std.meta.Int(.unsigned, @bitSizeOf(T));
+            const UT = @Int(.unsigned, @bitSizeOf(T));
             const U = if (@bitSizeOf(T) < 8) u8 else UT; //<u8 is a pain to work with
 
             var in: U = @as(UT, @bitCast(value));

--- a/src/simd.zig
+++ b/src/simd.zig
@@ -47,7 +47,7 @@ pub fn floatToInt(comptime DestinationType: type, source: anytype, comptime leng
 
     comptime var index: u32 = 0;
     inline while (index < length) : (index += 1) {
-        result[index] = @intFromFloat(source[index]);
+        result[index] = @trunc(source[index]);
     }
 
     return result;

--- a/tests/formats/gif_test.zig
+++ b/tests/formats/gif_test.zig
@@ -904,7 +904,7 @@ fn doGifTest(entry_name: []const u8) !void {
                     }
 
                     if (config_section.getValue("delay")) |delay| {
-                        const actual_duration: u32 = @intFromFloat(frames.items[frame_index].duration * 100);
+                        const actual_duration: u32 = @trunc(frames.items[frame_index].duration * 100);
 
                         try helpers.expectEq(actual_duration, delay.number);
                     }

--- a/tests/formats/gif_test.zig
+++ b/tests/formats/gif_test.zig
@@ -698,7 +698,7 @@ const IniFile = struct {
                         // Do nothing
                     },
                     '[' => {
-                        const end_bracket_position_opt = std.mem.lastIndexOf(u8, read_line[0..], "]");
+                        const end_bracket_position_opt = std.mem.findLast(u8, read_line[0..], "]");
 
                         if (end_bracket_position_opt) |end_bracket_position| {
                             current_section = try allocator.dupe(u8, read_line[1..end_bracket_position]);
@@ -709,7 +709,7 @@ const IniFile = struct {
                         }
                     },
                     else => {
-                        const equals_sign_position_opt = std.mem.indexOf(u8, read_line[0..], "=");
+                        const equals_sign_position_opt = std.mem.find(u8, read_line[0..], "=");
 
                         if (equals_sign_position_opt) |equals_sign_position| {
                             const key_name = std.mem.trimEnd(u8, read_line[0..(equals_sign_position - 1)], " ");
@@ -834,8 +834,8 @@ fn doGifTest(entry_name: []const u8) !void {
         try helpers.expectEq(gif_file.loopCount(), expected_loop_count);
 
         if (config_section.getValue("comment")) |comment_value| {
-            const first_quote_index = std.mem.indexOfScalar(u8, comment_value.string, '\'') orelse 0;
-            const last_quote_index = std.mem.lastIndexOfScalar(u8, comment_value.string, '\'') orelse comment_value.string.len;
+            const first_quote_index = std.mem.findScalar(u8, comment_value.string, '\'') orelse 0;
+            const last_quote_index = std.mem.findScalarLast(u8, comment_value.string, '\'') orelse comment_value.string.len;
 
             const comment_slice = comment_value.string[(first_quote_index + 1)..(last_quote_index)];
 

--- a/tests/formats/gif_test.zig
+++ b/tests/formats/gif_test.zig
@@ -520,7 +520,7 @@ fn makeAnimatedTestImage(allocator: std.mem.Allocator) !zigimg.Image {
 
     var frame0_pixels = try zigimg.color.PixelStorage.init(allocator, .indexed8, width * height);
     frame0_pixels.resizePalette(palette.len);
-    std.mem.copy(zigimg.color.Rgba32, frame0_pixels.indexed8.palette, palette[0..]);
+    @memcpy(frame0_pixels.indexed8.palette[0..palette.len], palette[0..]);
     for (0..width * height) |i| frame0_pixels.indexed8.indices[i] = @intCast(i % 2);
 
     const frame0 = zigimg.Image.AnimationFrame{
@@ -532,7 +532,7 @@ fn makeAnimatedTestImage(allocator: std.mem.Allocator) !zigimg.Image {
 
     var frame1_pixels = try zigimg.color.PixelStorage.init(allocator, .indexed8, width * height);
     frame1_pixels.resizePalette(palette.len);
-    std.mem.copy(zigimg.color.Rgba32, frame1_pixels.indexed8.palette, palette[0..]);
+    @memcpy(frame1_pixels.indexed8.palette[0..palette.len], palette[0..]);
     for (0..height) |row| {
         for (0..width) |col| {
             const idx = row * width + col;

--- a/tests/formats/jpeg_test.zig
+++ b/tests/formats/jpeg_test.zig
@@ -228,9 +228,9 @@ fn averageDelta(img0: Image, img1: Image) !f32 {
             for (0..height) |y| {
                 for (0..width) |x| {
                     const idx = y * width + x;
-                    sum += @abs(@as(f64, @floatFromInt(pix0[idx].r)) - @as(f64, @floatFromInt(pix1[idx].r)));
-                    sum += @abs(@as(f64, @floatFromInt(pix0[idx].g)) - @as(f64, @floatFromInt(pix1[idx].g)));
-                    sum += @abs(@as(f64, @floatFromInt(pix0[idx].b)) - @as(f64, @floatFromInt(pix1[idx].b)));
+                    sum += @abs(@as(f64, pix0[idx].r) - @as(f64, pix1[idx].r));
+                    sum += @abs(@as(f64, pix0[idx].g) - @as(f64, pix1[idx].g));
+                    sum += @abs(@as(f64, pix0[idx].b) - @as(f64, pix1[idx].b));
                     total_pixel_diff += 3;
                 }
             }
@@ -242,7 +242,7 @@ fn averageDelta(img0: Image, img1: Image) !f32 {
             for (0..height) |y| {
                 for (0..width) |x| {
                     const idx = y * width + x;
-                    sum += @abs(@as(f64, @floatFromInt(pix0[idx].value)) - @as(f64, @floatFromInt(pix1[idx].value)));
+                    sum += @abs(@as(f64, pix0[idx].value) - @as(f64, pix1[idx].value));
                     total_pixel_diff += 1;
                 }
             }

--- a/tests/formats/pcx_test.zig
+++ b/tests/formats/pcx_test.zig
@@ -448,7 +448,7 @@ test "Write PCX indexed 8 (even width)" {
     for (0..255) |index| {
         const current_step = index % colors_per_channel;
         const current_channel = index / colors_per_channel;
-        const current_intensity = toU8(@as(f32, @floatFromInt(current_step)) / @as(f32, @floatFromInt(colors_per_channel)));
+        const current_intensity = toU8(@as(f32, @floatFromInt(current_step)) / @as(f32, colors_per_channel));
 
         rainbow_test.pixels.indexed8.palette[index].r = 0;
         rainbow_test.pixels.indexed8.palette[index].g = 0;

--- a/tests/image_editor_test.zig
+++ b/tests/image_editor_test.zig
@@ -658,7 +658,7 @@ test "ImageEditor.crop: crop indexed2 images" {
 
     // Setup the palette
     for (0..big_image.pixels.indexed2.palette.len) |palette_index| {
-        const grayscale_value: u8 = @intFromFloat(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed2.palette.len)) * 255.0);
+        const grayscale_value: u8 = @trunc(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed2.palette.len)) * 255.0);
         big_image.pixels.indexed2.palette[0] = .{ .r = grayscale_value, .g = grayscale_value, .b = grayscale_value, .a = 255 };
     }
 
@@ -698,7 +698,7 @@ test "ImageEditor.crop: crop indexed4 images" {
 
     // Setup the palette
     for (0..big_image.pixels.indexed4.palette.len) |palette_index| {
-        const grayscale_value: u8 = @intFromFloat(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed4.palette.len)) * 255.0);
+        const grayscale_value: u8 = @trunc(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed4.palette.len)) * 255.0);
         big_image.pixels.indexed4.palette[0] = .{ .r = grayscale_value, .g = grayscale_value, .b = grayscale_value, .a = 255 };
     }
 
@@ -738,7 +738,7 @@ test "ImageEditor.crop: crop indexed8 images" {
 
     // Setup the palette
     for (0..big_image.pixels.indexed8.palette.len) |palette_index| {
-        const grayscale_value: u8 = @intFromFloat(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed8.palette.len)) * 255.0);
+        const grayscale_value: u8 = @trunc(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed8.palette.len)) * 255.0);
         big_image.pixels.indexed8.palette[0] = .{ .r = grayscale_value, .g = grayscale_value, .b = grayscale_value, .a = 255 };
     }
 
@@ -778,7 +778,7 @@ test "ImageEditor.crop: crop indexed16 images" {
 
     // Setup the palette
     for (0..big_image.pixels.indexed16.palette.len) |palette_index| {
-        const grayscale_value: u8 = @intFromFloat(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed16.palette.len)) * 255.0);
+        const grayscale_value: u8 = @trunc(@as(f32, @floatFromInt(palette_index)) / @as(f32, @floatFromInt(big_image.pixels.indexed16.palette.len)) * 255.0);
         big_image.pixels.indexed16.palette[0] = .{ .r = grayscale_value, .g = grayscale_value, .b = grayscale_value, .a = 255 };
     }
 

--- a/tests/pixel_format_converter_test.zig
+++ b/tests/pixel_format_converter_test.zig
@@ -535,8 +535,8 @@ test "PixelFormatConverter: convert from grayscale16 to rgb555" {
     defer grayscale16_pixels.deinit(helpers.zigimg_test_allocator);
 
     grayscale16_pixels.grayscale16[0].value = 0;
-    grayscale16_pixels.grayscale16[1].value = @intFromFloat(@as(f32, @floatFromInt(std.math.maxInt(u16))) * 0.25);
-    grayscale16_pixels.grayscale16[2].value = @intFromFloat(@as(f32, @floatFromInt(std.math.maxInt(u16))) * 0.50);
+    grayscale16_pixels.grayscale16[1].value = std.math.maxInt(u16) / 4;
+    grayscale16_pixels.grayscale16[2].value = std.math.maxInt(u16) / 2;
     grayscale16_pixels.grayscale16[3].value = std.math.maxInt(u16);
 
     const rgb555_pixels = try PixelFormatConverter.convert(helpers.zigimg_test_allocator, &grayscale16_pixels, .rgb555);


### PR DESCRIPTION
This replaces more deprecated things including `std.meta.Int`, `@intFromFloat`, and `std.mem.indexOf`. This passes all tests in both master and 0.16. I also removed some unnecessary casts in places where the types coerce.  The I also replaced `std.mem.copy` functions with `@memcpy` since the arguments don't seem to alias.