### PR TITLE
Bugfix/jpeg overflow guard

### DIFF
--- a/src/formats/jpeg.zig
+++ b/src/formats/jpeg.zig
@@ -178,7 +178,7 @@ pub const JPEG = struct {
 
         if (self.frame) |*frame| {
             try frame.dequantizeBlocks();
-            frame.idctBlocks();
+            try frame.idctBlocks();
             try frame.renderToPixels(&pixels_opt.*.?);
 
             return frame.*;

--- a/src/formats/jpeg/Frame.zig
+++ b/src/formats/jpeg/Frame.zig
@@ -16,6 +16,13 @@ const MAX_BLOCKS = @import("utils.zig").MAX_BLOCKS;
 const Block = @import("utils.zig").Block;
 
 const Frame = @This();
+const IDCT1DResult = struct { i32, i32, i32, i32, i32, i32, i32, i32 };
+
+// 30610 is the largest absolute coefficient sum in a guarded 1-D IDCT pass,
+// including the recombination before the shift.
+const IDCT_COEFFICIENT_SUM_MAX = 30610;
+const IDCT_ROUNDING_MAX = (1 << 17) / 2;
+const IDCT_INPUT_MAX = (std.math.maxInt(i32) - IDCT_ROUNDING_MAX) / IDCT_COEFFICIENT_SUM_MAX;
 
 allocator: std.mem.Allocator,
 frame_header: FrameHeader,
@@ -256,10 +263,20 @@ pub fn dequantizeBlocks(self: *Frame) Image.ReadError!void {
                         const block = &self.block_storage[block_id][component_id];
                         if (y + v >= self.block_height) {
                             @memset(block, 0);
-                        } else {
-                            for (0..64) |sample_id| {
-                                block[sample_id] = block[sample_id] * quantization_table.q8[sample_id];
-                            }
+                            continue;
+                        }
+
+                        switch (quantization_table) {
+                            .q8 => |q8| {
+                                for (0..64) |sample_id| {
+                                    block[sample_id] = std.math.mul(
+                                        i32,
+                                        block[sample_id],
+                                        q8[sample_id],
+                                    ) catch return Image.ReadError.Unsupported;
+                                }
+                            },
+                            .q16 => return Image.ReadError.Unsupported,
                         }
                     }
                 }
@@ -268,7 +285,7 @@ pub fn dequantizeBlocks(self: *Frame) Image.ReadError!void {
     }
 }
 
-pub fn idctBlocks(self: *Frame) void {
+pub fn idctBlocks(self: *Frame) Image.ReadError!void {
     const y_step = self.vertical_sampling_factor_max;
     const x_step = self.horizontal_sampling_factor_max;
 
@@ -284,7 +301,7 @@ pub fn idctBlocks(self: *Frame) void {
                     for (0..h_max) |h| {
                         const block_id = (y + v) * self.block_width_actual + (x + h);
                         const block = &self.block_storage[block_id][component_id];
-                        idctBlock(block);
+                        try idctBlock(block);
                     }
                 }
             }
@@ -299,7 +316,25 @@ fn f2f(comptime x: f32) i32 {
     return @trunc(x * 4096 + 0.5);
 }
 
-fn idct1D(s0: i32, s1: i32, s2: i32, s3: i32, s4: i32, s5: i32, s6: i32, s7: i32) struct { i32, i32, i32, i32, i32, i32, i32, i32 } {
+fn idct1D(
+    s0: i32,
+    s1: i32,
+    s2: i32,
+    s3: i32,
+    s4: i32,
+    s5: i32,
+    s6: i32,
+    s7: i32,
+) Image.ReadError!IDCT1DResult {
+    for ([_]i32{ s0, s1, s2, s3, s4, s5, s6, s7 }) |sample| {
+        if (sample < -IDCT_INPUT_MAX) {
+            return Image.ReadError.Unsupported;
+        }
+        if (sample > IDCT_INPUT_MAX) {
+            return Image.ReadError.Unsupported;
+        }
+    }
+
     var p2 = s2;
     var p3 = s6;
 
@@ -339,7 +374,7 @@ fn idct1D(s0: i32, s1: i32, s2: i32, s3: i32, s4: i32, s5: i32, s6: i32, s7: i32
     return .{ x0, x1, x2, x3, t0, t1, t2, t3 };
 }
 
-fn idctBlock(block: *Block) void {
+fn idctBlock(block: *Block) Image.ReadError!void {
     for (0..8) |x| {
         const s0 = block[0 * 8 + x];
         const s1 = block[1 * 8 + x];
@@ -359,7 +394,7 @@ fn idctBlock(block: *Block) void {
         var t2: i32 = 0;
         var t3: i32 = 0;
 
-        x0, x1, x2, x3, t0, t1, t2, t3 = idct1D(s0, s1, s2, s3, s4, s5, s6, s7);
+        x0, x1, x2, x3, t0, t1, t2, t3 = try idct1D(s0, s1, s2, s3, s4, s5, s6, s7);
 
         x0 += 512;
         x1 += 512;
@@ -395,7 +430,7 @@ fn idctBlock(block: *Block) void {
         var t2: i32 = 0;
         var t3: i32 = 0;
 
-        x0, x1, x2, x3, t0, t1, t2, t3 = idct1D(s0, s1, s2, s3, s4, s5, s6, s7);
+        x0, x1, x2, x3, t0, t1, t2, t3 = try idct1D(s0, s1, s2, s3, s4, s5, s6, s7);
 
         // add 0.5 scaled up by factor
         x0 += (1 << 17) / 2;

--- a/tests/formats/jpeg_overflow_test.zig
+++ b/tests/formats/jpeg_overflow_test.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+const zigimg = @import("zigimg");
+const Image = zigimg.Image;
+const helpers = @import("../helpers.zig");
+const test_io = std.testing.io;
+
+const test_image_path = helpers.fixtures_path ++ "jpeg/";
+
+fn expectLoadDoesNotPanic(path: []const u8) !void {
+    var read_buf: [256 * 1024]u8 = undefined;
+
+    var file = try helpers.testOpenFile(test_io, path);
+    defer file.close(test_io);
+
+    var image = Image.fromFile(helpers.zigimg_test_allocator, test_io, file, &read_buf) catch return;
+    defer image.deinit(helpers.zigimg_test_allocator);
+}
+
+test "JPEG loads crafted DC coefficient overflow fixtures without panicking" {
+    const fixtures = [_][]const u8{
+        test_image_path ++ "crafted_33000x8.jpg",
+        test_image_path ++ "crafted_40000x8.jpg",
+        test_image_path ++ "crafted_64000x8.jpg",
+    };
+
+    for (fixtures) |fixture| {
+        try expectLoadDoesNotPanic(fixture);
+    }
+}
+
+test "JPEG loads crafted IDCT overflow fixtures without panicking" {
+    const fixtures = [_][]const u8{
+        test_image_path ++ "crafted_80x8.jpg",
+        test_image_path ++ "crafted_3200x8.jpg",
+        test_image_path ++ "crafted_32000x8.jpg",
+    };
+
+    for (fixtures) |fixture| {
+        try expectLoadDoesNotPanic(fixture);
+    }
+}

--- a/tests/formats/jpeg_overflow_test.zig
+++ b/tests/formats/jpeg_overflow_test.zig
@@ -6,17 +6,22 @@ const test_io = std.testing.io;
 
 const test_image_path = helpers.fixtures_path ++ "jpeg/";
 
-fn expectLoadDoesNotPanic(path: []const u8) !void {
+fn expectLoadUnsupported(path: []const u8) !void {
     var read_buf: [256 * 1024]u8 = undefined;
 
     var file = try helpers.testOpenFile(test_io, path);
     defer file.close(test_io);
 
-    var image = Image.fromFile(helpers.zigimg_test_allocator, test_io, file, &read_buf) catch return;
+    var image = Image.fromFile(helpers.zigimg_test_allocator, test_io, file, &read_buf) catch |err| {
+        try std.testing.expectEqual(Image.ReadError.Unsupported, err);
+        return;
+    };
     defer image.deinit(helpers.zigimg_test_allocator);
+
+    return error.TestExpectedError;
 }
 
-test "JPEG loads crafted DC coefficient overflow fixtures without panicking" {
+test "JPEG rejects crafted DC coefficient overflow fixtures as unsupported" {
     const fixtures = [_][]const u8{
         test_image_path ++ "crafted_33000x8.jpg",
         test_image_path ++ "crafted_40000x8.jpg",
@@ -24,11 +29,11 @@ test "JPEG loads crafted DC coefficient overflow fixtures without panicking" {
     };
 
     for (fixtures) |fixture| {
-        try expectLoadDoesNotPanic(fixture);
+        try expectLoadUnsupported(fixture);
     }
 }
 
-test "JPEG loads crafted IDCT overflow fixtures without panicking" {
+test "JPEG rejects crafted IDCT overflow fixtures as unsupported" {
     const fixtures = [_][]const u8{
         test_image_path ++ "crafted_80x8.jpg",
         test_image_path ++ "crafted_3200x8.jpg",
@@ -36,6 +41,6 @@ test "JPEG loads crafted IDCT overflow fixtures without panicking" {
     };
 
     for (fixtures) |fixture| {
-        try expectLoadDoesNotPanic(fixture);
+        try expectLoadUnsupported(fixture);
     }
 }

--- a/zigimg.zig
+++ b/zigimg.zig
@@ -28,6 +28,7 @@ test {
     _ = @import("tests/formats/gif_test.zig");
     _ = @import("tests/formats/iff_test.zig");
     _ = @import("tests/formats/jpeg_test.zig");
+    _ = @import("tests/formats/jpeg_overflow_test.zig");
     _ = @import("tests/formats/pam_test.zig");
     _ = @import("tests/formats/netpbm_test.zig");
     _ = @import("tests/formats/pcx_test.zig");


### PR DESCRIPTION
## Summary
Fixes #324 by returning `Unsupported` before the decoder reaches overflowing fixed-point arithmetic.

## Details
- Checks JPEG dequantization multiplication and returns `Image.ReadError.Unsupported` on overflow.
- Rejects unsupported 16 bit quantization tables in the current 8-bit JPEG decode path.
- Adds a conservative input bound before each fixed point IDCT pass so existing i32 arithmetic cannot overflow.
- Propagates IDCT errors through the JPEG and pipeline.
- Tightens crafted overflow tests to expect `Image.ReadError.Unsupported`.

Small note: I didn't go with widening the arithmetic types since the SIMD operations underneath are currently built around i32, so I think for now just not supporting these kind of images is better.