### PR TITLE
Fix SGI 64-bit RGBA reading alpha from wrong buffer

### DIFF
--- a/src/formats/sgi.zig
+++ b/src/formats/sgi.zig
@@ -275,7 +275,7 @@ pub const SGI = struct {
                 for (0..image_height) |y| {
                     for (0..image_width) |x| {
                         const offset = (image_height - y - 1) * image_width + x;
-                        storage[y * image_width + x] = color.Rgba64{ .r = std.mem.bigToNative(u16, u16_buffer[offset]), .g = std.mem.bigToNative(u16, u16_buffer[offset + channel_size]), .b = std.mem.bigToNative(u16, u16_buffer[offset + channel_size * 2]), .a = std.mem.bigToNative(u16, buffer[offset + channel_size * 3]) };
+                        storage[y * image_width + x] = color.Rgba64{ .r = std.mem.bigToNative(u16, u16_buffer[offset]), .g = std.mem.bigToNative(u16, u16_buffer[offset + channel_size]), .b = std.mem.bigToNative(u16, u16_buffer[offset + channel_size * 2]), .a = std.mem.bigToNative(u16, u16_buffer[offset + channel_size * 3]) };
                     }
                 }
             },

--- a/tests/formats/sgi_test.zig
+++ b/tests/formats/sgi_test.zig
@@ -225,3 +225,58 @@ test "SGI 32-bit RGBA rle compressed" {
         try helpers.expectEq(pixels.rgba32[index].to.u32Rgb(), hex_color);
     }
 }
+
+test "SGI 64-bit RGBA uncompressed - alpha channel bug test" {
+    const width: u16 = 2;
+    const height: u16 = 2;
+
+    var file_data: [544]u8 = .{0} ** 544;
+
+    file_data[0] = 0x01;
+    file_data[1] = 0xda;
+    file_data[2] = 0x00;
+    file_data[3] = 0x02;
+    file_data[4] = 0x00;
+    file_data[5] = 0x03;
+    file_data[6] = 0x00;
+    file_data[7] = @intCast(width);
+    file_data[8] = 0x00;
+    file_data[9] = @intCast(height);
+    file_data[10] = 0x00;
+    file_data[11] = 0x04;
+
+    const data_offset = 512;
+
+    file_data[data_offset + 0] = 0x10; file_data[data_offset + 1] = 0x00;
+    file_data[data_offset + 2] = 0x20; file_data[data_offset + 3] = 0x00;
+    file_data[data_offset + 4] = 0x30; file_data[data_offset + 5] = 0x00;
+    file_data[data_offset + 6] = 0x40; file_data[data_offset + 7] = 0x00;
+
+    file_data[data_offset + 8] = 0x01; file_data[data_offset + 9] = 0x00;
+    file_data[data_offset + 10] = 0x02; file_data[data_offset + 11] = 0x00;
+    file_data[data_offset + 12] = 0x03; file_data[data_offset + 13] = 0x00;
+    file_data[data_offset + 14] = 0x04; file_data[data_offset + 15] = 0x00;
+
+    file_data[data_offset + 16] = 0x00; file_data[data_offset + 17] = 0x10;
+    file_data[data_offset + 18] = 0x00; file_data[data_offset + 19] = 0x20;
+    file_data[data_offset + 20] = 0x00; file_data[data_offset + 21] = 0x30;
+    file_data[data_offset + 22] = 0x00; file_data[data_offset + 23] = 0x40;
+
+    file_data[data_offset + 24] = 0xAB; file_data[data_offset + 25] = 0xCD;
+    file_data[data_offset + 26] = 0x12; file_data[data_offset + 27] = 0x34;
+    file_data[data_offset + 28] = 0x56; file_data[data_offset + 29] = 0x78;
+    file_data[data_offset + 30] = 0x9A; file_data[data_offset + 31] = 0xBC;
+
+    var read_stream = zigimg.io.ReadStream.initMemory(&file_data);
+
+    var sgi_file = sgi.SGI{};
+    const pixels = try sgi_file.read(helpers.zigimg_test_allocator, &read_stream);
+    defer pixels.deinit(helpers.zigimg_test_allocator);
+
+    try std.testing.expect(pixels == .rgba64);
+
+    try helpers.expectEq(pixels.rgba64[2].a, 0xABCD);
+    try helpers.expectEq(pixels.rgba64[3].a, 0x1234);
+    try helpers.expectEq(pixels.rgba64[0].a, 0x5678);
+    try helpers.expectEq(pixels.rgba64[1].a, 0x9ABC);
+}


### PR DESCRIPTION
## Summary

Fix bug where wrong buffer was used for alpha channel in SGI

## Details

https://github.com/zigimg/zigimg/blob/master/src%2Fformats%2Fsgi.zig#L278

here code uses `u16_buffer` for reading r, g and b channels but uses `buffer` for alpha channel, seems like a typo