### PR TITLE
Guard GIF LZW decoder against next_code overflow

### DIFF
--- a/src/compressions/lzw.zig
+++ b/src/compressions/lzw.zig
@@ -20,6 +20,7 @@ pub fn Decoder(comptime endian: std.builtin.Endian) type {
         early_change: u8 = 0,
 
         const MaxCodeSize = 12;
+        const MaxDictionarySize = @as(u14, 1) << MaxCodeSize;
 
         const Self = @This();
 
@@ -79,19 +80,21 @@ pub fn Decoder(comptime endian: std.builtin.Endian) type {
                 if (self.dictionary.get(read_code)) |value| {
                     _ = try writer.write(value);
 
-                    if (self.previous_code) |previous_code| {
-                        if (self.dictionary.get(previous_code)) |previous_value| {
-                            var new_value = try allocator.alloc(u8, previous_value.len + 1);
-                            @memcpy(new_value[0..previous_value.len], previous_value);
-                            new_value[previous_value.len] = value[0];
-                            try self.dictionary.put(allocator, self.next_code, new_value);
+                    if (self.next_code < MaxDictionarySize) {
+                        if (self.previous_code) |previous_code| {
+                            if (self.dictionary.get(previous_code)) |previous_value| {
+                                var new_value = try allocator.alloc(u8, previous_value.len + 1);
+                                @memcpy(new_value[0..previous_value.len], previous_value);
+                                new_value[previous_value.len] = value[0];
+                                try self.dictionary.put(allocator, self.next_code, new_value);
 
-                            self.next_code += 1;
+                                self.next_code += 1;
 
-                            const max_code = @as(u13, 1) << @intCast(self.code_size + 1);
-                            if (self.next_code == (max_code - self.early_change) and (self.code_size + 1) < MaxCodeSize) {
-                                self.code_size += 1;
-                                bits_to_read += 1;
+                                const max_code = @as(u13, 1) << @intCast(self.code_size + 1);
+                                if (self.next_code == (max_code - self.early_change) and (self.code_size + 1) < MaxCodeSize) {
+                                    self.code_size += 1;
+                                    bits_to_read += 1;
+                                }
                             }
                         }
                     }
@@ -104,6 +107,9 @@ pub fn Decoder(comptime endian: std.builtin.Endian) type {
                         return;
                     } else {
                         if (self.previous_code) |previous_code| {
+                            if (self.next_code >= MaxDictionarySize) {
+                                return error.InvalidData;
+                            }
                             if (self.dictionary.get(previous_code)) |previous_value| {
                                 var new_value = try allocator.alloc(u8, previous_value.len + 1);
                                 @memcpy(new_value[0..previous_value.len], previous_value);
@@ -405,6 +411,65 @@ test "Should decode a simple LZW little-endian stream" {
 
     try std.testing.expectEqual(@as(usize, 1), out_writer.end);
     try std.testing.expectEqual(@as(u8, 1), out_data_storage[0]);
+}
+
+test "Decoding a stream that never emits a clear code does not overflow next_code" {
+    const initial_code_size = 2;
+
+    // Pack codes LSB-first while mirroring the decoder's code-width growth so the
+    // crafted stream stays in sync with it. A clear code followed by a long run of a
+    // single root code keeps adding dictionary entries without ever resetting, which is
+    // what some real-world GIF encoders produce. The first code after a clear does not
+    // add a dictionary entry, matching the decoder.
+    var packed_bits = std.array_list.Managed(u8).init(std.testing.allocator);
+    defer packed_bits.deinit();
+
+    var bit_buffer: u32 = 0;
+    var bit_count: u6 = 0;
+    var code_size: u8 = initial_code_size;
+    var next_code: u32 = (@as(u32, 1) << @intCast(initial_code_size)) + 2;
+
+    const writeCode = struct {
+        fn call(list: *std.array_list.Managed(u8), buf: *u32, count: *u6, value: u13, width: u8) !void {
+            buf.* |= @as(u32, value) << @intCast(count.*);
+            count.* += @intCast(width);
+            while (count.* >= 8) {
+                try list.append(@truncate(buf.*));
+                buf.* >>= 8;
+                count.* -= 8;
+            }
+        }
+    }.call;
+
+    const clear_code: u13 = @as(u13, 1) << @intCast(initial_code_size);
+    try writeCode(&packed_bits, &bit_buffer, &bit_count, clear_code, code_size + 1);
+
+    // Emit enough copies of root code 0 to push next_code past the u13 maximum (8191).
+    var emitted: usize = 0;
+    while (emitted < 9000) : (emitted += 1) {
+        try writeCode(&packed_bits, &bit_buffer, &bit_count, 0, code_size + 1);
+        if (emitted > 0) {
+            next_code += 1;
+            const max_code = @as(u32, 1) << @intCast(code_size + 1);
+            if (next_code == max_code and (code_size + 1) < 12) {
+                code_size += 1;
+            }
+        }
+    }
+    if (bit_count > 0) {
+        try packed_bits.append(@truncate(bit_buffer));
+    }
+
+    var read_stream = io.ReadStream.initMemory(packed_bits.items);
+
+    var out_data_storage: [16384]u8 = undefined;
+    var out_write_stream = io.WriteStream.initMemory(out_data_storage[0..]);
+
+    var lzw = try Decoder(.little).init(std.testing.allocator, initial_code_size, 0);
+    defer lzw.deinit();
+
+    // Must not panic on integer overflow; a malformed stream may fail, but cleanly.
+    lzw.decode(read_stream.reader(), out_write_stream.writer()) catch {};
 }
 
 // ============================================================================


### PR DESCRIPTION
Some GIFs (about 1 in 10 from Giphy's search API, per #319) contain LZW data that keeps assigning new codes without ever sending a clear code. The decoder kept incrementing next_code past the 12-bit maximum, overflowing the u13 and panicking in decode. This stops adding dictionary entries once the table is full (4096 entries) and treats the unrecoverable KwKwK case at a full table as invalid data, which gif.zig already maps to InvalidData. Added a regression test that feeds such a stream and previously crashed at the same line as the report.

Fixes #319